### PR TITLE
feat: nas caching

### DIFF
--- a/config/paths/yaak/default.yaml
+++ b/config/paths/yaak/default.yaml
@@ -1,3 +1,3 @@
 data: /nasa/drives/yaak/data
 rbyte:
-  cache: .rbyte_cache
+  cache: /nasa/team-space/${oc.env:USER}/.rbyte_cache/${oc.env:HOSTNAME}

--- a/justfile
+++ b/justfile
@@ -1,3 +1,4 @@
+export HOSTNAME := `hostname`
 export PYTHONBREAKPOINT := "patdb.debug"
 export PATDB_CODE_STYLE := "vim"
 export BETTER_EXCEPTIONS := "1"


### PR DESCRIPTION
Move rbyte cache to NAS with per-host isolation

## Motivation

Local server disks fill up quickly when each user maintains their own `.rbyte_cache` directory. Moving the cache to NAS saves local disk space while allowing cache sharing.

 However, accessing the same cache directory from multiple servers simultaneously can cause corruption (pipefunc uses non-atomic writes). Using per-hostname subdirectories avoids this.

## Changes

  - Export HOSTNAME in `justfile` for use in Hydra configs
  - Update `paths.rbyte.cache` to `/nasa/team-space/${USER}/.rbyte_cache/${HOSTNAME}`