### PR TITLE
feat(nix): add aarch64-linux (Jetson) devShell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,6 +41,51 @@
         };
       };
 
+    devShells.aarch64-linux.default =
+      # Jetson (JetPack) target. CUDA is provided by the system (apt:
+      # nvidia-jetpack), not nixpkgs, so we wire the system driver/runtime
+      # libs into LD_LIBRARY_PATH for uv-installed wheels (torch, etc.).
+      with import nixpkgs { system = "aarch64-linux"; };
+      let
+        systemCudaPath = lib.concatStringsSep ":" [
+          "/usr/local/cuda/lib64"
+          "/usr/lib/aarch64-linux-gnu/nvidia"
+          "/usr/lib/aarch64-linux-gnu/tegra"
+        ];
+        uvLibraryPath = lib.makeLibraryPath [
+          stdenv.cc.cc.lib
+          zlib
+          openssl
+          libffi
+          ffmpeg
+        ];
+        uvWrapped = writeShellScriptBin "uv" ''
+          export LD_LIBRARY_PATH="${uvLibraryPath}:${systemCudaPath}''${NIX_LD_LIBRARY_PATH:+:''${NIX_LD_LIBRARY_PATH}}"
+          exec ${lib.getExe uv} "$@"
+        '';
+      in
+      mkShell {
+        packages = [
+          nushell
+          git
+          git-lfs
+          uvWrapped
+          ytt
+          just
+          prek
+          skim
+          openssl
+          ffmpeg
+        ];
+
+        env = {
+          UV_PYTHON = "${python312}/bin/python";
+          UV_NO_MANAGED_PYTHON = "1";
+          UV_PYTHON_DOWNLOADS = "never";
+          TRITON_LIBCUDA_PATH = "/usr/lib/aarch64-linux-gnu/nvidia"; # for TorchInductor (JetPack driver)
+        };
+      };
+
     devShells.aarch64-darwin.default =
       with import nixpkgs { system = "aarch64-darwin"; };
       let


### PR DESCRIPTION
## Problem
`nix develop` on the Jetson kits (e.g. `delta-dev1`, `aarch64-linux`) fails:
```
error: flake ... does not provide attribute 'devShells.aarch64-linux.default'
```
The flake only defined `x86_64-linux` and `aarch64-darwin` devShells.

## Change
Add `devShells.aarch64-linux.default`, mirroring the `x86_64-linux` shell (same tooling: nushell/git/git-lfs/uv-wrapped/ytt/just/prek/skim/openssl/ffmpeg).

Key difference: on Jetson, CUDA comes from the **system JetPack** install (`apt: nvidia-jetpack`), not nixpkgs. So the shell:
- prepends the system CUDA/driver dirs to `LD_LIBRARY_PATH` (`/usr/local/cuda/lib64`, `/usr/lib/aarch64-linux-gnu/{nvidia,tegra}`) so uv-installed wheels (torch, etc.) find CUDA at runtime
- points `TRITON_LIBCUDA_PATH` at the JetPack driver dir (`/run/opengl-driver/lib` is a NixOS-only path and doesn't exist here)

## Test
Verified on `delta-dev1` (aarch64 Jetson): `nix develop` enters successfully, `uv --version` → `0.11.16 (aarch64-unknown-linux-gnu)`, and git/just/nushell resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)