### PR TITLE
refactor: drop Timestep dict; precompute embeddings_flattened in declared timestep order

### DIFF
--- a/src/rmind/callbacks/loggers/attention_mask.py
+++ b/src/rmind/callbacks/loggers/attention_mask.py
@@ -43,10 +43,11 @@ def visualize_attention_mask(  # noqa: PLR0914
     for t in range(num_timesteps):
         t_sub = _subscript(t)
         for token in timestep_meta:
-            num_tokens = index[token.modality.value][str(token.name)].shape[-1]
-            name = str(token.name)
+            num_tokens = index[token.modality.value][token.name].shape[-1]
             label = (
-                f"{name}[{num_tokens}]{t_sub}" if num_tokens > 1 else f"{name}{t_sub}"
+                f"{token.name}[{num_tokens}]{t_sub}"
+                if num_tokens > 1
+                else f"{token.name}{t_sub}"
             )
             blocks.append((label, token.type, num_tokens))
 

--- a/src/rmind/callbacks/loggers/attention_mask.py
+++ b/src/rmind/callbacks/loggers/attention_mask.py
@@ -12,8 +12,8 @@ from structlog import get_logger
 from torch import Tensor
 from wandb import Image
 
-from rmind.components.base import TokenType
-from rmind.components.episode import Episode, EpisodeBuilder, TokenMeta
+from rmind.components.base import TokenMeta, TokenType
+from rmind.components.episode import Episode, EpisodeBuilder
 
 from .common import _figure_to_rgba, _get_wandb_loggers
 

--- a/src/rmind/components/base.py
+++ b/src/rmind/components/base.py
@@ -1,5 +1,5 @@
 from enum import StrEnum, auto, unique
-from typing import Protocol, runtime_checkable
+from typing import NamedTuple, Protocol, runtime_checkable
 
 from torch import Tensor
 
@@ -35,3 +35,9 @@ class SummaryToken(StrEnum):
     OBSERVATION_SUMMARY = auto()
     OBSERVATION_HISTORY = auto()
     ACTION_SUMMARY = auto()
+
+
+class TokenMeta(NamedTuple):
+    type: TokenType
+    modality: Modality
+    name: str

--- a/src/rmind/components/episode.py
+++ b/src/rmind/components/episode.py
@@ -104,7 +104,7 @@ class EpisodeBuilder(Module):
         )
         self.timestep: tuple[TokenMeta, ...] = timestep
         self._timestep_keys: tuple[tuple[str, str], ...] = tuple(
-            (token.modality.value, str(token.name)) for token in timestep
+            (token.modality.value, token.name) for token in timestep
         )
         self.input_transform: Module = input_transform
         self.tokenizers: ModuleDict = tokenizers
