### PR TITLE
bugfix: rmhc masking

### DIFF
--- a/src/rmind/components/objectives/random_masked_hindsight_control.py
+++ b/src/rmind/components/objectives/random_masked_hindsight_control.py
@@ -53,27 +53,18 @@ class RandomMaskedHindsightControlObjective(Objective):
         masked_observation_timestep_idx = np.random.choice(t, 1, replace=False).tolist()  # noqa: NPY002
 
         episode = episode.clone(recurse=True)
+
+        mask_action = torch.zeros((b, t), dtype=torch.bool, device=device)
+        mask_action[:, masked_action_timestep_idx] = True
         episode.input_embeddings.select(
             *episode.timestep.keys_by_type[TokenType.ACTION]
-        ).masked_fill_(
-            torch.zeros((b, t), dtype=torch.bool, device=device).index_fill_(
-                1,
-                torch.tensor(masked_action_timestep_idx, device=device),
-                True,  # noqa: FBT003
-            ),
-            -1.0,
-        )
+        ).masked_fill_(mask_action, -1.0)
 
+        mask_observation = torch.zeros((b, t), dtype=torch.bool, device=device)
+        mask_observation[:, masked_observation_timestep_idx] = True
         episode.input_embeddings.select(
             *episode.timestep.keys_by_type[TokenType.OBSERVATION]
-        ).masked_fill_(
-            torch.zeros((b, t), dtype=torch.bool, device=device).index_fill_(
-                1,
-                torch.tensor(masked_observation_timestep_idx, device=device),
-                True,  # noqa: FBT003
-            ),
-            -1.0,
-        )
+        ).masked_fill_(mask_observation, -1.0)
 
         mask = self.build_attention_mask(episode.index, episode.timestep)
         embedding = encoder(src=episode.embeddings_packed, mask=mask.mask)
@@ -124,27 +115,18 @@ class RandomMaskedHindsightControlObjective(Objective):
             ).tolist()
 
             episode = episode.clone(recurse=True)
+
+            mask_action = torch.zeros((b, t), dtype=torch.bool, device=device)
+            mask_action[:, masked_action_timestep_idx] = True
             episode.input_embeddings.select(
                 *episode.timestep.keys_by_type[TokenType.ACTION]
-            ).masked_fill_(
-                torch.zeros((b, t), dtype=torch.bool, device=device).index_fill_(
-                    1,
-                    torch.tensor(masked_action_timestep_idx, device=device),
-                    True,  # noqa: FBT003
-                ),
-                -1.0,
-            )
+            ).masked_fill_(mask_action, -1.0)
 
+            mask_observation = torch.zeros((b, t), dtype=torch.bool, device=device)
+            mask_observation[:, masked_observation_timestep_idx] = True
             episode.input_embeddings.select(
                 *episode.timestep.keys_by_type[TokenType.OBSERVATION]
-            ).masked_fill_(
-                torch.zeros((b, t), dtype=torch.bool, device=device).index_fill_(
-                    1,
-                    torch.tensor(masked_observation_timestep_idx, device=device),
-                    True,  # noqa: FBT003
-                ),
-                -1.0,
-            )
+            ).masked_fill_(mask_observation, -1.0)
 
             mask = self.build_attention_mask(episode.index, episode.timestep)
             embedding = encoder(src=episode.embeddings_packed, mask=mask.mask)


### PR DESCRIPTION
https://github.com/yaak-ai/rmind/pull/160 introduced a bug when masking wasn't applied to `episode.input_embeddings` in `RandomMaskedHindsightControl`. In a nutshell, `TensorDict` handles indexes and slices differently in `.apply_()`. Hence it was replaced with `.masked_apply_()`

Interestingly enough, such changes are not necessary at all with current setup (so simple `= 1.0` is sufficient). L2 normalization in https://github.com/yaak-ai/rmind/pull/156 converts `float16` to `float32` during episode building removing the necessity to consider `dtypes` of `episode.input_embeddings`. However, this is pure luck and proper tensor dtypes handing from this PR should be implemented.

https://wandb.ai/yaak/cargpt/runs/p3szi3o0/overview

[sc-34148]