### PR TITLE
feat: split PT/FT inference model configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ just rerun
 
 3. in another terminal:
 ```shell
-just predict inference=smart [...]
+just predict inference=smart model=control_transformer/pretrained model.artifact=yaak/cargpt/model-{run_id}:v{version} [+model.map_location=cuda:0] [+model.strict=false]
 ```

--- a/cargpt/components/objectives/random_masked_hindsight_control.py
+++ b/cargpt/components/objectives/random_masked_hindsight_control.py
@@ -26,7 +26,7 @@ from cargpt.components.objectives.common import PredictionResultKey
 
 
 class RandomMaskedHindsightControlObjective(Module):
-    def __init__(self, heads: ModuleDict, losses: ModuleDict | None) -> None:
+    def __init__(self, heads: ModuleDict, losses: ModuleDict | None = None) -> None:
         super().__init__()
         self.heads = heads
         self.losses = losses

--- a/config/inference/smart.yaml
+++ b/config/inference/smart.yaml
@@ -2,6 +2,7 @@
 
 defaults:
   - /paths: default
+  - /model: control_transformer/finetuned
   - /dataset/predict@datamodule.predict.dataset
   - _self_
 
@@ -9,52 +10,7 @@ vars:
   batch_size: 64
   clip_len: 6
   speed_range: [0.0, 130.0]
-
-model:
-  _target_: cargpt.models.control_transformer.ControlTransformer.load_from_wandb_artifact
-  artifact: ???
-  filename: model.ckpt
-  hparams_updaters:
-    # 1. wrap hparams in DictConfig
-    - _target_: omegaconf.DictConfig
-      _partial_: true
-
-    # 2. delete unnecesary keys
-    - _target_: funcy.del_in
-      _partial_: true
-      path: ["objective_scheduler"]
-
-    - _target_: funcy.del_in
-      _partial_: true
-      path: ["objectives", "forward_dynamics"]
-
-    - _target_: funcy.del_in
-      _partial_: true
-      path: ["objectives", "inverse_dynamics"]
-
-    - _target_: funcy.del_in
-      _partial_: true
-      path: ["objectives", "random_masked_hindsight_control"]
-
-    - _target_: funcy.del_in
-      _partial_: true
-      path: ["objectives", "copycat"]
-
-    # 3. merge config
-    #  NOTE(galaxy brain alert): hydra instantiation with `_partial_: true` uses
-    # `functools.partial`, which binds _leftmost_ positional arguments, which in this
-    # case means the original hparams would be merged last, effectively negating any
-    # updates. Using `funcy.rpartial` as a workaround.
-    # - _target_: funcy.rpartial
-    #   _args_:
-    #     - _target_: omegaconf.DictConfig.merge_with
-    #       _partial_: true
-
-    #     - _target_: omegaconf.DictConfig
-    #       _recursive_: false
-    #       content:
-    #         objectives:
-    #           _target_: cargpt.utils.ModuleDict
+  embedding_dim: 512
 
 datamodule:
   _target_: cargpt.datamodules.GenericDataModule
@@ -133,6 +89,6 @@ trainer:
     - _target_: cargpt.callbacks.model_summary.ModelSummary
       depth: 5
 
-    # - _target_: cargpt.callbacks.rerun.RerunPredictionWriter
-    #   write_interval: batch
-    #   application_id: ${model.artifact}
+    - _target_: cargpt.callbacks.rerun.RerunPredictionWriter
+      write_interval: batch
+      application_id: ${model.artifact}