@@ -120,9 +120,7 @@ class EpisodeBuilder(Module):
         self._role_idx_by_path: dict[tuple[MappingKey, MappingKey], int] = {
             (
                 MappingKey(token.modality.value),
-                MappingKey(
-                    str(token.name)
-                ),  # https://github.com/yaak-ai/rmind/issues/204
+                MappingKey(token.name),  # https://github.com/yaak-ai/rmind/issues/204
             ): role_idx_by_type_modality.setdefault(
                 (token.type.value, token.modality.value), len(role_idx_by_type_modality)
             )
@@ -253,7 +251,7 @@ class EpisodeBuilder(Module):
         lengths = [
             key_get(
                 embeddings,
-                (MappingKey(token.modality.value), MappingKey(str(token.name))),  # ty:ignore[invalid-argument-type]
+                (MappingKey(token.modality.value), MappingKey(token.name)),  # ty:ignore[invalid-argument-type]
             ).shape[2]
             for token in self.timestep
         ]
@@ -262,9 +260,7 @@ class EpisodeBuilder(Module):
         ranges = pairwise(accumulate(lengths, initial=0))
 
         timestep_index = unflatten_keys({
-            (token.modality.value, str(token.name)): torch.arange(
-                *range_, device=device
-            )
+            (token.modality.value, token.name): torch.arange(*range_, device=device)
             for token, range_ in zip(self.timestep, ranges, strict=True)
         })
 

--- a/src/rmind/components/episode.py
+++ b/src/rmind/components/episode.py
@@ -163,17 +163,18 @@ class EpisodeBuilder(Module):
 
         role_embeddings = self._build_role_embeddings(projected_embeddings)
 
-        embeddings = TensorDict.from_dict(
-            tree_map(
-                lambda p, r: p + r if p is not None and r is not None else None,
-                projected_embeddings,
-                role_embeddings,
-            ),
-            batch_dims=2,
-        ).filter_non_tensor_data()
+        embeddings = tree_map(
+            lambda p, r: p + r if p is not None and r is not None else None,
+            projected_embeddings,
+            role_embeddings,
+        )
 
         embeddings_flattened, _ = pack(
-            [embeddings.get(k) for k in self._timestep_keys], "b t * d"
+            [
+                key_get(embeddings, (MappingKey(k[0]), MappingKey(k[1])))  # ty:ignore[invalid-argument-type]
+                for k in self._timestep_keys
+            ],
+            "b t * d",
         )
 
         return (
@@ -181,7 +182,7 @@ class EpisodeBuilder(Module):
                 input=input,
                 input_tokens=input_tokens,
                 input_embeddings=input_embeddings,
-                embeddings=embeddings.to_dict(),
+                embeddings=embeddings,
                 index=index,
                 embeddings_flattened=embeddings_flattened,
                 attention_mask=attention_mask,
@@ -197,7 +198,9 @@ class EpisodeBuilder(Module):
                 input_embeddings=TensorDict.from_dict(
                     input_embeddings, batch_dims=2
                 ).filter_non_tensor_data(),
-                embeddings=embeddings,
+                embeddings=TensorDict.from_dict(
+                    embeddings, batch_dims=2
+                ).filter_non_tensor_data(),
                 index=Index.from_dict(index, batch_dims=1),
                 embeddings_flattened=embeddings_flattened,
                 attention_mask=attention_mask,

--- a/src/rmind/components/episode.py
+++ b/src/rmind/components/episode.py
@@ -1,8 +1,7 @@
 from collections.abc import Mapping
 from dataclasses import dataclass
 from itertools import accumulate, pairwise
-from operator import itemgetter
-from typing import Any, NamedTuple, final, override
+from typing import Any, final, override
 
 import more_itertools as mit
 import torch
@@ -10,24 +9,17 @@ from einops import pack, repeat
 from pydantic import InstanceOf, validate_call
 from structlog import get_logger
 from tensordict import TensorClass, TensorDict
-from tensordict._pytree import (  # noqa: PLC2701
-    _td_flatten_with_keys,
-    _tensordict_flatten,
-    _tensordict_unflatten,
-)
 from torch import Tensor
 from torch.nn import Module
 from torch.utils._pytree import (  # noqa: PLC2701
     MappingKey,
     key_get,
-    register_pytree_node,
     tree_leaves,
-    tree_leaves_with_path,
     tree_map,
     tree_map_with_path,
 )
 
-from rmind.components.base import Modality, TensorTree, TokenType
+from rmind.components.base import TensorTree, TokenMeta
 from rmind.components.containers import ModuleDict
 from rmind.components.mask import (
     FactorizedAttentionMask,
@@ -37,12 +29,6 @@ from rmind.components.mask import (
 from rmind.utils.pytree import unflatten_keys
 
 logger = get_logger(__name__)
-
-
-class TokenMeta(NamedTuple):
-    type: TokenType
-    modality: Modality
-    name: str
 
 
 class Index(TensorClass["frozen"]):  # ty:ignore[unsupported-base]
@@ -67,20 +53,6 @@ class Index(TensorClass["frozen"]):  # ty:ignore[unsupported-base]
         )
 
 
-class Timestep(TensorDict):
-    pass
-
-
-register_pytree_node(
-    Timestep,
-    _tensordict_flatten,
-    _tensordict_unflatten,  # ty:ignore[invalid-argument-type]
-    flatten_with_keys_fn=_td_flatten_with_keys,
-)
-
-TimestepExport = dict[str, dict[tuple[Modality, str], int]]
-
-
 class Episode(TensorClass["frozen"]):  # ty:ignore[unsupported-base]
     input: TensorDict
     input_tokens: TensorDict
@@ -88,26 +60,12 @@ class Episode(TensorClass["frozen"]):  # ty:ignore[unsupported-base]
     projected_embeddings: TensorDict
     role_embeddings: TensorDict
     index: Index
-    timestep: Timestep
+    embeddings_unpacked: Tensor
     attention_mask: FactorizedAttentionMask
 
     @property
     def embeddings(self) -> TensorDict:
         return self.projected_embeddings + self.role_embeddings
-
-    @property
-    def embeddings_unpacked(self) -> Tensor:
-        embeddings = self.embeddings
-        keys = (
-            (modality, name)
-            for (_token_type, modality, name), _pos in sorted(
-                self.timestep.items(include_nested=True, leaves_only=True),
-                key=itemgetter(1),
-            )
-        )
-        packed, _ = pack([embeddings[key] for key in keys], "b t * d")
-
-        return packed  # ty:ignore[invalid-return-type]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -118,7 +76,7 @@ class EpisodeExport:
     projected_embeddings: TensorTree
     role_embeddings: TensorTree
     index: TensorTree
-    timestep: TimestepExport
+    embeddings_unpacked: Tensor
     attention_mask: FactorizedAttentionMask
 
     @property
@@ -130,20 +88,6 @@ class EpisodeExport:
             self.projected_embeddings,
             self.role_embeddings,
         )
-
-    @property
-    def embeddings_unpacked(self) -> Tensor:
-        embeddings = self.embeddings
-        paths = (
-            (modality, name)
-            for (_token_type, modality, name), _pos in sorted(
-                tree_leaves_with_path(self.timestep), key=itemgetter(1)
-            )
-        )
-
-        packed, _ = pack([key_get(embeddings, path) for path in paths], "b t * d")
-
-        return packed
 
     def __getitem__(self, item: str) -> Any:
         return getattr(self, item)
@@ -228,13 +172,22 @@ class EpisodeBuilder(Module):
 
         index = self._build_index(projected_embeddings)
 
-        timestep = unflatten_keys({
-            tuple(map(str, k)): idx for idx, k in enumerate(self.timestep)
-        })
-
-        attention_mask = self._build_attention_mask(index=index, timestep=timestep)
+        attention_mask = self._build_attention_mask(index=index, timestep=self.timestep)
 
         role_embeddings = self._build_role_embeddings(projected_embeddings)
+
+        embeddings_unpacked, _ = pack(
+            [
+                key_get(projected_embeddings, kp)  # ty:ignore[invalid-argument-type]
+                + key_get(role_embeddings, kp)  # ty:ignore[invalid-argument-type]
+                for kp in (
+                    (MappingKey(token.modality.value), MappingKey(str(token.name)))
+                    for token in self.timestep
+                )
+            ],
+            "b t * d",
+        )
+
         return (
             EpisodeExport(
                 input=input,
@@ -243,7 +196,7 @@ class EpisodeBuilder(Module):
                 projected_embeddings=projected_embeddings,
                 role_embeddings=role_embeddings,
                 index=index,
-                timestep=timestep,
+                embeddings_unpacked=embeddings_unpacked,
                 attention_mask=attention_mask,
             )
             if torch.compiler.is_exporting()
@@ -265,14 +218,14 @@ class EpisodeBuilder(Module):
                     batch_dims=2,
                 ).filter_non_tensor_data(),
                 index=Index.from_dict(index, batch_dims=1),
-                timestep=Timestep.from_dict(timestep),
+                embeddings_unpacked=embeddings_unpacked,
                 attention_mask=attention_mask,
                 device=device,
             )
         )
 
     def _build_attention_mask(
-        self, *, index: TensorTree, timestep: TimestepExport
+        self, *, index: TensorTree, timestep: tuple[TokenMeta, ...]
     ) -> FactorizedAttentionMask:
         """Build (or return cached) spatial and temporal attention masks.
 

--- a/src/rmind/components/episode.py
+++ b/src/rmind/components/episode.py
@@ -59,15 +59,8 @@ class Episode(TensorClass["frozen"]):  # ty:ignore[unsupported-base]
     input_embeddings: TensorDict
     embeddings: TensorDict
     index: Index
-    timestep_keys: tuple[tuple[str, str], ...]
+    embeddings_flattened: Tensor
     attention_mask: FactorizedAttentionMask
-
-    @property
-    def token_embeddings(self) -> Tensor:
-        packed, _ = pack(
-            [self.embeddings.get(k) for k in self.timestep_keys], "b t * d"
-        )
-        return packed  # ty:ignore[invalid-return-type]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -77,28 +70,15 @@ class EpisodeExport:
     input_embeddings: TensorTree
     embeddings: TensorTree
     index: TensorTree
-    timestep_keys: tuple[tuple[str, str], ...]
+    embeddings_flattened: Tensor
     attention_mask: FactorizedAttentionMask
-
-    @property
-    def token_embeddings(self) -> Tensor:
-        packed, _ = pack(
-            [
-                key_get(self.embeddings, (MappingKey(k[0]), MappingKey(k[1])))  # ty:ignore[invalid-argument-type]
-                for k in self.timestep_keys
-            ],
-            "b t * d",
-        )
-        return packed
 
     def __getitem__(self, item: str) -> Any:
         return getattr(self, item)
 
 
-torch.utils._pytree.register_dataclass(  # noqa: SLF001
-    (cls := EpisodeExport),
-    drop_field_names=["timestep_keys"],  # non-tensor; treated as static context
-    serialized_type_name=cls.__name__,
+torch.export.register_dataclass(
+    (cls := EpisodeExport), serialized_type_name=cls.__name__
 )
 
 
@@ -183,10 +163,17 @@ class EpisodeBuilder(Module):
 
         role_embeddings = self._build_role_embeddings(projected_embeddings)
 
-        embeddings = tree_map(
-            lambda p, r: p + r if p is not None and r is not None else None,
-            projected_embeddings,
-            role_embeddings,
+        embeddings = TensorDict.from_dict(
+            tree_map(
+                lambda p, r: p + r if p is not None and r is not None else None,
+                projected_embeddings,
+                role_embeddings,
+            ),
+            batch_dims=2,
+        ).filter_non_tensor_data()
+
+        embeddings_flattened, _ = pack(
+            [embeddings.get(k) for k in self._timestep_keys], "b t * d"
         )
 
         return (
@@ -194,9 +181,9 @@ class EpisodeBuilder(Module):
                 input=input,
                 input_tokens=input_tokens,
                 input_embeddings=input_embeddings,
-                embeddings=embeddings,
+                embeddings=embeddings.to_dict(),
                 index=index,
-                timestep_keys=self._timestep_keys,
+                embeddings_flattened=embeddings_flattened,
                 attention_mask=attention_mask,
             )
             if torch.compiler.is_exporting()
@@ -210,11 +197,9 @@ class EpisodeBuilder(Module):
                 input_embeddings=TensorDict.from_dict(
                     input_embeddings, batch_dims=2
                 ).filter_non_tensor_data(),
-                embeddings=TensorDict.from_dict(
-                    embeddings, batch_dims=2
-                ).filter_non_tensor_data(),
+                embeddings=embeddings,
                 index=Index.from_dict(index, batch_dims=1),
-                timestep_keys=self._timestep_keys,
+                embeddings_flattened=embeddings_flattened,
                 attention_mask=attention_mask,
                 device=device,
             )

--- a/src/rmind/components/episode.py
+++ b/src/rmind/components/episode.py
@@ -59,8 +59,15 @@ class Episode(TensorClass["frozen"]):  # ty:ignore[unsupported-base]
     input_embeddings: TensorDict
     embeddings: TensorDict
     index: Index
-    token_embeddings: Tensor
+    timestep_keys: tuple[tuple[str, str], ...]
     attention_mask: FactorizedAttentionMask
+
+    @property
+    def token_embeddings(self) -> Tensor:
+        packed, _ = pack(
+            [self.embeddings.get(k) for k in self.timestep_keys], "b t * d"
+        )
+        return packed  # ty:ignore[invalid-return-type]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -70,15 +77,28 @@ class EpisodeExport:
     input_embeddings: TensorTree
     embeddings: TensorTree
     index: TensorTree
-    token_embeddings: Tensor
+    timestep_keys: tuple[tuple[str, str], ...]
     attention_mask: FactorizedAttentionMask
+
+    @property
+    def token_embeddings(self) -> Tensor:
+        packed, _ = pack(
+            [
+                key_get(self.embeddings, (MappingKey(k[0]), MappingKey(k[1])))  # ty:ignore[invalid-argument-type]
+                for k in self.timestep_keys
+            ],
+            "b t * d",
+        )
+        return packed
 
     def __getitem__(self, item: str) -> Any:
         return getattr(self, item)
 
 
-torch.export.register_dataclass(
-    (cls := EpisodeExport), serialized_type_name=cls.__name__
+torch.utils._pytree.register_dataclass(  # noqa: SLF001
+    (cls := EpisodeExport),
+    drop_field_names=["timestep_keys"],  # non-tensor; treated as static context
+    serialized_type_name=cls.__name__,
 )
 
 
@@ -103,6 +123,9 @@ class EpisodeBuilder(Module):
             special_tokens
         )
         self.timestep: tuple[TokenMeta, ...] = timestep
+        self._timestep_keys: tuple[tuple[str, str], ...] = tuple(
+            (token.modality.value, str(token.name)) for token in timestep
+        )
         self.input_transform: Module = input_transform
         self.tokenizers: ModuleDict = tokenizers
         self.embeddings: ModuleDict = embeddings
@@ -166,17 +189,6 @@ class EpisodeBuilder(Module):
             role_embeddings,
         )
 
-        token_embeddings, _ = pack(
-            [
-                key_get(embeddings, kp)  # ty:ignore[invalid-argument-type]
-                for kp in (
-                    (MappingKey(token.modality.value), MappingKey(str(token.name)))
-                    for token in self.timestep
-                )
-            ],
-            "b t * d",
-        )
-
         return (
             EpisodeExport(
                 input=input,
@@ -184,7 +196,7 @@ class EpisodeBuilder(Module):
                 input_embeddings=input_embeddings,
                 embeddings=embeddings,
                 index=index,
-                token_embeddings=token_embeddings,
+                timestep_keys=self._timestep_keys,
                 attention_mask=attention_mask,
             )
             if torch.compiler.is_exporting()
@@ -202,7 +214,7 @@ class EpisodeBuilder(Module):
                     embeddings, batch_dims=2
                 ).filter_non_tensor_data(),
                 index=Index.from_dict(index, batch_dims=1),
-                token_embeddings=token_embeddings,
+                timestep_keys=self._timestep_keys,
                 attention_mask=attention_mask,
                 device=device,
             )

--- a/src/rmind/components/episode.py
+++ b/src/rmind/components/episode.py
@@ -160,19 +160,20 @@ class EpisodeBuilder(Module):
 
         role_embeddings = self._build_role_embeddings(projected_embeddings)
 
-        embeddings = tree_map(
-            lambda p, r: p + r if p is not None and r is not None else None,
-            projected_embeddings,
-            role_embeddings,
+        embeddings = (
+            TensorDict.from_dict(
+                projected_embeddings, batch_dims=2
+            ).filter_non_tensor_data()
+            + TensorDict.from_dict(
+                role_embeddings,  # ty:ignore[invalid-argument-type]
+                batch_dims=2,
+            ).filter_non_tensor_data()
         )
 
         token_embeddings, _ = pack(
             [
-                key_get(embeddings, kp)  # ty:ignore[invalid-argument-type]
-                for kp in (
-                    (MappingKey(token.modality.value), MappingKey(str(token.name)))
-                    for token in self.timestep
-                )
+                embeddings.get((token.modality.value, str(token.name)))
+                for token in self.timestep
             ],
             "b t * d",
         )
@@ -182,7 +183,7 @@ class EpisodeBuilder(Module):
                 input=input,
                 input_tokens=input_tokens,
                 input_embeddings=input_embeddings,
-                embeddings=embeddings,
+                embeddings=embeddings.to_dict(),
                 index=index,
                 token_embeddings=token_embeddings,
                 attention_mask=attention_mask,
@@ -198,9 +199,7 @@ class EpisodeBuilder(Module):
                 input_embeddings=TensorDict.from_dict(
                     input_embeddings, batch_dims=2
                 ).filter_non_tensor_data(),
-                embeddings=TensorDict.from_dict(
-                    embeddings, batch_dims=2
-                ).filter_non_tensor_data(),
+                embeddings=embeddings,
                 index=Index.from_dict(index, batch_dims=1),
                 token_embeddings=token_embeddings,
                 attention_mask=attention_mask,

--- a/src/rmind/components/episode.py
+++ b/src/rmind/components/episode.py
@@ -57,15 +57,10 @@ class Episode(TensorClass["frozen"]):  # ty:ignore[unsupported-base]
     input: TensorDict
     input_tokens: TensorDict
     input_embeddings: TensorDict
-    projected_embeddings: TensorDict
-    role_embeddings: TensorDict
+    embeddings: TensorDict
     index: Index
-    embeddings_unpacked: Tensor
+    token_embeddings: Tensor
     attention_mask: FactorizedAttentionMask
-
-    @property
-    def embeddings(self) -> TensorDict:
-        return self.projected_embeddings + self.role_embeddings
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -73,21 +68,10 @@ class EpisodeExport:
     input: TensorTree
     input_tokens: TensorTree
     input_embeddings: TensorTree
-    projected_embeddings: TensorTree
-    role_embeddings: TensorTree
+    embeddings: TensorTree
     index: TensorTree
-    embeddings_unpacked: Tensor
+    token_embeddings: Tensor
     attention_mask: FactorizedAttentionMask
-
-    @property
-    def embeddings(self) -> TensorTree:
-        return tree_map(
-            lambda left, right: (
-                left + right if left is not None and right is not None else None
-            ),
-            self.projected_embeddings,
-            self.role_embeddings,
-        )
 
     def __getitem__(self, item: str) -> Any:
         return getattr(self, item)
@@ -176,10 +160,15 @@ class EpisodeBuilder(Module):
 
         role_embeddings = self._build_role_embeddings(projected_embeddings)
 
-        embeddings_unpacked, _ = pack(
+        embeddings = tree_map(
+            lambda p, r: p + r if p is not None and r is not None else None,
+            projected_embeddings,
+            role_embeddings,
+        )
+
+        token_embeddings, _ = pack(
             [
-                key_get(projected_embeddings, kp)  # ty:ignore[invalid-argument-type]
-                + key_get(role_embeddings, kp)  # ty:ignore[invalid-argument-type]
+                key_get(embeddings, kp)  # ty:ignore[invalid-argument-type]
                 for kp in (
                     (MappingKey(token.modality.value), MappingKey(str(token.name)))
                     for token in self.timestep
@@ -193,10 +182,9 @@ class EpisodeBuilder(Module):
                 input=input,
                 input_tokens=input_tokens,
                 input_embeddings=input_embeddings,
-                projected_embeddings=projected_embeddings,
-                role_embeddings=role_embeddings,
+                embeddings=embeddings,
                 index=index,
-                embeddings_unpacked=embeddings_unpacked,
+                token_embeddings=token_embeddings,
                 attention_mask=attention_mask,
             )
             if torch.compiler.is_exporting()
@@ -210,15 +198,11 @@ class EpisodeBuilder(Module):
                 input_embeddings=TensorDict.from_dict(
                     input_embeddings, batch_dims=2
                 ).filter_non_tensor_data(),
-                projected_embeddings=TensorDict.from_dict(
-                    projected_embeddings, batch_dims=2
-                ).filter_non_tensor_data(),
-                role_embeddings=TensorDict.from_dict(
-                    role_embeddings,  # ty:ignore[invalid-argument-type]
-                    batch_dims=2,
+                embeddings=TensorDict.from_dict(
+                    embeddings, batch_dims=2
                 ).filter_non_tensor_data(),
                 index=Index.from_dict(index, batch_dims=1),
-                embeddings_unpacked=embeddings_unpacked,
+                token_embeddings=token_embeddings,
                 attention_mask=attention_mask,
                 device=device,
             )

--- a/src/rmind/components/episode.py
+++ b/src/rmind/components/episode.py
@@ -160,20 +160,19 @@ class EpisodeBuilder(Module):
 
         role_embeddings = self._build_role_embeddings(projected_embeddings)
 
-        embeddings = (
-            TensorDict.from_dict(
-                projected_embeddings, batch_dims=2
-            ).filter_non_tensor_data()
-            + TensorDict.from_dict(
-                role_embeddings,  # ty:ignore[invalid-argument-type]
-                batch_dims=2,
-            ).filter_non_tensor_data()
+        embeddings = tree_map(
+            lambda p, r: p + r if p is not None and r is not None else None,
+            projected_embeddings,
+            role_embeddings,
         )
 
         token_embeddings, _ = pack(
             [
-                embeddings.get((token.modality.value, str(token.name)))
-                for token in self.timestep
+                key_get(embeddings, kp)  # ty:ignore[invalid-argument-type]
+                for kp in (
+                    (MappingKey(token.modality.value), MappingKey(str(token.name)))
+                    for token in self.timestep
+                )
             ],
             "b t * d",
         )
@@ -183,7 +182,7 @@ class EpisodeBuilder(Module):
                 input=input,
                 input_tokens=input_tokens,
                 input_embeddings=input_embeddings,
-                embeddings=embeddings.to_dict(),
+                embeddings=embeddings,
                 index=index,
                 token_embeddings=token_embeddings,
                 attention_mask=attention_mask,
@@ -199,7 +198,9 @@ class EpisodeBuilder(Module):
                 input_embeddings=TensorDict.from_dict(
                     input_embeddings, batch_dims=2
                 ).filter_non_tensor_data(),
-                embeddings=embeddings,
+                embeddings=TensorDict.from_dict(
+                    embeddings, batch_dims=2
+                ).filter_non_tensor_data(),
                 index=Index.from_dict(index, batch_dims=1),
                 token_embeddings=token_embeddings,
                 attention_mask=attention_mask,
@@ -223,7 +224,10 @@ class EpisodeBuilder(Module):
                 legend=TorchAttentionMaskLegend,
             )
 
-        if torch.compiler.is_exporting():
+        if torch.compiler.is_exporting() and not torch.compiler.is_compiling():
+            # Guard with is_compiling(): structlog's logger is not dynamo-traceable
+            # (_thread.allocate_lock breaks strict export). The warning still fires
+            # in fake-export paths where is_exporting()=True but dynamo isn't active.
             logger.warning(
                 "building attention mask during export; "
                 "run an eager forward pass first to populate the cache"

--- a/src/rmind/components/mask.py
+++ b/src/rmind/components/mask.py
@@ -1,6 +1,6 @@
 import operator
 from abc import ABC, abstractmethod
-from collections.abc import Mapping, Sequence
+from collections.abc import Sequence
 from typing import Protocol, Self, final, override
 
 import torch
@@ -11,7 +11,13 @@ from torch.nn import Module
 from torch.types import Number
 from torch.utils._pytree import tree_leaves, tree_map  # noqa: PLC2701
 
-from rmind.components.base import Modality, SummaryToken, TensorTree, TokenType
+from rmind.components.base import (
+    Modality,
+    SummaryToken,
+    TensorTree,
+    TokenMeta,
+    TokenType,
+)
 
 
 class AttentionMaskLegendProvider(Protocol):
@@ -102,7 +108,7 @@ class AttentionMaskBuilder(Module, ABC):
         self,
         *,
         index: TensorTree,
-        timestep: dict[str, dict[str, Mapping[str, int]]],
+        timestep: Sequence[TokenMeta],
         legend: type[AttentionMaskLegendProvider],
     ) -> Tensor: ...
 
@@ -132,7 +138,7 @@ class FactorizedAttentionMaskBuilder(Module, ABC):
         self,
         *,
         index: TensorTree,
-        timestep: dict[str, dict[str, Mapping[str, int]]],
+        timestep: Sequence[TokenMeta],
         legend: type[AttentionMaskLegendProvider],
     ) -> FactorizedAttentionMask: ...
 
@@ -143,7 +149,7 @@ class CausalAttentionMaskBuilder(AttentionMaskBuilder):
         self,
         *,
         index: TensorTree,
-        timestep: dict[str, dict[str, Mapping[str, int]]],
+        timestep: Sequence[TokenMeta],
         legend: type[AttentionMaskLegendProvider],
     ) -> Tensor:
         leaves = tree_leaves(index, lambda x: isinstance(x, Tensor))
@@ -159,14 +165,14 @@ class CausalAttentionMaskBuilder(AttentionMaskBuilder):
         )
 
         obs_keys = tuple(
-            (modality, name)
-            for modality, names in timestep[TokenType.OBSERVATION.value].items()
-            for name in names
+            (token.modality.value, str(token.name))
+            for token in timestep
+            if token.type == TokenType.OBSERVATION
         )
         action_keys = tuple(
-            (modality, name)
-            for modality, names in timestep[TokenType.ACTION.value].items()
-            for name in names
+            (token.modality.value, str(token.name))
+            for token in timestep
+            if token.type == TokenType.ACTION
         )
         foresight_keys = tuple(
             (Modality.FORESIGHT.value, name) for name in index[Modality.FORESIGHT.value]
@@ -238,7 +244,7 @@ class FactorizedCausalAttentionMaskBuilder(FactorizedAttentionMaskBuilder):
         self,
         *,
         index: TensorTree,
-        timestep: dict[str, dict[str, Mapping[str, int]]],
+        timestep: Sequence[TokenMeta],
         legend: type[AttentionMaskLegendProvider],
     ) -> FactorizedAttentionMask:
         leaves = tree_leaves(index, lambda x: isinstance(x, Tensor))

--- a/src/rmind/components/mask.py
+++ b/src/rmind/components/mask.py
@@ -165,12 +165,12 @@ class CausalAttentionMaskBuilder(AttentionMaskBuilder):
         )
 
         obs_keys = tuple(
-            (token.modality.value, str(token.name))
+            (token.modality.value, token.name)
             for token in timestep
             if token.type == TokenType.OBSERVATION
         )
         action_keys = tuple(
-            (token.modality.value, str(token.name))
+            (token.modality.value, token.name)
             for token in timestep
             if token.type == TokenType.ACTION
         )

--- a/src/rmind/models/control_transformer.py
+++ b/src/rmind/models/control_transformer.py
@@ -179,7 +179,7 @@ class ControlTransformer(pl.LightningModule, LoadableFromArtifact):
     def training_step(self, batch: dict[str, Any], batch_idx: int) -> STEP_OUTPUT:
         episode = self.episode_builder(batch)
         embedding = self.encoder(
-            src=episode.token_embeddings, mask=episode.attention_mask
+            src=episode.embeddings_flattened, mask=episode.attention_mask
         )
 
         metrics = TensorDict({
@@ -219,7 +219,7 @@ class ControlTransformer(pl.LightningModule, LoadableFromArtifact):
     def validation_step(self, batch: dict[str, Any], _batch_idx: int) -> STEP_OUTPUT:
         episode = self.episode_builder(batch)
         embedding = self.encoder(
-            src=episode.token_embeddings, mask=episode.attention_mask
+            src=episode.embeddings_flattened, mask=episode.attention_mask
         )
         metrics = TensorDict({
             name: objective.compute_metrics(episode=episode, embedding=embedding)  # ty:ignore[call-non-callable]
@@ -252,7 +252,7 @@ class ControlTransformer(pl.LightningModule, LoadableFromArtifact):
     def predict_step(self, batch: dict[str, Any]) -> TensorDict:
         episode = self.episode_builder(batch)
         embedding = self.encoder(
-            src=episode.token_embeddings, mask=episode.attention_mask
+            src=episode.embeddings_flattened, mask=episode.attention_mask
         )
         objectives_predictions = {
             name: objective.predict(
@@ -269,7 +269,7 @@ class ControlTransformer(pl.LightningModule, LoadableFromArtifact):
     def forward(self, batch: TensorTree) -> TensorTree | TensorDict:
         episode = self.episode_builder(batch)
         embedding = self.encoder(
-            src=episode.token_embeddings, mask=episode.attention_mask
+            src=episode.embeddings_flattened, mask=episode.attention_mask
         )
 
         outputs = {

--- a/src/rmind/models/control_transformer.py
+++ b/src/rmind/models/control_transformer.py
@@ -179,7 +179,7 @@ class ControlTransformer(pl.LightningModule, LoadableFromArtifact):
     def training_step(self, batch: dict[str, Any], batch_idx: int) -> STEP_OUTPUT:
         episode = self.episode_builder(batch)
         embedding = self.encoder(
-            src=episode.embeddings_unpacked, mask=episode.attention_mask
+            src=episode.token_embeddings, mask=episode.attention_mask
         )
 
         metrics = TensorDict({
@@ -219,7 +219,7 @@ class ControlTransformer(pl.LightningModule, LoadableFromArtifact):
     def validation_step(self, batch: dict[str, Any], _batch_idx: int) -> STEP_OUTPUT:
         episode = self.episode_builder(batch)
         embedding = self.encoder(
-            src=episode.embeddings_unpacked, mask=episode.attention_mask
+            src=episode.token_embeddings, mask=episode.attention_mask
         )
         metrics = TensorDict({
             name: objective.compute_metrics(episode=episode, embedding=embedding)  # ty:ignore[call-non-callable]
@@ -252,7 +252,7 @@ class ControlTransformer(pl.LightningModule, LoadableFromArtifact):
     def predict_step(self, batch: dict[str, Any]) -> TensorDict:
         episode = self.episode_builder(batch)
         embedding = self.encoder(
-            src=episode.embeddings_unpacked, mask=episode.attention_mask
+            src=episode.token_embeddings, mask=episode.attention_mask
         )
         objectives_predictions = {
             name: objective.predict(
@@ -269,7 +269,7 @@ class ControlTransformer(pl.LightningModule, LoadableFromArtifact):
     def forward(self, batch: TensorTree) -> TensorTree | TensorDict:
         episode = self.episode_builder(batch)
         embedding = self.encoder(
-            src=episode.embeddings_unpacked, mask=episode.attention_mask
+            src=episode.token_embeddings, mask=episode.attention_mask
         )
 
         outputs = {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,9 +13,15 @@ from torch.testing import make_tensor
 from torchvision.ops import MLP
 from torchvision.transforms.v2 import CenterCrop, Normalize, Resize, ToDtype
 
-from rmind.components.base import Modality, SummaryToken, TensorTree, TokenType
+from rmind.components.base import (
+    Modality,
+    SummaryToken,
+    TensorTree,
+    TokenMeta,
+    TokenType,
+)
 from rmind.components.containers import ModuleDict
-from rmind.components.episode import Episode, EpisodeBuilder, TokenMeta
+from rmind.components.episode import Episode, EpisodeBuilder
 from rmind.components.loss import (
     GaussianNLLLoss,
     GramAnchoringLoss,

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -154,17 +154,17 @@ def test_factorized_causal_attention_mask_builder(device: torch.device) -> None:
     )
 
 
-def test_embeddings_unpacked_order(
+def test_token_embeddings_order(
     episode_builder: EpisodeBuilder, episode: Episode
 ) -> None:
-    """embeddings_unpacked must pack tokens in the order declared in episode_builder.timestep.
+    """token_embeddings must pack tokens in the order declared in episode_builder.timestep.
 
     The index assigns flat positions by enumerating episode_builder.timestep, so the
     slice at each offset must match the corresponding token's embeddings. Removing
-    sorted() from embeddings_unpacked causes TensorDict to iterate alphabetically,
+    sorted() from token_embeddings causes TensorDict to iterate alphabetically,
     placing e.g. action tokens before image tokens and failing this check.
     """
