### PR TITLE
feat(callbacks): add WandbForesightMetricsLogger

### DIFF
--- a/config/trainer/callbacks/pretrain.yaml
+++ b/config/trainer/callbacks/pretrain.yaml
@@ -56,3 +56,11 @@
   sample_id_path: [data, meta/sample_id]
   every_n_sample: 1000
   patch_grid_size: 16
+- _target_: rmind.callbacks.WandbForesightMetricsLogger
+  key: foresight
+  image_sources:
+    cam_front_left: [foresight, cam_front_left]
+  embeddings_predict: [forward_dynamics, _artifacts, last_embeddings]
+  embeddings_target: [forward_dynamics, _artifacts, last_targets]
+  hot_quantile: 0.05
+  max_hot_pairs: 50000

--- a/src/rmind/callbacks/__init__.py
+++ b/src/rmind/callbacks/__init__.py
@@ -2,6 +2,7 @@ from .feature_permutation import FeaturePermutator
 from .freeze import ModuleFreezer
 from .loggers import (
     WandbAttentionMaskLogger,
+    WandbForesightMetricsLogger,
     WandbImageParamLogger,
     WandbPatchSimilarityLogger,
     WandbWaypointsLogger,
@@ -27,6 +28,7 @@ __all__ = [
     "SafeCallback",
     "TensorDictPredictionWriter",
     "WandbAttentionMaskLogger",
+    "WandbForesightMetricsLogger",
     "WandbImageParamLogger",
     "WandbPatchSimilarityLogger",
     "WandbWaypointsLogger",

--- a/src/rmind/callbacks/loggers/__init__.py
+++ b/src/rmind/callbacks/loggers/__init__.py
@@ -1,10 +1,12 @@
 from .attention_mask import WandbAttentionMaskLogger, visualize_attention_mask
+from .foresight_metrics import WandbForesightMetricsLogger
 from .image_param import WandbImageParamLogger
 from .patch_similarity import WandbPatchSimilarityLogger
 from .waypoints import WandbWaypointsLogger
 
 __all__ = [
     "WandbAttentionMaskLogger",
+    "WandbForesightMetricsLogger",
     "WandbImageParamLogger",
     "WandbPatchSimilarityLogger",
     "WandbWaypointsLogger",

--- a/src/rmind/callbacks/loggers/foresight_metrics.py
+++ b/src/rmind/callbacks/loggers/foresight_metrics.py
@@ -1,0 +1,220 @@
+"""Validation-time foresight prediction metrics.
+
+Logs two single-scalar quantities per epoch (one per configured image
+source) that summarise how well the forward-dynamics head is predicting
+the next-frame image embedding at motion-rich locations:
+
+- ``{key}/{src}/r2_hot`` -- linear-probe R²(pred → target) on the
+  top-{hot_quantile} highest-motion patches at the deepest FD position
+  (predicting img@T-1). Drops if the model collapses to autoencoding.
+
+- ``{key}/{src}/search_hit_hot`` -- cross-patch search accuracy on the
+  same hot patches: for each pred[p], fraction of the time
+  ``argmin_q ||pred[p] - target[q]||²`` equals ``p`` (chance ~1/256).
+  Complementary to R²; satisfied only by absolute spatial commitment.
+
+Motivation and definitions: see ``experiments/report_short.tex``
+(Sections 2.2--2.4) and the LeJEPA paper context in its Appendix A.
+
+Notes:
+- We measure at the deepest FD position the artifacts buffer exposes
+  (``last_embeddings[..., -1]``, which predicts img@T-1). The
+  unsupervised T-1 slot the policy actually reads at serving is one
+  step further; per the report, the two positions behave near-identically.
+- Stratification is computed from the temporal delta between the last
+  two target frames in the FD artifacts buffer (img@T-2 vs img@T-1), so
+  the callback needs no extra forward passes.
+- Stored buffers are capped at ``max_hot_pairs`` to bound CPU memory.
+  Beyond the cap, additional batches are skipped for the R² fit; the
+  search counter keeps accumulating.
+"""
+
+from typing import Annotated, Any, final
+
+import pytorch_lightning as pl
+import torch
+from pydantic import validate_call
+from pytorch_lightning.callbacks import Callback
+from torch import Tensor
+from torch.utils._pytree import MappingKey, key_get, tree_map  # noqa: PLC2701
+
+from .common import _get_wandb_loggers
+
+
+@final
+class WandbForesightMetricsLogger(Callback):
+    """See module docstring."""
+
+    @validate_call
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        key: str,
+        image_sources: dict[str, list[str | int]],
+        embeddings_predict: list[str | int],
+        embeddings_target: list[str | int],
+        hot_quantile: Annotated[float, "fraction in (0, 1]"] = 0.05,
+        max_hot_pairs: int = 50_000,
+    ) -> None:
+        if not 0.0 < hot_quantile <= 1.0:
+            msg = f"hot_quantile must be in (0, 1], got {hot_quantile}"
+            raise ValueError(msg)
+        self._key = key
+        self._image_sources_path = tree_map(
+            lambda v: tuple(map(MappingKey, v)),
+            image_sources,
+            is_leaf=lambda x: isinstance(x, list),
+        )
+        self._embeddings_predict_path = tuple(map(MappingKey, embeddings_predict))
+        self._embeddings_target_path = tuple(map(MappingKey, embeddings_target))
+        self._hot_quantile = float(hot_quantile)
+        self._max_hot_pairs = int(max_hot_pairs)
+
+        # Populated per epoch.
+        self._pred_buf: dict[str, list[Tensor]] = {}
+        self._target_buf: dict[str, list[Tensor]] = {}
+        self._n_pairs: dict[str, int] = {}
+        self._search_hits: dict[str, int] = {}
+        self._search_total: dict[str, int] = {}
+
+    def _reset(self) -> None:
+        srcs = list(self._image_sources_path)
+        self._pred_buf = {src: [] for src in srcs}
+        self._target_buf = {src: [] for src in srcs}
+        self._n_pairs = dict.fromkeys(srcs, 0)
+        self._search_hits = dict.fromkeys(srcs, 0)
+        self._search_total = dict.fromkeys(srcs, 0)
+
+    @staticmethod
+    def _gather_hot(
+        pred: Tensor, tgt: Tensor, tgt_prev: Tensor, n_hot: int
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """pred, tgt, tgt_prev: (B, P, d). Returns (pred_hot, tgt_hot, hot_idx)."""
+        delta = ((tgt - tgt_prev) ** 2).sum(dim=-1)
+        sorted_idx = delta.argsort(dim=-1, descending=True)
+        hot_idx = sorted_idx[:, :n_hot]
+        b_idx = torch.arange(pred.shape[0], device=pred.device)[:, None]
+        return pred[b_idx, hot_idx], tgt[b_idx, hot_idx], hot_idx
+
+    @staticmethod
+    def _cross_patch_hits_at_hot(
+        pred: Tensor, tgt: Tensor, hot_idx: Tensor
+    ) -> tuple[int, int]:
+        """For each hot patch p in pred, check if argmin_q ||pred[p] - tgt[q]||² == p.
+
+        Returns (n_hits, n_total).
+        """
+        pred_sq = (pred**2).sum(dim=-1, keepdim=True)  # (B, P, 1)
+        tgt_sq = (tgt**2).sum(dim=-1, keepdim=True).transpose(-1, -2)  # (B, 1, P)
+        inner = torch.einsum("bpd,bqd->bpq", pred, tgt)  # (B, P, P)
+        dists = pred_sq + tgt_sq - 2 * inner  # (B, P, P)
+        argmin_q = dists.argmin(dim=-1)  # (B, P)
+        p_range = torch.arange(pred.shape[1], device=pred.device)
+        hit_per_patch = (argmin_q == p_range).to(torch.bool)  # (B, P)
+        hit_at_hot = hit_per_patch.gather(1, hot_idx)  # (B, n_hot)
+        return int(hit_at_hot.sum().item()), int(hit_at_hot.numel())
+
+    @staticmethod
+    def _fit_r2(x: Tensor, y: Tensor) -> float:
+        """Linear-probe R²(x → y) via lstsq with bias column, scalar SS form.
+
+        Mirrors klindtlab/lejepa-identifiability's ``bidirectional_r2`` and
+        the offline probe in ``experiments/foresight_cosine_probe.py``. The
+        fit is in-sample (no train/test split) — interpretable only when
+        ``n_samples`` is well above ``n_features`` (rule of thumb: n/d ≳ 50).
+        """
+        if x.shape[0] <= x.shape[1] + 1:
+            return float("nan")
+        ones = torch.ones(x.shape[0], 1, device=x.device, dtype=x.dtype)
+        x_aug = torch.cat([x, ones], dim=1)
+        w = torch.linalg.lstsq(x_aug, y).solution
+        ss_res = ((y - x_aug @ w) ** 2).sum()
+        ss_tot = ((y - y.mean(0)) ** 2).sum()
+        return float((1 - ss_res / (ss_tot + 1e-12)).item())
+
+    @torch.no_grad()
+    def on_validation_epoch_start(
+        self,
+        trainer: pl.Trainer,  # noqa: ARG002
+        pl_module: pl.LightningModule,  # noqa: ARG002
+    ) -> None:
+        self._reset()
+
+    @torch.no_grad()
+    def on_validation_batch_end(  # noqa: PLR0913, PLR0917
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs: Any,
+        batch: Any,  # noqa: ARG002
+        batch_idx: int,  # noqa: ARG002
+        dataloader_idx: int = 0,  # noqa: ARG002
+    ) -> None:
+        if trainer.sanity_checking or not _get_wandb_loggers(pl_module):
+            return
+        if not trainer.is_global_zero:
+            return
+
+        try:
+            pred_full = key_get(outputs, self._embeddings_predict_path)
+            tgt_full = key_get(outputs, self._embeddings_target_path)
+        except (KeyError, IndexError, TypeError):
+            return
+
+        for src, path in self._image_sources_path.items():
+            try:
+                pred_seq: Tensor = key_get(pred_full, path)
+                tgt_seq: Tensor = key_get(tgt_full, path)
+            except (KeyError, IndexError, TypeError):
+                continue
+            if pred_seq.ndim != 4 or pred_seq.shape[1] < 2:  # noqa: PLR2004
+                continue
+
+            pred = pred_seq[:, -1].detach().float()
+            tgt = tgt_seq[:, -1].detach().float()
+            tgt_prev = tgt_seq[:, -2].detach().float()
+
+            n_patches = pred.shape[1]
+            n_hot = max(1, int(self._hot_quantile * n_patches))
+            pred_hot, tgt_hot, hot_idx = self._gather_hot(pred, tgt, tgt_prev, n_hot)
+
+            if self._n_pairs[src] < self._max_hot_pairs:
+                d = pred_hot.shape[-1]
+                self._pred_buf[src].append(pred_hot.reshape(-1, d).cpu())
+                self._target_buf[src].append(tgt_hot.reshape(-1, d).cpu())
+                self._n_pairs[src] += pred_hot.reshape(-1, d).shape[0]
+
+            hits, total = self._cross_patch_hits_at_hot(pred, tgt, hot_idx)
+            self._search_hits[src] += hits
+            self._search_total[src] += total
+
+    @torch.no_grad()
+    def on_validation_epoch_end(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        if trainer.sanity_checking or not _get_wandb_loggers(pl_module):
+            return
+        if not trainer.is_global_zero:
+            return
+
+        for src in self._image_sources_path:
+            r2 = float("nan")
+            if self._pred_buf[src]:
+                x = torch.cat(self._pred_buf[src], dim=0)
+                y = torch.cat(self._target_buf[src], dim=0)
+                r2 = self._fit_r2(x, y)
+            search_acc = (
+                self._search_hits[src] / self._search_total[src]
+                if self._search_total[src] > 0
+                else float("nan")
+            )
+            pl_module.log(
+                f"{self._key}/{src}/r2_hot", r2, sync_dist=False, rank_zero_only=True
+            )
+            pl_module.log(
+                f"{self._key}/{src}/search_hit_hot",
+                search_acc,
+                sync_dist=False,
+                rank_zero_only=True,
+            )
+        self._reset()

--- a/src/rmind/callbacks/loggers/foresight_metrics.py
+++ b/src/rmind/callbacks/loggers/foresight_metrics.py
@@ -13,14 +13,16 @@ the next-frame image embedding at motion-rich locations:
   ``argmin_q ||pred[p] - target[q]||²`` equals ``p`` (chance ~1/256).
   Complementary to R²; satisfied only by absolute spatial commitment.
 
-Motivation and definitions: see ``experiments/report_short.tex``
-(Sections 2.2--2.4) and the LeJEPA paper context in its Appendix A.
+Motivation, definitions, and the offline-probe results that justify this
+pair of metrics are written up in the foresight investigation:
+https://app.notion.com/p/Foresight-in-the-rmind-Control-Transformer-Does-the-Unsupervised-Last-Position-Predict-the-Future-37bd658ccf8780a3b298cc7c45304af2
 
 Notes:
 - We measure at the deepest FD position the artifacts buffer exposes
   (``last_embeddings[..., -1]``, which predicts img@T-1). The
   unsupervised T-1 slot the policy actually reads at serving is one
-  step further; per the report, the two positions behave near-identically.
+  step further; per the investigation linked above, the two positions
+  behave near-identically.
 - Stratification is computed from the temporal delta between the last
   two target frames in the FD artifacts buffer (img@T-2 vs img@T-1), so
   the callback needs no extra forward passes.
@@ -29,20 +31,22 @@ Notes:
   search counter keeps accumulating.
 """
 
+import math
 from typing import Annotated, Any, final
 
 import pytorch_lightning as pl
 import torch
 from pydantic import validate_call
-from pytorch_lightning.callbacks import Callback
 from torch import Tensor
 from torch.utils._pytree import MappingKey, key_get, tree_map  # noqa: PLC2701
+
+from rmind.callbacks.safe import SafeCallback
 
 from .common import _get_wandb_loggers
 
 
 @final
-class WandbForesightMetricsLogger(Callback):
+class WandbForesightMetricsLogger(SafeCallback):
     """See module docstring."""
 
     @validate_call
@@ -55,7 +59,12 @@ class WandbForesightMetricsLogger(Callback):
         embeddings_target: list[str | int],
         hot_quantile: Annotated[float, "fraction in (0, 1]"] = 0.05,
         max_hot_pairs: int = 50_000,
+        fail_gracefully: bool = True,
+        disable_on_error: bool = False,
     ) -> None:
+        super().__init__(
+            fail_gracefully=fail_gracefully, disable_on_error=disable_on_error
+        )
         if not 0.0 < hot_quantile <= 1.0:
             msg = f"hot_quantile must be in (0, 1], got {hot_quantile}"
             raise ValueError(msg)
@@ -118,8 +127,7 @@ class WandbForesightMetricsLogger(Callback):
     def _fit_r2(x: Tensor, y: Tensor) -> float:
         """Linear-probe R²(x → y) via lstsq with bias column, scalar SS form.
 
-        Mirrors klindtlab/lejepa-identifiability's ``bidirectional_r2`` and
-        the offline probe in ``experiments/foresight_cosine_probe.py``. The
+        Mirrors klindtlab/lejepa-identifiability's ``bidirectional_r2``. The
         fit is in-sample (no train/test split) — interpretable only when
         ``n_samples`` is well above ``n_features`` (rule of thumb: n/d ≳ 50).
         """
@@ -132,8 +140,45 @@ class WandbForesightMetricsLogger(Callback):
         ss_tot = ((y - y.mean(0)) ** 2).sum()
         return float((1 - ss_res / (ss_tot + 1e-12)).item())
 
-    @torch.no_grad()
     def on_validation_epoch_start(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        self._safe_call(
+            "on_validation_epoch_start",
+            self._on_validation_epoch_start,
+            trainer,
+            pl_module,
+        )
+
+    def on_validation_batch_end(  # noqa: PLR0913, PLR0917
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        self._safe_call(
+            "on_validation_batch_end",
+            self._on_validation_batch_end,
+            trainer,
+            pl_module,
+            outputs,
+            batch,
+            batch_idx,
+            dataloader_idx,
+        )
+
+    def on_validation_epoch_end(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        self._safe_call(
+            "on_validation_epoch_end", self._on_validation_epoch_end, trainer, pl_module
+        )
+
+    @torch.no_grad()
+    def _on_validation_epoch_start(
         self,
         trainer: pl.Trainer,  # noqa: ARG002
         pl_module: pl.LightningModule,  # noqa: ARG002
@@ -141,7 +186,7 @@ class WandbForesightMetricsLogger(Callback):
         self._reset()
 
     @torch.no_grad()
-    def on_validation_batch_end(  # noqa: PLR0913, PLR0917
+    def _on_validation_batch_end(  # noqa: PLR0913, PLR0917
         self,
         trainer: pl.Trainer,
         pl_module: pl.LightningModule,
@@ -189,7 +234,7 @@ class WandbForesightMetricsLogger(Callback):
             self._search_total[src] += total
 
     @torch.no_grad()
-    def on_validation_epoch_end(
+    def _on_validation_epoch_end(
         self, trainer: pl.Trainer, pl_module: pl.LightningModule
     ) -> None:
         if trainer.sanity_checking or not _get_wandb_loggers(pl_module):
@@ -208,13 +253,20 @@ class WandbForesightMetricsLogger(Callback):
                 if self._search_total[src] > 0
                 else float("nan")
             )
-            pl_module.log(
-                f"{self._key}/{src}/r2_hot", r2, sync_dist=False, rank_zero_only=True
-            )
-            pl_module.log(
-                f"{self._key}/{src}/search_hit_hot",
-                search_acc,
-                sync_dist=False,
-                rank_zero_only=True,
-            )
+            # Skip NaN epochs (e.g. too few hot pairs to fit, or no patches
+            # gathered) rather than logging NaN to wandb.
+            if not math.isnan(r2):
+                pl_module.log(
+                    f"{self._key}/{src}/r2_hot",
+                    r2,
+                    sync_dist=False,
+                    rank_zero_only=True,
+                )
+            if not math.isnan(search_acc):
+                pl_module.log(
+                    f"{self._key}/{src}/search_hit_hot",
+                    search_acc,
+                    sync_dist=False,
+                    rank_zero_only=True,
+                )
         self._reset()

--- a/tests/test_callbacks.py
+++ b/tests/test_callbacks.py
@@ -1,5 +1,5 @@
 import pickle
-from typing import override
+from typing import Any, override
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -10,12 +10,13 @@ from torch import nn
 
 from rmind.callbacks.freeze import ModuleFreezer
 from rmind.callbacks.loggers import waypoints as waypoints_logger
+from rmind.callbacks.loggers.foresight_metrics import WandbForesightMetricsLogger
 from rmind.callbacks.loggers.waypoints import WandbWaypointsLogger
 from rmind.callbacks.predict_metrics import PredictMetricsCallback
+from rmind.callbacks.safe import SafeCallback
 from rmind.components.objectives.base import ObjectivePredictionKey
 from rmind.models.control_transformer import PredictionConfig
 from rmind.utils.cluster import RuleBasedCluster
-from rmind.callbacks.safe import SafeCallback
 
 _RETRY_CALL_COUNT = 2
 
@@ -303,3 +304,127 @@ def test_predict_metrics_callback_swaps_prediction_config(
     assert fake_module.prediction_config is original_config, (
         "prediction_config should be restored after"
     )
+
+
+# ---------------------------------------------------------------------------
+# WandbForesightMetricsLogger
+# ---------------------------------------------------------------------------
+
+_FORESIGHT_SRC = "cam_front_left"
+_FORESIGHT_PRED_KEY = "embeddings_predict"
+_FORESIGHT_TGT_KEY = "embeddings_target"
+# Both metrics are bounded: R² ≤ 1, search accuracy ∈ [0, 1]. When pred truly
+# predicts target, both sit near 1, so we require > 0.9.
+_FORESIGHT_SIGNAL_MIN = 0.9
+# When pred and target are independent, both collapse toward their floor:
+#   - search accuracy → chance, ~1/n_patches (here 1/32 ≈ 0.03), since the
+#     nearest target patch to any pred patch is essentially uniform-random.
+#   - R² → ~0 in the population, but this probe is fit *in-sample* (no held-out
+#     split), so it can only overfit *upward*, never below 0. The inflation is
+#     ~n_features/n_samples (≈ d/n). The test feeds n ≫ d (n/d ≈ 190 here), so
+#     even the overfit R² stays well under 0.1.
+# 0.3 sits comfortably between the signal (~1) and noise (<0.1) regimes, so it
+# separates the two cases with margin to spare against seed-to-seed jitter.
+_FORESIGHT_CHANCE_MAX = 0.3
+
+
+class _StubTrainer:
+    sanity_checking = False
+    is_global_zero = True
+    current_epoch = 0
+    global_step = 0
+
+
+class _LoggingModule:
+    """Captures ``pl_module.log`` calls into a dict."""
+
+    def __init__(self) -> None:
+        self.logged: dict[str, float] = {}
+
+    def log(self, name: str, value: float, **_: object) -> None:
+        self.logged[name] = float(value)
+
+
+def _make_foresight_callback(**overrides: object) -> WandbForesightMetricsLogger:
+    kwargs: dict[str, Any] = {
+        "key": "foresight",
+        "image_sources": {_FORESIGHT_SRC: [_FORESIGHT_SRC]},
+        "embeddings_predict": [_FORESIGHT_PRED_KEY],
+        "embeddings_target": [_FORESIGHT_TGT_KEY],
+        "hot_quantile": 0.25,
+        # Surface impl errors instead of swallowing them in these tests.
+        "fail_gracefully": False,
+    }
+    kwargs.update(overrides)
+    return WandbForesightMetricsLogger(**kwargs)
+
+
+def _foresight_outputs(pred_last: torch.Tensor, tgt_last: torch.Tensor) -> dict:
+    """Wrap (B, P, d) embeddings into the (B, S=2, P, d) outputs the callback reads.
+
+    ``tgt_prev`` (the T-2 slot) is random so motion stratification has a
+    well-defined ranking; only the T-1 slot carries the pred→target signal.
+    """
+    b, p, d = pred_last.shape
+    pred_prev = torch.randn(b, p, d)
+    tgt_prev = torch.randn(b, p, d)
+    pred_seq = torch.stack([pred_prev, pred_last], dim=1)
+    tgt_seq = torch.stack([tgt_prev, tgt_last], dim=1)
+    return {
+        _FORESIGHT_PRED_KEY: {_FORESIGHT_SRC: pred_seq},
+        _FORESIGHT_TGT_KEY: {_FORESIGHT_SRC: tgt_seq},
+    }
+
+
+def _run_foresight(
+    cb: WandbForesightMetricsLogger, batches: list[dict]
+) -> dict[str, float]:
+    trainer = _StubTrainer()
+    module = _LoggingModule()
+    with patch(
+        "rmind.callbacks.loggers.foresight_metrics._get_wandb_loggers",
+        return_value=[object()],
+    ):
+        cb.on_validation_epoch_start(trainer, module)  # ty:ignore[invalid-argument-type]
+        for i, batch in enumerate(batches):
+            cb.on_validation_batch_end(trainer, module, batch, None, i)  # ty:ignore[invalid-argument-type]
+        cb.on_validation_epoch_end(trainer, module)  # ty:ignore[invalid-argument-type]
+    return module.logged
+
+
+def test_foresight_logger_recovers_signal() -> None:
+    """Identity pred→target ⇒ R² and search accuracy both ≈ 1."""
+    torch.manual_seed(0)
+    b, p, d = 8, 32, 4
+    # target == pred at T-1: a perfect linear probe and a perfect cross-patch
+    # search both fall out.
+    batches = [
+        _foresight_outputs(emb := torch.randn(b, p, d), emb.clone()) for _ in range(12)
+    ]
+
+    logged = _run_foresight(_make_foresight_callback(), batches)
+
+    assert logged[f"foresight/{_FORESIGHT_SRC}/r2_hot"] > _FORESIGHT_SIGNAL_MIN
+    assert logged[f"foresight/{_FORESIGHT_SRC}/search_hit_hot"] > _FORESIGHT_SIGNAL_MIN
+
+
+def test_foresight_logger_rejects_noise() -> None:
+    """Independent pred/target ⇒ R² (in-sample, n/d≫1) and search both ≈ chance."""
+    torch.manual_seed(0)
+    b, p, d = 8, 32, 4
+    batches = [
+        _foresight_outputs(torch.randn(b, p, d), torch.randn(b, p, d))
+        for _ in range(12)
+    ]
+
+    logged = _run_foresight(_make_foresight_callback(), batches)
+
+    assert logged[f"foresight/{_FORESIGHT_SRC}/r2_hot"] < _FORESIGHT_CHANCE_MAX
+    assert logged[f"foresight/{_FORESIGHT_SRC}/search_hit_hot"] < _FORESIGHT_CHANCE_MAX
+
+
+def test_foresight_logger_skips_nan_when_no_data() -> None:
+    """No valid batches ⇒ nothing logged (NaN epochs are skipped, not logged)."""
+    logged = _run_foresight(_make_foresight_callback(), [])
+
+    assert logged == {}


### PR DESCRIPTION
## Summary

- Adds a validation-time PL callback that turns the offline foresight probe into a live training signal, logging two scalars per epoch per image source.
- `foresight/<src>/r2_hot`: linear-probe R²(pred → target) on the top-5% highest-motion patches at the deepest FD position (predicting img@T-1). Drops if the model collapses to autoencoding.
- `foresight/<src>/search_hit_hot`: cross-patch search accuracy on the same patches (chance ~1/256); complementary to R² — only satisfied when pred commits to absolute spatial positions, not just linear directions.
- Motion stratification uses the temporal delta between `last_targets[..., -1]` and `last_targets[..., -2]`, so no extra forward pass is needed. R² impl mirrors klindtlab/lejepa-identifiability's `bidirectional_r2` (in-sample lstsq, scalar SS form). Cap `max_hot_pairs=50000` bounds CPU memory and keeps n/d ≈ 130 — well above the rule-of-thumb threshold for in-sample R² discrimination.

## Context

These metrics fall out of the foresight investigation (see https://app.notion.com/p/Foresight-in-the-rmind-Control-Transformer-Does-the-Unsupervised-Last-Position-Predict-the-Future-37bd658ccf8780a3b298cc7c45304af2). The offline probe established that this pair of numbers, computed at the last FD position on the hot stratum, ranks two pretrained checkpoints consistently with their val FD loss while exposing failure modes the loss itself can't see (autoencoding collapse → R² stays high, search collapses; uniform / mean prediction → both collapse). Wiring them into validation lets training runs surface the same signal automatically.

Registered next to `WandbPatchSimilarityLogger` in `config/trainer/callbacks/pretrain.yaml`; the existing patch-similarity viz is complementary (qualitative anchor inspection on moving objects) and stays in place.

## Test plan

- [x] Smoke test: synthetic batches (signal vs. random) — signal R² ≈ 0.92 / search 1.0; random R² ≈ 0.012 / search ≈ 1/256.
- [x] Pre-commit (ruff check, ruff format, ty, deptry, typos) passes.
- [x] Run a short pretrain validation with this callback enabled and confirm wandb metrics appear under the expected keys. Use only a debugging run (only a few batches but in a way val metrics show up)