--- a/config/model/control_transformer/finetuned.yaml
+++ b/config/model/control_transformer/finetuned.yaml
@@ -1,0 +1,46 @@
+_target_: cargpt.models.control_transformer.ControlTransformer.load_from_wandb_artifact
+artifact: ???
+filename: model.ckpt
+hparams_updaters:
+  # 1. wrap hparams in DictConfig
+  - _target_: omegaconf.DictConfig
+    _partial_: true
+
+  # 2. delete unnecesary keys
+  - _target_: funcy.del_in
+    _partial_: true
+    path: ["objectives", "copycat", "streams", "policy", "losses"]
+
+  # 3. merge config
+  #  NOTE(galaxy brain alert): hydra instantiation with `_partial_: true` uses
+  # `functools.partial`, which binds _leftmost_ positional arguments, which in this
+  # case means the original hparams would be merged last, effectively negating any
+  # updates. Using `funcy.rpartial` as a workaround.
+  - _target_: funcy.rpartial
+    _args_:
+      - _target_: omegaconf.DictConfig.merge_with
+        _partial_: true
+
+      - _target_: omegaconf.DictConfig
+        _recursive_: false
+        content:
+          objectives:
+            copycat:
+              policy:
+                detokenizers:
+                  _target_: cargpt.utils.ModuleDict
+                  continuous:
+                    gas_pedal:
+                      _target_: cargpt.components.norm.UniformUnbinner
+                      out_range: [0.0, 1.0]
+                      num_bins: 255
+
+                    brake_pedal:
+                      _target_: cargpt.components.norm.UniformUnbinner
+                      out_range: [0.0, 1.0]
+                      num_bins: 165
+
+                    steering_angle:
+                      _target_: cargpt.components.norm.UniformUnbinner
+                      out_range: [1.0, 1.0]
+                      num_bins: 961

--- a/config/model/control_transformer/pretrained.yaml
+++ b/config/model/control_transformer/pretrained.yaml
@@ -1,0 +1,93 @@
+_target_: cargpt.models.control_transformer.ControlTransformer.load_from_wandb_artifact
+artifact: ???
+filename: model.ckpt
+hparams_updaters:
+  # 1. wrap hparams in DictConfig
+  - _target_: omegaconf.DictConfig
+    _partial_: true
+
+  # 2. delete unnecesary keys
+  - _target_: funcy.del_in
+    _partial_: true
+    path: ["objective_scheduler"]
+
+  - _target_: funcy.del_in
+    _partial_: true
+    path: ["objectives", "inverse_dynamics", "losses"]
+
+  - _target_: funcy.del_in
+    _partial_: true
+    path: ["objectives", "forward_dynamics", "losses"]
+
+  - _target_: funcy.del_in
+    _partial_: true
+    path: ["objectives", "random_masked_hindsight_control", "losses"]
+
+  - _target_: funcy.del_in
+    _partial_: true
+    path: ["objectives", "copycat", "streams", "memory_extraction", "losses"]
+
+  # 3. merge config
+  #  NOTE(galaxy brain alert): hydra instantiation with `_partial_: true` uses
+  # `functools.partial`, which binds _leftmost_ positional arguments, which in this
+  # case means the original hparams would be merged last, effectively negating any
+  # updates. Using `funcy.rpartial` as a workaround.
+  - _target_: funcy.rpartial
+    _args_:
+      - _target_: omegaconf.DictConfig.merge_with
+        _partial_: true
+
+      - _target_: omegaconf.DictConfig
+        _recursive_: false
+        content:
+          episode_builder:
+            detokenizers:
+              _target_: cargpt.utils.ModuleDict
+              continuous:
+                speed:
+                  _target_: cargpt.components.norm.UniformUnbinner
+                  out_range: [0.0, 130.0]
+                  num_bins: 1024
+
+                gas_pedal:
+                  _target_: cargpt.components.norm.UniformUnbinner
+                  out_range: [0.0, 1.0]
+                  num_bins: 255
+
+                brake_pedal:
+                  _target_: cargpt.components.norm.UniformUnbinner
+                  out_range: [0.0, 1.0]
+                  num_bins: 165
+
+                steering_angle:
+                  _target_: cargpt.components.norm.UniformUnbinner
+                  out_range: [1.0, 1.0]
+                  num_bins: 961
+
+              discrete:
+                turn_signal:
+                  _target_: torch.nn.Identity
+
+          objectives:
+            copycat:
+              memory_extraction:
+                delta_detokenizers:
+                  _target_: cargpt.utils.ModuleDict
+                  continuous:
+                    gas_pedal:
+                      _target_: torchaudio.transforms.MuLawDecoding
+                      quantization_channels: ${vars.embedding_dim}
+
+                    brake_pedal:
+                      _target_: torchaudio.transforms.MuLawDecoding
+                      quantization_channels: ${vars.embedding_dim}
+
+                    steering_angle:
+                      _target_: torch.nn.Sequential
+                      _args_:
+                        - _target_: torchaudio.transforms.MuLawDecoding
+                          quantization_channels: ${vars.embedding_dim}
+
+                        - _target_: cargpt.components.norm.Scaler
+                          in_range: [-1.0, 1.0]
+                          out_range: [-2.0, 2.0]

