### PR TITLE
Fix element count for drop

### DIFF
--- a/cargpt/components/llm.py
+++ b/cargpt/components/llm.py
@@ -115,7 +115,7 @@ class xFormerEncoder(nn.Module):
                     # TODO: exclude certain indices from getting dropped?
                     if drop_ratio is not None:
                         attn_flat = rearrange(attn, "b s_from s_to -> b (s_from s_to)")
-                        drop_count = int(attn_flat.size[-1] * drop_ratio)
+                        drop_count = int(attn_flat.shape[-1] * drop_ratio)
                         drop_indices = attn_flat.topk(
                             k=drop_count, dim=-1, largest=False
                         ).indices


### PR DESCRIPTION
We need to drop values from each sample in the batch separately. 

```
File [~/.cache/pypoetry/virtualenvs/non-package-mode-KhixpDEn-py3.11/lib/python3.11/site-packages/cargpt/components/llm.py:119](http://localhost:8892/home/harsimrat/.cache/pypoetry/virtualenvs/non-package-mode-KhixpDEn-py3.11/lib/python3.11/site-packages/cargpt/components/llm.py#line=118), in xFormerEncoder.compute_attention_rollout(self, src, mask, drop_ratio)
    117 drop_count = int(attn.nelement() * drop_ratio)
    118 attn_flat = rearrange(attn, "b s_from s_to -> b (s_from s_to)")
--> 119 drop_indices = attn_flat.topk(
    120     k=drop_count, dim=-1, largest=False
    121 ).indices
    122 for batch_idx, batch_drop_indices in enumerate(drop_indices):
    123     attn_flat[batch_idx, batch_drop_indices] = 0

RuntimeError: selected index k out of range
```