### PR TITLE
chore: add VSCode launch.json for pytest debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,8 @@ config/logger/*
 
 # editor
 .helix/
+.vscode/
+!.vscode/launch.json
 
 # artifacts
 inference_results/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "pytest: current file",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "args": ["${file}", "-x", "-s"],
+            "python": "${workspaceFolder}/.venv/bin/python3",
+            "justMyCode": true,
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "pytest: all",
+            "type": "debugpy",
+            "module": "pytest",
+            "request": "launch",
+            "args": ["-x", "-s"],
+            "python": "${workspaceFolder}/.venv/bin/python3",
+            "justMyCode": true,
+            "cwd": "${workspaceFolder}"
+        },
+        {
+            "name": "pytest: attach (debugpy)",
+            "type": "debugpy",
+            "request": "attach",
+            "connect": {
+                "host": "localhost",
+                "port": 5678
+            },
+            "justMyCode": true
+        }
+    ]
+}


### PR DESCRIPTION
Adds `.vscode/launch.json` with three pytest debug configurations:

- **pytest: current file** — open a test file, hit F5 to debug it (`-x -s`)
- **pytest: all** — run the full suite under the debugger
- **pytest: attach** — attach to a `debugpy --listen 5678` process

`justMyCode: true` by default; toggle to `false` to step into library internals.

Note: `.vscode/` is ignored in the gitignore (added separately in #231) but `launch.json` is explicitly unignored via `!.vscode/launch.json` so it can be tracked as shared project config.