-    unpacked = episode.embeddings_unpacked  # (b, t, s, d)
+    unpacked = episode.token_embeddings  # (b, t, s, d)
     embeddings = episode.embeddings
 
     pos = 0
@@ -180,14 +180,14 @@ def test_embeddings_unpacked_order(
 
 
 def test_index_unpacked_alignment(episode: Episode) -> None:
-    """index.parse(flat embeddings_unpacked) must recover the per-token embeddings.
+    """index.parse(flat token_embeddings) must recover the per-token embeddings.
 
     This is the load-bearing invariant for every downstream `index.parse(encoder_output)`
     call: a token's position in the flat (t*s,) sequence — assigned by the builder when
     constructing the index — must match where that token actually sits in
-    embeddings_unpacked. If the two disagree, every objective reads the wrong slice.
+    token_embeddings. If the two disagree, every objective reads the wrong slice.
     """
-    unpacked = episode.embeddings_unpacked  # (b, t, s, d)
+    unpacked = episode.token_embeddings  # (b, t, s, d)
     b, t, s, d = unpacked.shape
     flat = unpacked.reshape(b, t * s, d)  # same shape the encoder returns
 

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -92,8 +92,8 @@ def test_gram_anchoring_loss_runs_without_gram(device: torch.device) -> None:
 
 def _causal_mask_inputs(device: torch.device) -> tuple[dict, tuple[TokenMeta, ...]]:
     index = {
-        Modality.IMAGE.value: {"obs": torch.tensor([[0], [6]], device=device)},
-        Modality.CONTINUOUS.value: {"act": torch.tensor([[4], [10]], device=device)},
+        Modality.IMAGE.value: {"observation": torch.tensor([[0], [6]], device=device)},
+        Modality.CONTINUOUS.value: {"action": torch.tensor([[4], [10]], device=device)},
         Modality.CONTEXT.value: {},
         Modality.DISCRETE.value: {},
         Modality.FORESIGHT.value: {"future": torch.tensor([[3], [9]], device=device)},
@@ -108,7 +108,7 @@ def _causal_mask_inputs(device: torch.device) -> tuple[dict, tuple[TokenMeta, ..
         },
     }
     timestep = (
-        TokenMeta(TokenType.OBSERVATION, Modality.IMAGE, "obs"),
+        TokenMeta(TokenType.OBSERVATION, Modality.IMAGE, "observation"),
         TokenMeta(
             TokenType.SPECIAL, Modality.SUMMARY, SummaryToken.OBSERVATION_SUMMARY
         ),
@@ -116,7 +116,7 @@ def _causal_mask_inputs(device: torch.device) -> tuple[dict, tuple[TokenMeta, ..
             TokenType.SPECIAL, Modality.SUMMARY, SummaryToken.OBSERVATION_HISTORY
         ),
         TokenMeta(TokenType.SPECIAL, Modality.FORESIGHT, "future"),
-        TokenMeta(TokenType.ACTION, Modality.CONTINUOUS, "act"),
+        TokenMeta(TokenType.ACTION, Modality.CONTINUOUS, "action"),
         TokenMeta(TokenType.SPECIAL, Modality.SUMMARY, SummaryToken.ACTION_SUMMARY),
     )
     return index, timestep
@@ -154,17 +154,17 @@ def test_factorized_causal_attention_mask_builder(device: torch.device) -> None:
     )
 
 
-def test_token_embeddings_order(
+def test_embeddings_flattened_order(
     episode_builder: EpisodeBuilder, episode: Episode
 ) -> None:
-    """token_embeddings must pack tokens in the order declared in episode_builder.timestep.
+    """embeddings_flattened must pack tokens in the order declared in episode_builder.timestep.
 
     The index assigns flat positions by enumerating episode_builder.timestep, so the
     slice at each offset must match the corresponding token's embeddings. Removing
-    sorted() from token_embeddings causes TensorDict to iterate alphabetically,
+    sorted() from embeddings_flattened causes TensorDict to iterate alphabetically,
     placing e.g. action tokens before image tokens and failing this check.
     """
-    unpacked = episode.token_embeddings  # (b, t, s, d)
+    unpacked = episode.embeddings_flattened  # (b, t, s, d)
     embeddings = episode.embeddings
 
     pos = 0
@@ -180,14 +180,14 @@ def test_token_embeddings_order(
 
 
 def test_index_unpacked_alignment(episode: Episode) -> None:
-    """index.parse(flat token_embeddings) must recover the per-token embeddings.
+    """index.parse(flat embeddings_flattened) must recover the per-token embeddings.
 
     This is the load-bearing invariant for every downstream `index.parse(encoder_output)`
     call: a token's position in the flat (t*s,) sequence — assigned by the builder when
     constructing the index — must match where that token actually sits in
-    token_embeddings. If the two disagree, every objective reads the wrong slice.
+    embeddings_flattened. If the two disagree, every objective reads the wrong slice.
     """
-    unpacked = episode.token_embeddings  # (b, t, s, d)
+    unpacked = episode.embeddings_flattened  # (b, t, s, d)
     b, t, s, d = unpacked.shape
     flat = unpacked.reshape(b, t * s, d)  # same shape the encoder returns
 
@@ -199,7 +199,7 @@ def test_index_unpacked_alignment(episode: Episode) -> None:
     # are NOT in timestep and therefore have no position in the packed sequence.
     # Those tokens are accessed directly from episode.embeddings by objectives
     # (e.g. ForwardDynamics uses utility/mask as a learned placeholder) and are
-    # intentionally absent from token_embeddings and the index.
+    # intentionally absent from embeddings_flattened and the index.
     assert set(recovered.keys(include_nested=True, leaves_only=True)) == set(
         episode.index.keys(include_nested=True, leaves_only=True)
     )

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -13,6 +13,7 @@ from rmind.components.mask import (
 )
 from rmind.components.nn import Sequential
 from rmind.components.norm import Scaler, UniformBinner
+from rmind.components.transformer import TransformerEncoder
 
 
 def test_scaler(device: torch.device) -> None:
@@ -169,7 +170,7 @@ def test_embeddings_flattened_order(
 
     pos = 0
     for idx, token in enumerate(episode_builder.timestep):
-        key = (token.modality.value, str(token.name))
+        key = (token.modality.value, token.name)
         expected = embeddings[key]  # (b, t, n, d)
         n = expected.shape[2]
         actual = unpacked[:, :, pos : pos + n, :]
@@ -209,3 +210,19 @@ def test_index_unpacked_alignment(episode: Episode) -> None:
         expected.select(*recovered.keys(include_nested=True, leaves_only=True)),
         msg="index/unpacked misaligned",
     )
+
+
+def test_encoder_no_inplace_ops(encoder: TransformerEncoder) -> None:
+    """Encoder must not use in-place ops.
+
+    Episode.embeddings_flattened is passed directly to the encoder without
+    cloning. A clone would cost ~134 MB per forward at production batch size
+    (b=90, bf16). In-place ops on submodule level are caught here; if one is
+    ever added, this test fails before it silently corrupts Episode state.
+    """
+    inplace_modules = [
+        name
+        for name, module in encoder.named_modules()
+        if getattr(module, "inplace", False)
+    ]
+    assert not inplace_modules, f"encoder contains inplace ops: {inplace_modules}"

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -3,7 +3,7 @@ from itertools import pairwise
 import torch
 from torch.testing import assert_close, make_tensor
 
-from rmind.components.base import Modality, SummaryToken, TokenType
+from rmind.components.base import Modality, SummaryToken, TokenMeta, TokenType
 from rmind.components.episode import Episode, EpisodeBuilder
 from rmind.components.loss import GramAnchoringLoss
 from rmind.components.mask import (
@@ -90,7 +90,7 @@ def test_gram_anchoring_loss_runs_without_gram(device: torch.device) -> None:
     assert loss.isfinite()
 
 
-def _causal_mask_inputs(device: torch.device) -> tuple[dict, dict]:
+def _causal_mask_inputs(device: torch.device) -> tuple[dict, tuple[TokenMeta, ...]]:
     index = {
         Modality.IMAGE.value: {"obs": torch.tensor([[0], [6]], device=device)},
         Modality.CONTINUOUS.value: {"act": torch.tensor([[4], [10]], device=device)},
@@ -107,18 +107,18 @@ def _causal_mask_inputs(device: torch.device) -> tuple[dict, dict]:
             SummaryToken.ACTION_SUMMARY.value: torch.tensor([[5], [11]], device=device),
         },
     }
-    timestep = {
-        TokenType.OBSERVATION.value: {Modality.IMAGE.value: {"obs": 0}},
-        TokenType.ACTION.value: {Modality.CONTINUOUS.value: {"act": 4}},
-        TokenType.SPECIAL.value: {
-            Modality.FORESIGHT.value: {"future": 3},
-            Modality.SUMMARY.value: {
-                SummaryToken.OBSERVATION_SUMMARY.value: 1,
-                SummaryToken.OBSERVATION_HISTORY.value: 2,
-                SummaryToken.ACTION_SUMMARY.value: 5,
-            },
-        },
-    }
+    timestep = (
+        TokenMeta(TokenType.OBSERVATION, Modality.IMAGE, "obs"),
+        TokenMeta(
+            TokenType.SPECIAL, Modality.SUMMARY, SummaryToken.OBSERVATION_SUMMARY
+        ),
+        TokenMeta(
+            TokenType.SPECIAL, Modality.SUMMARY, SummaryToken.OBSERVATION_HISTORY
+        ),
+        TokenMeta(TokenType.SPECIAL, Modality.FORESIGHT, "future"),
+        TokenMeta(TokenType.ACTION, Modality.CONTINUOUS, "act"),
+        TokenMeta(TokenType.SPECIAL, Modality.SUMMARY, SummaryToken.ACTION_SUMMARY),
+    )
     return index, timestep
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -85,7 +85,7 @@ def encoder_eval(encoder: Module) -> Module:
 @pytest.fixture
 def policy_embedding(encoder_eval: Module, episode: Episode) -> Tensor:
     return encoder_eval(
-        src=episode.embeddings_unpacked.clone(), mask=episode.attention_mask
+        src=episode.token_embeddings.clone(), mask=episode.attention_mask
     )
 
 
@@ -94,8 +94,7 @@ def policy_embedding_export(
     encoder_eval: Module, episode_export: EpisodeExport
 ) -> Tensor:
     return encoder_eval(
-        src=episode_export.embeddings_unpacked.clone(),
-        mask=episode_export.attention_mask,
+        src=episode_export.token_embeddings.clone(), mask=episode_export.attention_mask
     )
 
 
@@ -122,11 +121,10 @@ def control_transformer(
 def test_episode(episode: Episode, episode_export: EpisodeExport) -> None:
     episode_dict = (src := episode).to_dict() | {
         "embeddings": src.embeddings.to_dict(),
-        "embeddings_unpacked": src.embeddings_unpacked,
+        "token_embeddings": src.token_embeddings,
     }
     episode_export_dict = asdict(src := episode_export) | {
-        "embeddings": src.embeddings,
-        "embeddings_unpacked": src.embeddings_unpacked,
+        "token_embeddings": src.token_embeddings
     }
 
     for kp, expected in tree_flatten_with_path(episode_dict)[0]:

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -123,9 +123,11 @@ def test_episode(episode: Episode, episode_export: EpisodeExport) -> None:
         "embeddings": src.embeddings.to_dict(),
         "token_embeddings": src.token_embeddings,
     }
+    episode_dict.pop("timestep_keys", None)
     episode_export_dict = asdict(src := episode_export) | {
         "token_embeddings": src.token_embeddings
     }
+    episode_export_dict.pop("timestep_keys", None)
 
     for kp, expected in tree_flatten_with_path(episode_dict)[0]:
         actual = key_get(episode_export_dict, kp)

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -240,7 +240,9 @@ def test_episode_builder_warms_attention_mask_cache(
 )
 @torch.inference_mode()
 def test_torch_export(module: Module, args: tuple[Any]) -> None:
-    torch.export.export(module.eval(), args=args, strict=True)
+    module = module.eval()
+    module(*args)  # warm internal caches (e.g. attention mask) before export
+    torch.export.export(module, args=args, strict=True)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -84,9 +84,7 @@ def encoder_eval(encoder: Module) -> Module:
 
 @pytest.fixture
 def policy_embedding(encoder_eval: Module, episode: Episode) -> Tensor:
-    return encoder_eval(
-        src=episode.embeddings_flattened.clone(), mask=episode.attention_mask
-    )
+    return encoder_eval(src=episode.embeddings_flattened, mask=episode.attention_mask)
 
 
 @pytest.fixture
@@ -94,8 +92,7 @@ def policy_embedding_export(
     encoder_eval: Module, episode_export: EpisodeExport
 ) -> Tensor:
     return encoder_eval(
-        src=episode_export.embeddings_flattened.clone(),
-        mask=episode_export.attention_mask,
+        src=episode_export.embeddings_flattened, mask=episode_export.attention_mask
     )
 
 

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -85,7 +85,7 @@ def encoder_eval(encoder: Module) -> Module:
 @pytest.fixture
 def policy_embedding(encoder_eval: Module, episode: Episode) -> Tensor:
     return encoder_eval(
-        src=episode.token_embeddings.clone(), mask=episode.attention_mask
+        src=episode.embeddings_flattened.clone(), mask=episode.attention_mask
     )
 
 
@@ -94,7 +94,8 @@ def policy_embedding_export(
     encoder_eval: Module, episode_export: EpisodeExport
 ) -> Tensor:
     return encoder_eval(
-        src=episode_export.token_embeddings.clone(), mask=episode_export.attention_mask
+        src=episode_export.embeddings_flattened.clone(),
+        mask=episode_export.attention_mask,
     )
 
 
@@ -121,13 +122,11 @@ def control_transformer(
 def test_episode(episode: Episode, episode_export: EpisodeExport) -> None:
     episode_dict = (src := episode).to_dict() | {
         "embeddings": src.embeddings.to_dict(),
-        "token_embeddings": src.token_embeddings,
+        "embeddings_flattened": src.embeddings_flattened,
     }
-    episode_dict.pop("timestep_keys", None)
     episode_export_dict = asdict(src := episode_export) | {
-        "token_embeddings": src.token_embeddings
+        "embeddings_flattened": src.embeddings_flattened
     }
-    episode_export_dict.pop("timestep_keys", None)
 
     for kp, expected in tree_flatten_with_path(episode_dict)[0]:
         actual = key_get(episode_export_dict, kp)

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -20,7 +20,7 @@ from rmind.components.transformer import TransformerEncoder
 def test_compute_metrics(
     objective: Objective, episode: Episode, encoder: TransformerEncoder
 ) -> None:
-    embedding = encoder(src=episode.embeddings_unpacked, mask=episode.attention_mask)
+    embedding = encoder(src=episode.token_embeddings, mask=episode.attention_mask)
     assert "loss" in objective.compute_metrics(episode=episode, embedding=embedding)
 
 
@@ -50,7 +50,7 @@ def test_predict(  # noqa: PLR0913, PLR0917
     predictions = objective.predict(
         episode=episode,
         keys=keys,
-        embedding=encoder(src=episode.embeddings_unpacked, mask=episode.attention_mask),
+        embedding=encoder(src=episode.token_embeddings, mask=episode.attention_mask),
         tokenizers=tokenizers,
     )
     prediction_keys = set(predictions.keys())

--- a/tests/test_objectives.py
+++ b/tests/test_objectives.py
@@ -20,7 +20,7 @@ from rmind.components.transformer import TransformerEncoder
 def test_compute_metrics(
     objective: Objective, episode: Episode, encoder: TransformerEncoder
 ) -> None:
-    embedding = encoder(src=episode.token_embeddings, mask=episode.attention_mask)
+    embedding = encoder(src=episode.embeddings_flattened, mask=episode.attention_mask)
     assert "loss" in objective.compute_metrics(episode=episode, embedding=embedding)
 
 
@@ -50,7 +50,9 @@ def test_predict(  # noqa: PLR0913, PLR0917
     predictions = objective.predict(
         episode=episode,
         keys=keys,
-        embedding=encoder(src=episode.token_embeddings, mask=episode.attention_mask),
+        embedding=encoder(
+            src=episode.embeddings_flattened, mask=episode.attention_mask
+        ),
         tokenizers=tokenizers,
     )
     prediction_keys = set(predictions.keys())


### PR DESCRIPTION
Stacked on #229.

## Summary

The `Timestep(TensorDict)` / `TimestepExport` scheme stored positional indices inside a nested dict, and the old packing code had to `sorted(timestep.items(), key=itemgetter(1))` to recover declared order at read time.

This PR collapses that to **one source of truth**: `EpisodeBuilder.timestep` (`tuple[TokenMeta, ...]`). The final design:

- **`projected_embeddings` + `role_embeddings` dropped** from `Episode`/`EpisodeExport` — neither is used downstream of `EpisodeBuilder`. Their sum is stored directly as `embeddings: TensorDict`.
- **`embeddings_flattened: Tensor`** replaces the old `embeddings_unpacked` field — precomputed in `forward()` by packing `embeddings` in declared `timestep` order using `self._timestep_keys`, then stored as a direct field on both `Episode` and `EpisodeExport`.
- **`_timestep_keys`** computed once in `EpisodeBuilder.__init__` and used in `forward()` to drive the pack order. Never stored on the output objects.
- **`logger.warning` guarded** with `not torch.compiler.is_compiling()` — structlog's `_thread.allocate_lock` is not dynamo-traceable; the guard keeps the warning alive in fake-export paths while making strict export safe.
- **`test_torch_export`** fixed to warm the attention mask cache with an eager forward pass before calling `torch.export.export()`, matching the documented usage contract.

## What didn't work

**`timestep_keys` as a field on `Episode`/`EpisodeExport`** — `torch.export.register_dataclass` treats all dataclass fields as dynamic tensor leaves. Passing `timestep_keys` (a Python tuple of strings) through the forward trace caused an `AttrSource` chain that triggered `AttributeError: 'AttrSource' object has no attribute 'is_input'` in `output_graph.py`. Resolved by precomputing `embeddings_flattened` directly in `forward()` so `timestep_keys` never appears on the output objects.

## Regression gates (from #229, already on this branch)

- `test_embeddings_flattened_order` — verifies `embeddings_flattened` packs tokens in declared `timestep` order, not alphabetically.
- `test_index_unpacked_alignment` — verifies `index.parse(flat embeddings_flattened)` recovers per-token embeddings.
- `test_training_step_losses_snapshot` — deterministic forward with sin-based weights; passes before and after.
- `test_torch_export_fake` — covers `episode_builder`, `policy_objective`, and `control_transformer` export paths.

## Test plan
- [x] 60 tests pass (excluding 2 pre-existing `test_torch_export`/`test_onnx_export` failures on MPS unrelated to this PR)