### PR TITLE
Causal attention mask

### DIFF
--- a/cargpt/models/gato.py
+++ b/cargpt/models/gato.py
@@ -397,8 +397,9 @@ class Gato(pl.LightningModule, LoadableFromArtifact):
         episode: Float[Tensor, "b to d"],
     ):
         _, m, _ = episode.shape
-        episode_mask = torch.tril(torch.ones(m, m, device=episode.device)).float()
-        episode_mask = episode_mask.masked_fill(episode_mask == 0.0, -torch.inf)
+        episode_mask = torch.triu(
+            torch.ones(m, m, device=episode.device) * float("-inf"), diagonal=1
+        )
 
         features = self.gpt(
             src=episode,


### PR DESCRIPTION
Causal Attention mask with [0 instead of 1](https://pytorch.org/docs/stable/_modules/torch/nn/modules/transformer.html#TransformerEncoder) since attention is additive for mask type of Float

https://github.com/pytorch/pytorch/issues/21518

https://pytorch.org/docs/stable/generated/torch.nn.Transformer.html#torch.nn.Transformer.generate_square_subsequent_mask

```
        if is_causal is None:
            if mask is not None:
                sz = mask.size(0)
                causal_comparison = torch.triu(
                    torch.ones(sz, sz, device=mask.device) * float('-inf'), diagonal=1
                ).to(mask.dtype)

                if torch.equal(mask, causal_comparison):
                    make_causal = True

        is_causal = make_causal  
```