--- a/poetry.lock
+++ b/poetry.lock
@@ -5287,18 +5287,18 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [[package]]
 name = "wandb"
-version = "0.17.1"
+version = "0.17.2"
 description = "A CLI and library for interacting with the Weights & Biases API."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "wandb-0.17.1-py3-none-any.whl", hash = "sha256:6d3eb0abb5cd189992ffe7892167aa54900cc9bfc78b9a1af032b930cc9b4bc5"},
-    {file = "wandb-0.17.1-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:14f4e6751541c171e85ab25d208b2d04fe12d08e1d9bed9fb67c78b2e31617f6"},
-    {file = "wandb-0.17.1-py3-none-macosx_11_0_arm64.whl", hash = "sha256:037aef76eddc0eef3b0fee604eade50273eae6558eda900b2a1c096acfa764f1"},
-    {file = "wandb-0.17.1-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1098b1244fa448e0ad8326c518588bb27e3a78caf9c627f0bb74019446d392db"},
-    {file = "wandb-0.17.1-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eeacf9b7ab075fe2c07cc38481d8be8ff50c8e7569f68633c9d885c118ef65b2"},
-    {file = "wandb-0.17.1-py3-none-win32.whl", hash = "sha256:93baed41ce7842c1a2f6e7eb20d6ad2abc402c74fdd035b14cd46ab1ee354e21"},
-    {file = "wandb-0.17.1-py3-none-win_amd64.whl", hash = "sha256:c6efd1f9c77815ed0b9b3df00d8bb46df811c0e3cfd290deb7c9c65ad9a0370b"},
+    {file = "wandb-0.17.2-py3-none-any.whl", hash = "sha256:4bd351be28cea87730365856cfaa72f72ceb787accc21bad359dde5aa9c4356d"},
+    {file = "wandb-0.17.2-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:638353a2d702caedd304a5f1e526ef93a291c984c109fcb444262a57aeaacec9"},
+    {file = "wandb-0.17.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:824e33ca77af87f87a9cf1122acba164da5bf713adc9d67332bc686028921ec9"},
+    {file = "wandb-0.17.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:032ca5939008643349af178a8b66b8047a1eefcb870c4c4a86e22acafde6470f"},
+    {file = "wandb-0.17.2-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9558bab47a0c8ac4f22cfa2d43f91d1bc1f75d4255629286db674fe49fcd30e5"},
+    {file = "wandb-0.17.2-py3-none-win32.whl", hash = "sha256:4bc176e3c81be216dc889fcd098341eb17a14b04e080d4343ce3f0b1740abfc1"},
+    {file = "wandb-0.17.2-py3-none-win_amd64.whl", hash = "sha256:62cd707f38b5711971729dae80343b8c35f6003901e690166cc6d526187a9785"},
 ]
 
 [package.dependencies]
@@ -5571,4 +5571,4 @@ predict = ["funcy", "wandb"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.12"
-content-hash = "10d555659072f8533b7e83048785233fc413f7e08fef79096f8b91a9ee22657f"
+content-hash = "d461d763237d9f7f854ceffde1232956024bd97e529b8891363899da765f9990"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ jaxtyping = "*"
 beartype = "*"
 more-itertools = "^9.0.0"
 torchinfo = "^1.8.0"
-numpy = "*"
+numpy = "<2.0.0"
 typing-extensions = "*"
 omegaconf = "^2.3.0"
 funcy = { version = "*", optional = true }


### PR DESCRIPTION
- split PT/FT inference model configs
- fix map_location

NOTE: I didn't verify correctness, just that things run.

Also realized it's reeeeal easy to misspecify detokenizer yaml config -- we should probably make tokenizers invertible instead and call that on detokenization.