### PR TITLE
Remove unnecessary credentials from CircleCI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,5 +25,4 @@ jobs:
 workflows:
   main: 
     jobs:
-      - build:
-          context: builder-creds
+      - build


### PR DESCRIPTION
The previously used context contains long-lived AWS credentials which we are trying to get rid of.