### PR TITLE
Cleanup predictions

### DIFF
--- a/cargpt/models/cilpp.py
+++ b/cargpt/models/cilpp.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any, Dict, List, Mapping, Optional, Sequence, Tupl
 import more_itertools as mit
 import pytorch_lightning as pl
 import torch
+import wandb
 from deephouse.tools.camera import Camera
 from einops import rearrange, reduce, repeat
 from hydra.utils import instantiate
@@ -16,13 +17,12 @@ from torch import Tensor
 from torch.nn import Module, ModuleDict, TransformerEncoder
 from torch.nn import functional as F
 from torchvision.transforms.functional import resize
-
-import wandb
-from cargpt.utils._wandb import LoadableFromArtifact
 from wandb.data_types import JoinedTable
 from wandb.errors import CommError
 from wandb.sdk.interface.artifacts import Artifact, ArtifactManifestEntry
 from wandb.wandb_run import Run
+
+from cargpt.utils._wandb import LoadableFromArtifact
 
 
 class DepthFrameEncoder(Module):

--- a/cargpt/utils/_wandb.py
+++ b/cargpt/utils/_wandb.py
@@ -2,14 +2,13 @@ from pathlib import Path
 from typing import Callable, Dict, List
 
 import more_itertools as mit
+import wandb
 from einops import rearrange
 from jaxtyping import Float
 from pytorch_lightning import Trainer
 from pytorch_lightning.loggers.wandb import WandbLogger
 from pytorch_lightning.utilities.parsing import AttributeDict
 from torch import Tensor
-
-import wandb
 from wandb.sdk.interface.artifacts import Artifact
 from wandb.sdk.lib import RunDisabled
 from wandb.wandb_run import Run

--- a/train.py
+++ b/train.py
@@ -6,12 +6,12 @@ from subprocess import check_output
 
 import hydra
 import pytorch_lightning as pl
+import wandb
 from hydra.utils import instantiate
 from jaxtyping import install_import_hook
 from loguru import logger
 from omegaconf import DictConfig, OmegaConf
 
-import wandb
 from cargpt.utils.logging import setup_logging
 
 


### PR DESCRIPTION
1. No pred trajectory 
2. Instead log values to video
3. Fix episode mask for updated history
4. Optional log prediction to terminal
5. Standardize action key names

```
python predict.py inference=trajectory paths.data_dir=/home/perception/workspace/datasets/Niro104-HQ paths.metadata_cache_dir=./yaak-datasets/metadata datamodule.predict.dataset.config.data.drives.0.id=2023-04-18--17-42-03 model.logging.log_to_terminal=True
```