### PR TITLE
feat: gracefull callbacks failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ ignore = [
 ]
 
 [tool.ruff.lint.extend-per-file-ignores]
-"tests/**/*.py" = ["S101"]
+"tests/**/*.py" = ["S101", "S301", "S403"]
 
 [tool.ruff.lint.isort]
 split-on-trailing-comma = false

--- a/src/rmind/callbacks/__init__.py
+++ b/src/rmind/callbacks/__init__.py
@@ -13,6 +13,7 @@ from .prediction import (
     TensorDictPredictionWriter,
 )
 from .prediction_config import PredictionConfigSetter
+from .safe import SafeCallback
 
 __all__ = [
     "DataFramePredictionWriter",
@@ -21,6 +22,7 @@ __all__ = [
     "ModuleFreezer",
     "PredictionConfigSetter",
     "RerunPredictionWriter",
+    "SafeCallback",
     "TensorDictPredictionWriter",
     "WandbAttentionMaskLogger",
     "WandbImageParamLogger",

--- a/src/rmind/callbacks/loggers/attention_mask.py
+++ b/src/rmind/callbacks/loggers/attention_mask.py
@@ -132,7 +132,7 @@ class WandbAttentionMaskLogger(SafeCallback):
         *,
         num_vis_timesteps: int = 2,
         fail_gracefully: bool = True,
-        disable_on_error: bool = True,
+        disable_on_error: bool = False,
     ) -> None:
         super().__init__(
             fail_gracefully=fail_gracefully, disable_on_error=disable_on_error

--- a/src/rmind/callbacks/loggers/attention_mask.py
+++ b/src/rmind/callbacks/loggers/attention_mask.py
@@ -6,14 +6,14 @@ import pytorch_lightning as pl
 import torch
 from matplotlib.colors import BoundaryNorm, ListedColormap
 from matplotlib.patches import Patch
-from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.utilities.types import STEP_OUTPUT
 from structlog import get_logger
 from torch import Tensor
 from wandb import Image
 
-from rmind.components.base import TokenMeta, TokenType
-from rmind.components.episode import Episode, EpisodeBuilder
+from rmind.callbacks.safe import SafeCallback
+from rmind.components.base import TokenType
+from rmind.components.episode import Episode, EpisodeBuilder, TokenMeta
 
 from .common import _figure_to_rgba, _get_wandb_loggers
 
@@ -126,11 +126,38 @@ def visualize_attention_mask(  # noqa: PLR0914
 
 
 @final
-class WandbAttentionMaskLogger(Callback):
-    def __init__(self, *, num_vis_timesteps: int = 2) -> None:
+class WandbAttentionMaskLogger(SafeCallback):
+    def __init__(
+        self,
+        *,
+        num_vis_timesteps: int = 2,
+        fail_gracefully: bool = True,
+        disable_on_error: bool = True,
+    ) -> None:
+        super().__init__(
+            fail_gracefully=fail_gracefully, disable_on_error=disable_on_error
+        )
         self._num_vis_timesteps = num_vis_timesteps
 
     def on_train_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs: STEP_OUTPUT,
+        batch: Any,
+        batch_idx: int,
+    ) -> None:
+        self._safe_call(
+            "on_train_batch_end",
+            self._log_attention_mask,
+            trainer,
+            pl_module,
+            outputs,
+            batch,
+            batch_idx,
+        )
+
+    def _log_attention_mask(
         self,
         trainer: pl.Trainer,
         pl_module: pl.LightningModule,

--- a/src/rmind/callbacks/loggers/image_param.py
+++ b/src/rmind/callbacks/loggers/image_param.py
@@ -33,7 +33,7 @@ class WandbImageParamLogger(SafeCallback):
         every_n_batch: int | None = None,
         cmap_type: K.ColorMapType | None = K.ColorMapType.viridis,
         fail_gracefully: bool = True,
-        disable_on_error: bool = True,
+        disable_on_error: bool = False,
     ) -> None:
         super().__init__(
             fail_gracefully=fail_gracefully, disable_on_error=disable_on_error

--- a/src/rmind/callbacks/loggers/image_param.py
+++ b/src/rmind/callbacks/loggers/image_param.py
@@ -5,10 +5,11 @@ import kornia.color as K
 import pytorch_lightning as pl
 from einops import rearrange
 from pydantic import AfterValidator, validate_call
-from pytorch_lightning.callbacks import Callback
 from tensordict import TensorDict
 from torch import Tensor
 from wandb import Image
+
+from rmind.callbacks.safe import SafeCallback
 
 from .common import (
     BATCH_HOOKS,
@@ -20,7 +21,7 @@ from .common import (
 
 
 @final
-class WandbImageParamLogger(Callback):
+class WandbImageParamLogger(SafeCallback):
     @validate_call
     def __init__(  # noqa: PLR0913
         self,
@@ -31,7 +32,12 @@ class WandbImageParamLogger(Callback):
         apply: Callable[[Tensor], Tensor] | None = None,
         every_n_batch: int | None = None,
         cmap_type: K.ColorMapType | None = K.ColorMapType.viridis,
+        fail_gracefully: bool = True,
+        disable_on_error: bool = True,
     ) -> None:
+        super().__init__(
+            fail_gracefully=fail_gracefully, disable_on_error=disable_on_error
+        )
         self._key = key
         self._select = select
         self._apply = apply
@@ -42,7 +48,7 @@ class WandbImageParamLogger(Callback):
         )
         self._every_n_batch = every_n_batch
         self._when = when
-        setattr(self, when, self._call)
+        setattr(self, when, self._safe_hook(when, self._call))
 
     def _call(
         self,

--- a/src/rmind/callbacks/loggers/patch_similarity.py
+++ b/src/rmind/callbacks/loggers/patch_similarity.py
@@ -36,7 +36,7 @@ class WandbPatchSimilarityLogger(SafeCallback):
         every_n_sample: int,
         patch_grid_size: int = 16,
         fail_gracefully: bool = True,
-        disable_on_error: bool = True,
+        disable_on_error: bool = False,
     ) -> None:
         super().__init__(
             fail_gracefully=fail_gracefully, disable_on_error=disable_on_error

--- a/src/rmind/callbacks/loggers/patch_similarity.py
+++ b/src/rmind/callbacks/loggers/patch_similarity.py
@@ -6,11 +6,12 @@ import numpy as np
 import pytorch_lightning as pl
 import torch
 from pydantic import AfterValidator, validate_call
-from pytorch_lightning.callbacks import Callback
 from torch import Tensor
 from torch.nn.functional import cosine_similarity
 from torch.utils._pytree import MappingKey, key_get, tree_map  # noqa: PLC2701
 from wandb import Image
+
+from rmind.callbacks.safe import SafeCallback
 
 from .common import (
     _bind_hook_arguments,
@@ -21,7 +22,7 @@ from .common import (
 
 
 @final
-class WandbPatchSimilarityLogger(Callback):
+class WandbPatchSimilarityLogger(SafeCallback):
     @validate_call
     def __init__(  # noqa: PLR0913
         self,
@@ -34,7 +35,12 @@ class WandbPatchSimilarityLogger(Callback):
         sample_id_path: list[str | int],
         every_n_sample: int,
         patch_grid_size: int = 16,
+        fail_gracefully: bool = True,
+        disable_on_error: bool = True,
     ) -> None:
+        super().__init__(
+            fail_gracefully=fail_gracefully, disable_on_error=disable_on_error
+        )
         self._key = key
         self._image_sources_path = tree_map(
             lambda v: tuple(map(MappingKey, v)),
@@ -49,7 +55,7 @@ class WandbPatchSimilarityLogger(Callback):
         self._every_n_sample = every_n_sample
         self._when = when
 
-        setattr(self, when, self._call)
+        setattr(self, when, self._safe_hook(when, self._call))
 
     @staticmethod
     def _stable_ref_patch_idx(

--- a/src/rmind/callbacks/loggers/waypoints.py
+++ b/src/rmind/callbacks/loggers/waypoints.py
@@ -48,7 +48,7 @@ class WandbWaypointsLogger(SafeCallback):
         every_n_batch: int | None = None,
         crs: str | None = None,
         fail_gracefully: bool = True,
-        disable_on_error: bool = True,
+        disable_on_error: bool = False,
     ) -> None:
         super().__init__(
             fail_gracefully=fail_gracefully, disable_on_error=disable_on_error

--- a/src/rmind/callbacks/loggers/waypoints.py
+++ b/src/rmind/callbacks/loggers/waypoints.py
@@ -7,12 +7,12 @@ import pytorch_lightning as pl
 from contextily.tile import requests
 from einops import rearrange
 from pydantic import AfterValidator, validate_call
-from pytorch_lightning.callbacks import Callback
 from structlog import get_logger
 from torch import Tensor
 from torch.utils._pytree import MappingKey, key_get, tree_map  # noqa: PLC2701
 from wandb import Image
 
+from rmind.callbacks.safe import SafeCallback
 from rmind.utils.pytree import key_get_default
 
 from .common import (
@@ -30,7 +30,7 @@ NoneKey = (MappingKey(None),)
 
 
 @final
-class WandbWaypointsLogger(Callback):
+class WandbWaypointsLogger(SafeCallback):
     class DataColumns(StrEnum):
         IMAGE = auto()
         WAYPOINTS_XY_NORMALIZED = auto()
@@ -47,7 +47,12 @@ class WandbWaypointsLogger(Callback):
         key: str,
         every_n_batch: int | None = None,
         crs: str | None = None,
+        fail_gracefully: bool = True,
+        disable_on_error: bool = True,
     ) -> None:
+        super().__init__(
+            fail_gracefully=fail_gracefully, disable_on_error=disable_on_error
+        )
         self._key = key
         _validate_every_n_batch(
             when=when, every_n_batch=every_n_batch, allowed_hooks=BATCH_HOOKS
@@ -65,7 +70,7 @@ class WandbWaypointsLogger(Callback):
             is_leaf=lambda x: isinstance(x, list),
         )
         self._crs = crs
-        setattr(self, when, self._call)
+        setattr(self, when, self._safe_hook(when, self._call))
 
     def _call(
         self,

--- a/src/rmind/callbacks/safe.py
+++ b/src/rmind/callbacks/safe.py
@@ -1,0 +1,69 @@
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, TypeVar
+
+from pydantic import validate_call
+from pytorch_lightning.callbacks import Callback
+from structlog import get_logger
+
+logger = get_logger(__name__)
+
+T = TypeVar("T")
+
+
+def _validate_callback_hook(hook: str) -> str:
+    if not callable(getattr(Callback, hook, None)):
+        msg = f"`{hook}` is not a valid Lightning callback hook"
+        raise TypeError(msg)
+
+    return hook
+
+
+class SafeCallback(Callback):
+    @validate_call
+    def __init__(
+        self, *, fail_gracefully: bool = True, disable_on_error: bool = False
+    ) -> None:
+        self._fail_gracefully = fail_gracefully
+        self._safe_disable_on_error = disable_on_error
+        self._disabled_hooks: set[str] = set()
+
+    def _safe_hook(self, hook: str, fn: Callable[..., T]) -> Callable[..., T | None]:
+        hook = _validate_callback_hook(hook)
+
+        @wraps(fn)
+        def wrapper(*args: Any, **kwargs: Any) -> T | None:
+            return self._safe_call(hook, fn, *args, **kwargs)
+
+        return wrapper
+
+    def _safe_call(
+        self, hook: str, fn: Callable[..., T], *args: Any, **kwargs: Any
+    ) -> T | None:
+        hook = _validate_callback_hook(hook)
+        if not self._fail_gracefully:
+            return fn(*args, **kwargs)
+
+        if hook in self._disabled_hooks:
+            return None
+
+        try:
+            return fn(*args, **kwargs)
+        except Exception as exc:
+            if self._safe_disable_on_error:
+                self._disabled_hooks.add(hook)
+
+            trainer = args[0] if args else kwargs.get("trainer")
+            logger.warning(
+                "safe callback hook failed",
+                callback=type(self).__name__,
+                hook=hook,
+                disabled=self._safe_disable_on_error,
+                epoch=getattr(trainer, "current_epoch", None),
+                global_step=getattr(trainer, "global_step", None),
+                error_type=type(exc).__name__,
+                error=str(exc),
+                exc_info=True,
+            )
+
+            return None

--- a/src/rmind/callbacks/safe.py
+++ b/src/rmind/callbacks/safe.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable
-from functools import wraps
+from functools import partial
 from typing import Any, TypeVar
 
 from pydantic import validate_call
@@ -29,13 +29,10 @@ class SafeCallback(Callback):
         self._disabled_hooks: set[str] = set()
 
     def _safe_hook(self, hook: str, fn: Callable[..., T]) -> Callable[..., T | None]:
-        hook = _validate_callback_hook(hook)
-
-        @wraps(fn)
-        def wrapper(*args: Any, **kwargs: Any) -> T | None:
-            return self._safe_call(hook, fn, *args, **kwargs)
-
-        return wrapper
+        # Return `partial` over the bound `_safe_call` rather than a nested
+        # closure so the resulting attribute stays pickleable for spawn-based
+        # DDP launchers.
+        return partial(self._safe_call, _validate_callback_hook(hook), fn)
 
     def _safe_call(
         self, hook: str, fn: Callable[..., T], *args: Any, **kwargs: Any

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -67,7 +67,7 @@ class FailingBatchCallback(SafeCallback):
         *,
         hook_style: str = "direct",
         fail_gracefully: bool = True,
-        disable_on_error: bool = True,
+        disable_on_error: bool = False,
     ) -> None:
         super().__init__(
             fail_gracefully=fail_gracefully, disable_on_error=disable_on_error
@@ -112,7 +112,7 @@ class FailingBatchCallback(SafeCallback):
 def test_safe_callback_swallows_batch_hook_error(
     trainer: pl.Trainer, module: ToyModule, hook_style: str
 ) -> None:
-    callback = FailingBatchCallback(hook_style=hook_style)
+    callback = FailingBatchCallback(hook_style=hook_style, disable_on_error=True)
 
     callback.on_train_batch_end(trainer, module, outputs=None, batch=None, batch_idx=0)
     callback.on_train_batch_end(trainer, module, outputs=None, batch=None, batch_idx=1)
@@ -123,7 +123,7 @@ def test_safe_callback_swallows_batch_hook_error(
 def test_safe_callback_can_retry_after_error(
     trainer: pl.Trainer, module: ToyModule
 ) -> None:
-    callback = FailingBatchCallback(disable_on_error=False)
+    callback = FailingBatchCallback()
 
     callback.on_train_batch_end(trainer, module, outputs=None, batch=None, batch_idx=0)
     callback.on_train_batch_end(trainer, module, outputs=None, batch=None, batch_idx=1)

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -8,6 +8,9 @@ from torch import nn
 from rmind.callbacks.freeze import ModuleFreezer
 from rmind.callbacks.loggers import waypoints as waypoints_logger
 from rmind.callbacks.loggers.waypoints import WandbWaypointsLogger
+from rmind.callbacks.safe import SafeCallback
+
+_RETRY_CALL_COUNT = 2
 
 
 class ToyModule(pl.LightningModule):
@@ -55,6 +58,85 @@ def test_missing_path_raises(trainer: pl.Trainer, module: ToyModule) -> None:
     cb = ModuleFreezer(paths={"does_not_exist"})
     with pytest.raises(AttributeError):
         cb.setup(trainer, module, "fit")
+
+
+class FailingBatchCallback(SafeCallback):
+    def __init__(
+        self,
+        *,
+        hook_style: str = "direct",
+        fail_gracefully: bool = True,
+        disable_on_error: bool = True,
+    ) -> None:
+        super().__init__(
+            fail_gracefully=fail_gracefully, disable_on_error=disable_on_error
+        )
+        self.calls = 0
+        self.msg = "logger failed"
+        if hook_style == "dynamic":
+            hook = "on_train_batch_end"
+            setattr(self, hook, self._safe_hook(hook, self._call))
+
+    def on_train_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs: object,
+        batch: object,
+        batch_idx: int,
+    ) -> None:
+        self._safe_call(
+            "on_train_batch_end",
+            self._call,
+            trainer,
+            pl_module,
+            outputs,
+            batch,
+            batch_idx,
+        )
+
+    def _call(
+        self,
+        trainer: pl.Trainer,  # noqa: ARG002
+        pl_module: pl.LightningModule,  # noqa: ARG002
+        outputs: object,  # noqa: ARG002
+        batch: object,  # noqa: ARG002
+        batch_idx: int,  # noqa: ARG002
+    ) -> None:
+        self.calls += 1
+        raise RuntimeError(self.msg)
+
+
+@pytest.mark.parametrize("hook_style", ["direct", "dynamic"])
+def test_safe_callback_swallows_batch_hook_error(
+    trainer: pl.Trainer, module: ToyModule, hook_style: str
+) -> None:
+    callback = FailingBatchCallback(hook_style=hook_style)
+
+    callback.on_train_batch_end(trainer, module, outputs=None, batch=None, batch_idx=0)
+    callback.on_train_batch_end(trainer, module, outputs=None, batch=None, batch_idx=1)
+
+    assert callback.calls == 1
+
+
+def test_safe_callback_can_retry_after_error(
+    trainer: pl.Trainer, module: ToyModule
+) -> None:
+    callback = FailingBatchCallback(disable_on_error=False)
+
+    callback.on_train_batch_end(trainer, module, outputs=None, batch=None, batch_idx=0)
+    callback.on_train_batch_end(trainer, module, outputs=None, batch=None, batch_idx=1)
+
+    assert callback.calls == _RETRY_CALL_COUNT
+
+
+def test_safe_callback_can_fail_loudly(trainer: pl.Trainer, module: ToyModule) -> None:
+    callback = FailingBatchCallback(fail_gracefully=False)
+
+    with pytest.raises(RuntimeError, match="logger failed"):
+        callback.on_train_batch_end(
+            trainer, module, outputs=None, batch=None, batch_idx=0
+        )
 
 
 def test_waypoints_map_handles_basemap_http_error(

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,3 +1,4 @@
+import pickle
 from typing import override
 
 import pytest
@@ -137,6 +138,14 @@ def test_safe_callback_can_fail_loudly(trainer: pl.Trainer, module: ToyModule) -
         callback.on_train_batch_end(
             trainer, module, outputs=None, batch=None, batch_idx=0
         )
+
+
+def test_safe_callback_dynamic_hook_is_picklable() -> None:
+    # Spawn-based DDP launchers pickle the trainer (and therefore callbacks);
+    # the dynamically-installed hook must survive a pickle round-trip.
+    callback = FailingBatchCallback(hook_style="dynamic")
+
+    pickle.loads(pickle.dumps(callback))
 
 
 def test_waypoints_map_handles_basemap_http_error(


### PR DESCRIPTION
resolves #233 


Adds fail-graceful handling for optional WandB logger callbacks so logging/visualization errors do not interrupt training by default.

## Changes

- Added `SafeCallback` lightning callback wrapper with `fail_gracefully` and `disable_on_error`.
- Updated WandB logger callbacks to route hook execution through it.

## Defaults
```
fail_gracefully: true
disable_on_error: false
```
So a logger failure emits a warning but doesn't disable that failing hook.