### PR TITLE
feat: add non_zero_signal_with_threshold

### DIFF
--- a/src/rmind/components/objectives/policy.py
+++ b/src/rmind/components/objectives/policy.py
@@ -96,7 +96,7 @@ class PolicyObjective(Objective):
                     case (Modality.CONTINUOUS, _):
                         return x[..., 0]
                     case (Modality.DISCRETE, "turn_signal"):
-                        return torch.argmax(x, dim=-1)
+                        return non_zero_signal_with_threshold(x).class_idx
                     case _:
                         raise NotImplementedError
 
@@ -107,7 +107,7 @@ class PolicyObjective(Objective):
                 return v[..., 0]
 
             if kp[0].key == Modality.DISCRETE.value and kp[1].key == "turn_signal":
-                return torch.argmax(v, dim=-1)
+                return non_zero_signal_with_threshold(v).class_idx
 
             raise NotImplementedError
 

--- a/src/rmind/components/objectives/policy.py
+++ b/src/rmind/components/objectives/policy.py
@@ -37,7 +37,11 @@ from rmind.components.objectives.base import (
 from rmind.components.objectives.forward_dynamics import (
     ForwardDynamicsPredictionObjective,
 )
-from rmind.utils.functional import gauss_prob, nan_padder
+from rmind.utils.functional import (
+    gauss_prob,
+    nan_padder,
+    non_zero_signal_with_threshold,
+)
 
 
 @final
@@ -264,7 +268,7 @@ class PolicyObjective(Objective):
                         case (Modality.CONTINUOUS, _):
                             return x[..., 0]
                         case (Modality.DISCRETE, "turn_signal"):
-                            return torch.argmax(x, dim=-1)
+                            return non_zero_signal_with_threshold(x).class_idx
                         case _:
                             msg = f"Invalid action type: {action_type}"
                             raise NotImplementedError(msg)
@@ -283,7 +287,7 @@ class PolicyObjective(Objective):
                             return torch.sqrt(torch.exp(x[..., 1]))
 
                         case (Modality.DISCRETE, "turn_signal"):
-                            return torch.ones_like(x[..., 0])  # placeholder
+                            return torch.zeros_like(x[..., 0])  # placeholder
                         case _:
                             msg = f"Invalid action type: {action_type}"
                             raise NotImplementedError(msg)
@@ -304,7 +308,8 @@ class PolicyObjective(Objective):
                             return gauss_prob(mean, mean=mean, std=std)
 
                         case (Modality.DISCRETE, "turn_signal"):
-                            return F.softmax(x, dim=-1)
+                            return non_zero_signal_with_threshold(x).prob
+
                         case _:
                             msg = f"Invalid action type: {action_type}"
                             raise NotImplementedError(msg)
@@ -350,7 +355,7 @@ class PolicyObjective(Objective):
 
                         case (Modality.DISCRETE, "turn_signal"):
                             return F.l1_loss(
-                                torch.argmax(x, dim=-1).float(),
+                                non_zero_signal_with_threshold(x).class_idx.float(),
                                 gt.float(),
                                 reduction="none",
                             )

--- a/src/rmind/utils/functional.py
+++ b/src/rmind/utils/functional.py
@@ -45,7 +45,7 @@ class SignalWithThresholdResult(NamedTuple):
 
 
 def non_zero_signal_with_threshold(
-    logits: Tensor, threshold: float = 0.85
+    logits: Tensor, threshold: float = 0.8
 ) -> SignalWithThresholdResult:
     # assuming zero signal is at index 0
     probs = F.softmax(logits, dim=-1)

--- a/src/rmind/utils/functional.py
+++ b/src/rmind/utils/functional.py
@@ -1,5 +1,5 @@
 from functools import partial
-from typing import Any
+from typing import Any, NamedTuple
 
 import more_itertools as mit
 import torch
@@ -37,3 +37,21 @@ def diff_last(input: Tensor, n: int = 1, *, append: float | None = None) -> Tens
         else None
     )
     return torch.diff(input, n=n, dim=-1, append=append_)
+
+
+class SignalWithThresholdResult(NamedTuple):
+    class_idx: Tensor
+    prob: Tensor
+
+
+def non_zero_signal_with_threshold(
+    logits: Tensor, threshold: float = 0.85
+) -> SignalWithThresholdResult:
+    # assuming zero signal is at index 0
+    probs = F.softmax(logits, dim=-1)
+    max_prob_interest, max_idx_relative = torch.max(probs[..., 1:], dim=-1)
+    final_class_idx = torch.where(
+        max_prob_interest > threshold, max_idx_relative + 1, 0
+    )
+    final_prob = torch.gather(probs, -1, final_class_idx.unsqueeze(-1)).squeeze(-1)
+    return SignalWithThresholdResult(class_idx=final_class_idx, prob=final_prob)


### PR DESCRIPTION
Model predicts lots of false positives for `turn_signal`. We want it to predict `0` except for cases when model actually confident about it. 
<img width="1467" height="841" alt="Screenshot 2025-08-29 at 14 12 06" src="https://github.com/user-attachments/assets/d6749e8f-0120-43e7-a996-61540b74e401" />
