### PR TITLE
docs: expand README setup and migrate deptry to local hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,11 +21,6 @@ repos:
     hooks:
       - id: typos
 
-  - repo: https://github.com/fpgmaas/deptry.git
-    rev: 0.25.1
-    hooks:
-      - id: deptry
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.11
     hooks:
@@ -41,6 +36,13 @@ repos:
 
   - repo: local
     hooks:
+      - id: deptry
+        name: deptry
+        entry: uv run deptry .
+        language: system
+        always_run: true
+        pass_filenames: false
+
       # TODO: replace once available
       - id: ty
         name: ty check

--- a/README.md
+++ b/README.md
@@ -7,12 +7,34 @@ Foundation models for spatial intelligence.
 
 ## Setup
 
-```bash
-git clone https://github.com/yaak-ai/rmind
-cd rmind
-nix develop # alternatively, install `just`, `uv`, `ytt`
-just setup
-```
+### macOS quick start
+
+1. Install [Nix](https://determinate.systems/nix/) (Determinate):
+
+   ```bash
+   curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+   ```
+
+2. Clone and enter the repo:
+
+   ```bash
+   git clone https://github.com/yaak-ai/rmind
+   cd rmind
+   ```
+
+3. Enter the dev shell (installs `just`, `uv`, `ytt`):
+
+   ```bash
+   nix develop
+   ```
+
+4. Install Python dependencies and dev tooling:
+
+   ```bash
+   just setup
+   ```
+
+> On other platforms, install `just`, `uv`, and `ytt` manually, then run `just setup`.
 
 ## Training
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ train = [
 [dependency-groups]
 dev = [
   "better-exceptions>=0.3.3",
-  "deptry>=0.25.1",
+  "deptry==0.25.1",
   "ipython",
   "lovely-tensors",
   "patdb",

--- a/src/rmind/components/transformer/encoder.py
+++ b/src/rmind/components/transformer/encoder.py
@@ -143,11 +143,11 @@ class TransformerEncoder(nn.Module):
         fuse_heads: Callable[[Tensor], Tensor]
         match config.head_fusion:
             case "mean":
-                fuse_heads = lambda x: x.mean(axis=1)  # noqa: E731
+                fuse_heads = lambda x: x.mean(dim=1)  # noqa: E731
             case "max":
-                fuse_heads = lambda x: x.max(axis=1).values  # noqa: E731
+                fuse_heads = lambda x: x.max(dim=1).values  # noqa: E731
             case "min":
-                fuse_heads = lambda x: x.min(axis=1).values  # noqa: E731
+                fuse_heads = lambda x: x.min(dim=1).values  # noqa: E731
 
         _, s, _ = src.shape
         identity = torch.eye(s, s, device=src.device)

--- a/uv.lock
+++ b/uv.lock
@@ -2296,7 +2296,7 @@ check = [
 ]
 dev = [
   { name = "better-exceptions", specifier = ">=0.3.3" },
-  { name = "deptry", specifier = ">=0.25.1" },
+  { name = "deptry", specifier = "==0.25.1" },
   { name = "ipython" },
   { name = "lovely-tensors" },
   { name = "patdb" },
@@ -2538,7 +2538,7 @@ dependencies = [
   { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-  { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43b35116802c85fb88d99f4a396b8bd4472bfca1dd82e69499e5a4f9b8b4e252" },
+  { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:43b35116802c85fb88d99f4a396b8bd4472bfca1dd82e69499e5a4f9b8b4e252", upload-time = "2026-03-23T15:16:58Z" },
 ]
 
 [[package]]
@@ -2558,7 +2558,7 @@ dependencies = [
   { name = "typing-extensions", marker = "sys_platform != 'darwin' and sys_platform != 'linux'" },
 ]
 wheels = [
-  { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-win_amd64.whl" },
+  { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:1abeaa46fa7532ed35ed79146f4de5d7a9d4b30462c98052ea4ddfe781ea3eca", upload-time = "2026-04-28T00:06:34Z" },
 ]
 
 [[package]]
@@ -2597,8 +2597,8 @@ dependencies = [
   { name = "typing-extensions", marker = "sys_platform == 'linux'" },
 ]
 wheels = [
-  { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl" },
-  { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl" },
+  { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:9c8f38efee365cb9d334de8a83ce52fc7e5fc9e5a7b0853285efa1b69e00b0f2", upload-time = "2026-04-27T17:41:30Z" },
+  { url = "https://download-r2.pytorch.org/whl/cu128/torch-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:d252cf975fb18c94a85336323ad425f473df56dab35a44b00399bd70c7a3b997", upload-time = "2026-04-27T17:42:06Z" },
 ]
 
 [[package]]
@@ -2609,7 +2609,7 @@ resolution-markers = [
   "sys_platform == 'darwin'",
 ]
 wheels = [
-  { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a1cf1acc883bee9cb906a933572fed6a8a933f86ef34e9ea7d803f72317e8c1b" },
+  { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a1cf1acc883bee9cb906a933572fed6a8a933f86ef34e9ea7d803f72317e8c1b", upload-time = "2026-03-23T15:50:10Z" },
 ]
 
 [[package]]
@@ -2620,7 +2620,7 @@ resolution-markers = [
   "sys_platform != 'darwin' and sys_platform != 'linux'",
 ]
 wheels = [
-  { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:95d517bd1a0a28dacd1c37550ced95cab64f3a7a4ef9b8219b41049388a71163" },
+  { url = "https://download-r2.pytorch.org/whl/cpu/torchaudio-2.11.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:95d517bd1a0a28dacd1c37550ced95cab64f3a7a4ef9b8219b41049388a71163", upload-time = "2026-03-23T15:50:10Z" },
 ]
 
 [[package]]
@@ -2631,8 +2631,8 @@ resolution-markers = [
   "sys_platform == 'linux'",
 ]
 wheels = [
-  { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d055c9ca9d4f0ffcbaa0fc22138bafd675256de392bdaadde00d797faa90ca56" },
-  { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:78b86a17f164bdaabdcee93fdfde2587fc43b9ebf15cd61dcf730b4f8615176b" },
+  { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:d055c9ca9d4f0ffcbaa0fc22138bafd675256de392bdaadde00d797faa90ca56", upload-time = "2026-03-23T15:50:23Z" },
+  { url = "https://download-r2.pytorch.org/whl/cu128/torchaudio-2.11.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:78b86a17f164bdaabdcee93fdfde2587fc43b9ebf15cd61dcf730b4f8615176b", upload-time = "2026-03-23T15:50:23Z" },
 ]
 
 [[package]]
@@ -2680,7 +2680,7 @@ dependencies = [
   { name = "torch", version = "2.11.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
-  { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4" },
+  { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c409e1c3fdebec7a3834465086dbda8bf7680eff79abf7fd2f10c6b59520a7a4", upload-time = "2026-03-23T15:36:09Z" },
 ]
 
 [[package]]
@@ -2696,7 +2696,7 @@ dependencies = [
   { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin' and sys_platform != 'linux'" },
 ]
 wheels = [
-  { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:52aa8401850a9792e71a8a1e65ac004e2b23622a6b6fd278cd11179efbefc65b" },
+  { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.26.0%2Bcpu-cp312-cp312-win_amd64.whl", hash = "sha256:52aa8401850a9792e71a8a1e65ac004e2b23622a6b6fd278cd11179efbefc65b", upload-time = "2026-03-23T15:36:09Z" },
 ]
 
 [[package]]
@@ -2712,8 +2712,8 @@ dependencies = [
   { name = "torch", version = "2.11.0+cu128", source = { registry = "https://download.pytorch.org/whl/cu128" }, marker = "sys_platform == 'linux'" },
 ]
 wheels = [
-  { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:63e35234aed13b6edda37056f417b5c281249669db631e706811917af36b21d7" },
-  { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ccf26b4b659cfce6f2208cb8326071d51c70219a34856dfdf468d1e19af52c0d" },
+  { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:63e35234aed13b6edda37056f417b5c281249669db631e706811917af36b21d7", upload-time = "2026-04-09T23:21:35Z" },
+  { url = "https://download-r2.pytorch.org/whl/cu128/torchvision-0.26.0%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:ccf26b4b659cfce6f2208cb8326071d51c70219a34856dfdf468d1e19af52c0d", upload-time = "2026-03-23T15:36:22Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Before: 
- Deptry is failing (moved hook location) and local pre-commit hooks didn't fully run successfully preventing git commits.
- typecheck is failing for Tensor.max and Tensor.min because "axis" parameter is not the official parameter - "dim" is.
- readme is on point, but could use some more explanations here and there

Details:
- Deptry: is currently failing due to a migration of the hook from fpgmaas private repo to a public one.
  - Pins `deptry` to an exact version (`==0.25.1`) in `pyproject.toml`
  - Moves the deptry pre-commit hook from the upstream remote repo (`fpgmaas/deptry`) to a local `uv run deptry .` entry, so it always uses the project-managed version
- Fixes `ty` `no-matching-overload` CI errors in `encoder.py` by replacing `axis=1` with `dim=1` in the attention rollout head fusion lambdas (torch stubs only declare `dim=`)

## Test plan

- [x] `pre-commit run --all-files` passes (deptry, ty, ruff, etc.)
- [x] `just typecheck` passes
- [x] README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)