### PR TITLE
fix: teacher-force the offset loss in JointPolicyObjective

### DIFF
--- a/config/experiment/yaak/control_transformer/finetune.yaml
+++ b/config/experiment/yaak/control_transformer/finetune.yaml
@@ -23,3 +23,7 @@ clip_length: "${eval:'${episode_length} + ${clip_horizon} - 1'}"
 clip_period: "${eval:'${clip_length} * ${episode_step}'}i"
 
 action_tokenizer_artifact: ???
+
+# supervise the offset head at ground-truth codes (fix) instead of sampled codes
+# (pre-fix behavior, kept for A/B via teacher_force_offset=false)
+teacher_force_offset: true

--- a/config/model/yaak/control_transformer/policy_finetune.yaml
+++ b/config/model/yaak/control_transformer/policy_finetune.yaml
@@ -66,7 +66,8 @@ hparams_jq: |
             "offset": { "_target_": "torch.nn.L1Loss" }
           }
         },
-        "chunk": ["input", "joint_actions"]
+        "chunk": ["input", "joint_actions"],
+        "teacher_force_offset": ("${teacher_force_offset}" | ascii_downcase == "true")
       }
     }
   }

--- a/src/rmind/__init__.py
+++ b/src/rmind/__init__.py
@@ -5,6 +5,6 @@ from omegaconf import OmegaConf
 __version__ = version(__package__ or __name__)
 
 # arithmetic in interpolations, e.g. "${eval:(${episode_length} + ${action_horizon} - 1) * 10}i"
-OmegaConf.register_new_resolver("eval", eval, replace=True)
+OmegaConf.register_new_resolver("eval", eval, replace=True)  # noqa: RUF067, S307
 
 __all__ = ["__version__"]

--- a/src/rmind/callbacks/loggers/attention_mask.py
+++ b/src/rmind/callbacks/loggers/attention_mask.py
@@ -9,11 +9,11 @@ from matplotlib.patches import Patch
 from pytorch_lightning.utilities.types import STEP_OUTPUT
 from structlog import get_logger
 from torch import Tensor
+from wandb import Image
 
 from rmind.callbacks.safe import SafeCallback
 from rmind.components.base import TokenType
 from rmind.components.episode import Episode, EpisodeBuilder, TokenMeta
-from wandb import Image
 
 from .common import _figure_to_rgba, _get_wandb_loggers
 

--- a/src/rmind/callbacks/loggers/image_param.py
+++ b/src/rmind/callbacks/loggers/image_param.py
@@ -7,9 +7,9 @@ from einops import rearrange
 from pydantic import AfterValidator, validate_call
 from tensordict import TensorDict
 from torch import Tensor
+from wandb import Image
 
 from rmind.callbacks.safe import SafeCallback
-from wandb import Image
 
 from .common import (
     BATCH_HOOKS,

--- a/src/rmind/callbacks/loggers/patch_similarity.py
+++ b/src/rmind/callbacks/loggers/patch_similarity.py
@@ -9,9 +9,9 @@ from pydantic import AfterValidator, validate_call
 from torch import Tensor
 from torch.nn.functional import cosine_similarity
 from torch.utils._pytree import MappingKey, key_get, tree_map  # noqa: PLC2701
+from wandb import Image
 
 from rmind.callbacks.safe import SafeCallback
-from wandb import Image
 
 from .common import (
     _bind_hook_arguments,

--- a/src/rmind/callbacks/loggers/waypoints.py
+++ b/src/rmind/callbacks/loggers/waypoints.py
@@ -10,10 +10,10 @@ from pydantic import AfterValidator, validate_call
 from structlog import get_logger
 from torch import Tensor
 from torch.utils._pytree import MappingKey, key_get, tree_map  # noqa: PLC2701
+from wandb import Image
 
 from rmind.callbacks.safe import SafeCallback
 from rmind.utils.pytree import key_get_default
-from wandb import Image
 
 from .common import (
     BATCH_HOOKS,

--- a/src/rmind/components/objectives/base.py
+++ b/src/rmind/components/objectives/base.py
@@ -40,6 +40,8 @@ class Prediction(TensorClass["autocast"]):  # ty:ignore[unsupported-base]
 
 class Metrics(TypedDict):
     loss: TensorTree | None
+    # logged (train/<objective>/metric/...) but excluded from the total loss
+    metric: NotRequired[TensorTree]
     _artifacts: NotRequired[TensorTree]
 
 

--- a/src/rmind/components/objectives/joint_policy.py
+++ b/src/rmind/components/objectives/joint_policy.py
@@ -42,6 +42,7 @@ class JointPolicyObjective(Objective):
         norm: InstanceOf[Module] | None = None,
         sample_codes: bool = True,
         teacher_force_offset: bool = True,
+        offset_scale: float | None = None,
     ) -> None:
         super().__init__()
 
@@ -55,6 +56,7 @@ class JointPolicyObjective(Objective):
         self.chunk: Path = chunk
         self.sample_codes = sample_codes
         self.teacher_force_offset = teacher_force_offset
+        self.offset_scale = offset_scale
 
     @override
     def train(self, mode: bool = True) -> "JointPolicyObjective":
@@ -122,6 +124,18 @@ class JointPolicyObjective(Objective):
         # https://arxiv.org/pdf/2403.03181 Figure 2.
         return offsets.gather(2, index).squeeze(2).sum(dim=1)  # (b, action_dim)
 
+    def _offset(self, offsets: Tensor, codes: Tensor) -> Tensor:
+        """Gathered offset, optionally soft-bounded to (-offset_scale, offset_scale).
+
+        The bound is `scale * tanh(x / scale)`: identity for |x| << scale, so
+        enabling it on a cleanly-trained model preserves sub-cell offsets while
+        capping cross-cell excursions.
+        """
+        offset = self._gather_offset(offsets, codes)
+        if self.offset_scale is None:
+            return offset
+        return torch.tanh(offset / self.offset_scale) * self.offset_scale
+
     def _sample_codes(self, code_logits: Tensor) -> Tensor:
         if self.sample_codes:
             _, g, c = code_logits.shape
@@ -136,7 +150,7 @@ class JointPolicyObjective(Objective):
         """VQ-BeT joint code prediction with a code-conditioned offset."""
         code_logits, offsets = self._heads(features)
         codes = self._sample_codes(code_logits)
-        offset = self._gather_offset(offsets, codes)
+        offset = self._offset(offsets, codes)
 
         return code_logits, codes, offset
 
@@ -165,7 +179,7 @@ class JointPolicyObjective(Objective):
         # reconstruction as inference does it (decode sampled/argmax codes + offset
         # gathered at those codes); the frozen tokenizer makes invert() gradient-free
         codes = self._sample_codes(code_logits)
-        sampled_chunk = tokenizer.invert(codes) + self._gather_offset(offsets, codes)
+        sampled_chunk = tokenizer.invert(codes) + self._offset(offsets, codes)
         sampled_recon = self.losses["offset"](sampled_chunk.detach(), target)
 
         if self.teacher_force_offset:
@@ -173,7 +187,7 @@ class JointPolicyObjective(Objective):
             # code's offset entry only sees residuals of actions that quantized to it;
             # supervising at sampled codes lets the offset learn the conditional median
             # regardless of code, cancelling the code selection
-            predicted_chunk = tokenizer.invert(target_codes) + self._gather_offset(
+            predicted_chunk = tokenizer.invert(target_codes) + self._offset(
                 offsets, target_codes
             )
         else:

--- a/src/rmind/components/objectives/joint_policy.py
+++ b/src/rmind/components/objectives/joint_policy.py
@@ -102,27 +102,39 @@ class JointPolicyObjective(Objective):
             [observation_summary, observation_history, waypoints], "i b 1 d -> b (i d)"
         )
 
-    def _predict(self, features: Tensor) -> tuple[Tensor, Tensor, Tensor]:
-        """VQ-BeT joint code prediction with a code-conditioned offset."""
+    def _heads(self, features: Tensor) -> tuple[Tensor, Tensor]:
+        """Code logits (b, g, c) and the full offset table (b, g, c, action_dim)."""
         quantizer = self.tokenizer.quantizer
         g, c = quantizer.num_quantizers, quantizer.codebook_size
 
         code_logits = rearrange(self.code_head(features), "b (g c) -> b g c", g=g, c=c)
+        offsets = rearrange(
+            self.offset_head(features), "b (g c a) -> b g c a", g=g, c=c
+        )
+        return code_logits, offsets
+
+    @staticmethod
+    def _gather_offset(offsets: Tensor, codes: Tensor) -> Tensor:
+        """Select each quantizer's offset at `codes` and sum over quantizers."""
+        index = codes[..., None, None].expand(-1, -1, 1, offsets.shape[-1])
+        # https://arxiv.org/pdf/2403.03181 Figure 2.
+        return offsets.gather(2, index).squeeze(2).sum(dim=1)  # (b, action_dim)
+
+    def _sample_codes(self, code_logits: Tensor) -> Tensor:
         if self.sample_codes:
-            codes = rearrange(
+            _, g, c = code_logits.shape
+            return rearrange(
                 torch.multinomial(code_logits.softmax(dim=-1).reshape(-1, c), 1),
                 "(b g) 1 -> b g",
                 g=g,
             )
-        else:
-            codes = code_logits.argmax(dim=-1)
+        return code_logits.argmax(dim=-1)
 
-        offsets = rearrange(
-            self.offset_head(features), "b (g c a) -> b g c a", g=g, c=c
-        )
-        index = codes[..., None, None].expand(-1, -1, 1, offsets.shape[-1])
-        # https://arxiv.org/pdf/2403.03181 Figure 2.
-        offset = offsets.gather(2, index).squeeze(2).sum(dim=1)  # (b, action_dim)
+    def _predict(self, features: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        """VQ-BeT joint code prediction with a code-conditioned offset."""
+        code_logits, offsets = self._heads(features)
+        codes = self._sample_codes(code_logits)
+        offset = self._gather_offset(offsets, codes)
 
         return code_logits, codes, offset
 
@@ -204,8 +216,7 @@ class JointPolicyObjective(Objective):
                 }),
                 "discrete": TensorDict({
                     "turn_signal": torch.bucketize(
-                        chunk[..., 3] * 2,
-                        torch.tensor([0.5, 1.5], device=chunk.device),
+                        chunk[..., 3] * 2, torch.tensor([0.5, 1.5], device=chunk.device)
                     )
                 }),
             })

--- a/src/rmind/components/objectives/joint_policy.py
+++ b/src/rmind/components/objectives/joint_policy.py
@@ -41,6 +41,7 @@ class JointPolicyObjective(Objective):
         chunk: Path,
         norm: InstanceOf[Module] | None = None,
         sample_codes: bool = True,
+        teacher_force_offset: bool = True,
     ) -> None:
         super().__init__()
 
@@ -53,6 +54,7 @@ class JointPolicyObjective(Objective):
         self.losses = losses  # {"code": ..., "offset": ...}
         self.chunk: Path = chunk
         self.sample_codes = sample_codes
+        self.teacher_force_offset = teacher_force_offset
 
     @override
     def train(self, mode: bool = True) -> "JointPolicyObjective":
@@ -150,7 +152,7 @@ class JointPolicyObjective(Objective):
                 chunk.flatten(-2, -1)
             )  # (b, action_dim): the GT action chunk the policy must reconstruct
 
-        code_logits, codes, offset = self._predict(features)
+        code_logits, offsets = self._heads(features)
 
         losses: dict[str, Tensor] = {}
 
@@ -160,13 +162,28 @@ class JointPolicyObjective(Objective):
                 code_logits[:, q, :], target_codes[:, q]
             )
 
-        # reconstruct the chunk as inference does (decode sampled codes + code-conditioned
-        # offset); the frozen tokenizer makes invert(codes) gradient-free, so this term
-        # trains only the offset head
-        predicted_chunk = tokenizer.invert(codes) + offset
+        # reconstruction as inference does it (decode sampled/argmax codes + offset
+        # gathered at those codes); the frozen tokenizer makes invert() gradient-free
+        codes = self._sample_codes(code_logits)
+        sampled_chunk = tokenizer.invert(codes) + self._gather_offset(offsets, codes)
+        sampled_recon = self.losses["offset"](sampled_chunk.detach(), target)
+
+        if self.teacher_force_offset:
+            # offset supervised at the GROUND-TRUTH codes (teacher forcing), so each
+            # code's offset entry only sees residuals of actions that quantized to it;
+            # supervising at sampled codes lets the offset learn the conditional median
+            # regardless of code, cancelling the code selection
+            predicted_chunk = tokenizer.invert(target_codes) + self._gather_offset(
+                offsets, target_codes
+            )
+        else:
+            predicted_chunk = sampled_chunk
+
         losses["offset"] = self.losses["offset"](predicted_chunk, target)
 
-        return {"loss": losses}
+        # sampled-code reconstruction error (the pre-fix loss value), logged for
+        # comparability across the teacher-forcing A/B; carries no gradient
+        return {"loss": losses, "metric": {"offset_sampled_recon": sampled_recon}}
 
     @override
     def predict(

--- a/src/rmind/components/vq.py
+++ b/src/rmind/components/vq.py
@@ -3,14 +3,14 @@ from typing import final
 import torch
 from torch import Tensor
 from torch.nn import Module
-from vector_quantize_pytorch import ResidualVQ as RVQ
+from vector_quantize_pytorch import ResidualVQ as RVQ  # noqa: N817
 
 
 @final
 class ResidualVQ(Module):
     """Residual vector quantizer from VQ-BeT (https://arxiv.org/pdf/2403.03181)."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         *,
         dim: int,
@@ -49,7 +49,9 @@ class ResidualVQ(Module):
         return self.vq.get_output_from_indices(codes)
 
     def codebook(self, level: int) -> Tensor:
-        return self.vq.layers[level]._codebook.embed.reshape(-1, self.dim)
+        return self.vq.layers[level]._codebook.embed.reshape(  # noqa: SLF001
+            -1, self.dim
+        )
 
     @torch.no_grad()
     def perplexity(self, codes: Tensor) -> Tensor:

--- a/src/rmind/inference/backends/tensorrt.py
+++ b/src/rmind/inference/backends/tensorrt.py
@@ -71,7 +71,12 @@ class TensorRTInferenceBackend:
             raise RuntimeError(msg)
 
         input = {
-            k: v.to(self._device, dtype=torch.int32 if k == "turn_signal" and v.dtype == torch.int64 else None).contiguous()
+            k: v.to(
+                self._device,
+                dtype=torch.int32
+                if k == "turn_signal" and v.dtype == torch.int64
+                else None,
+            ).contiguous()
             for k, v in input.items()
         }
         output = {

--- a/src/rmind/scripts/codebook_conflict_surface.py
+++ b/src/rmind/scripts/codebook_conflict_surface.py
@@ -1,0 +1,693 @@
+"""Codebook conflict surface + clean-codebook heads retrain (tier 2b).
+
+Two no-dataloader diagnostics for the offset-supervision bug, driven entirely
+by the cached shards from `offset_head_retrain extract` and local
+`ActionTokenizer` checkpoints (no datamodule, no `.rbyte_cache`):
+
+- `surface`: decode ALL 16^4 = 65536 residual-VQ code combinations of each
+  tokenizer (`invert` on the full cartesian product) and measure how much of
+  the codebook itself decodes to a gas+brake conflict — before any policy
+  head is involved. Reported per tokenizer: unweighted % of combos whose
+  decode conflicts (any of the 6 horizon frames; also the per-frame mean),
+  under both the sensor-derived thresholds of `pedal_conflict_stats` and a
+  flat 0.02/0.02 set. Real-data impact is quantified on BOTH cached splits
+  (val and train): USAGE-WEIGHTED % (each combo weighted by its empirical
+  ground-truth frequency under that tokenizer; GT codes recomputed from the
+  cached normalized target, raw chunk reconstructed by undoing the
+  turn_signal Scaler (0,2)->(0,1)), the GT-decode conflict rate (fraction of
+  samples whose own GT-code decode conflicts — the codebook floor under
+  perfect code prediction), usage concentration (how many distinct combos
+  cover 90% of GT usage and how many of those conflict), and — for the OLD
+  tokenizer — the policy-side hit rate: the fraction of val samples whose
+  cached-code-logits argmax combo decodes to a conflict (offset-free). The
+  chunk reconstruction is validated by round-tripping the OLD tokenizer: its
+  recomputed codes must match the cached `target_codes` for >= 99% of
+  samples.
+
+- `tier2b`: clean-codebook heads retrain on frozen features. Both the
+  `code_head` and `offset_head` are initialized from the BUGGED finetuned
+  checkpoint and retrained jointly on the cached train features against GT
+  codes recomputed under a CLEAN tokenizer (the code head's outputs index a
+  new codebook, so it relearns). Loss = per-quantizer FocalLoss on the new GT
+  codes + L1(invert(gt_codes) + gather_offset(offsets, gt_codes), target)
+  (teacher-forced), plus a control variant whose offset loss uses codes
+  SAMPLED from the training head's own logits each step (the pre-fix signal).
+  Eval on cached val mirrors `offset_head_retrain eval`: predicted pedal
+  conflicts at argmax decoding (with the gathered offset, and offset-free —
+  the clean-codebook analogue of the surface policy hit rate) bucketed by
+  the NEW code logits' entropy, cancellation ratio R per field,
+  per-quantizer code top-1 accuracy, offset magnitudes, and L1 to target.
+
+Usage:
+    uv run python -m rmind.scripts.codebook_conflict_surface surface \\
+        --val-cache caches/offset_head/val
+    uv run python -m rmind.scripts.codebook_conflict_surface tier2b \\
+        --train-cache caches/offset_head/train --val-cache caches/offset_head/val
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import gc
+import json
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import pytorch_lightning as pl
+import torch
+from einops import rearrange
+from torch.nn import functional as F
+
+from rmind.components.loss import FocalLoss
+from rmind.components.objectives.joint_policy import JointPolicyObjective
+from rmind.models.action_tokenizer import ActionTokenizer
+from rmind.scripts.offset_cancellation_probe import (
+    FIELD_NAMES,
+    _aggregate_cancellation,
+    _cancellation_batch,
+    _sample_codes_seeded,
+)
+from rmind.scripts.offset_diag import (
+    DEFAULT_CKPT,
+    EXPECTED_CODEBOOK_SIZE,
+    EXPECTED_NUM_QUANTIZERS,
+    REPO_ROOT,
+    load_policy,
+)
+from rmind.scripts.offset_head_retrain import _load_cache, _rearrange_offsets
+from rmind.scripts.pedal_conflict_probe import BRAKE_DIM, GAS_DIM
+from rmind.scripts.pedal_conflict_probe import summarize as summarize_pedal_conflicts
+from rmind.scripts.pedal_conflict_stats import BRAKE_THRESH, GAS_THRESH
+
+if TYPE_CHECKING:
+    from torch import Tensor
+    from torch.nn import Module
+
+G = EXPECTED_NUM_QUANTIZERS
+C = EXPECTED_CODEBOOK_SIZE
+N_COMBOS = C**G  # 65536
+N_FIELDS = len(FIELD_NAMES)
+HORIZON = 6
+TURN_SIGNAL_DIM = 3  # Scaler (0, 2) -> (0, 1): raw = normalized * 2
+
+# threshold sets: the sensor-derived ones from pedal_conflict_stats plus the
+# flat 0.02/0.02 pair behind the "42.2% of combos conflict" observation
+THRESHOLD_SETS: dict[str, tuple[float, float]] = {
+    "script": (GAS_THRESH, BRAKE_THRESH),
+    "flat_0.02": (0.02, 0.02),
+}
+
+TOKENIZER_CKPTS: dict[str, Path] = {
+    "old_dirty_gkzgn6gk": REPO_ROOT / "artifacts" / "model-gkzgn6gk:v9" / "model.ckpt",
+    "clean_baseline_y74asdtd": (
+        REPO_ROOT / "artifacts" / "model-y74asdtd:v9" / "model.ckpt"
+    ),
+    "clean_throttle_s7al9vc8": (
+        REPO_ROOT / "artifacts" / "model-s7al9vc8:v9" / "model.ckpt"
+    ),
+}
+OLD_TOKENIZER = "old_dirty_gkzgn6gk"
+DEFAULT_CLEAN_TOKENIZER = "clean_baseline_y74asdtd"
+MIN_ROUNDTRIP_MATCH_RATE = 0.99
+
+DEFAULT_SURFACE_OUT = REPO_ROOT / "diag_results" / "codebook_conflict_surface.json"
+DEFAULT_TIER2B_OUT = REPO_ROOT / "diag_results" / "tier2b_clean_codebook.json"
+
+_gather_offset = JointPolicyObjective._gather_offset  # noqa: SLF001
+
+
+def load_tokenizer(ckpt: str | Path, device: str) -> ActionTokenizer:
+    """Load a frozen ActionTokenizer from a local checkpoint.
+
+    Raises:
+        ValueError: if the quantizer geometry is not G=4, C=16.
+    """
+    tokenizer = ActionTokenizer.load_from_checkpoint(
+        Path(ckpt), map_location="cpu", weights_only=False
+    )
+    tokenizer = tokenizer.to(device).eval().requires_grad_(requires_grad=False)
+    quantizer = tokenizer.quantizer
+    if (quantizer.num_quantizers, quantizer.codebook_size) != (G, C):
+        msg = (
+            f"{ckpt}: unexpected quantizer geometry "
+            f"G={quantizer.num_quantizers} C={quantizer.codebook_size}"
+        )
+        raise ValueError(msg)
+    return tokenizer
+
+
+def reconstruct_chunk(target: Tensor) -> Tensor:
+    """Cached normalized target (n, 24) -> raw action chunk (n, 6, 4).
+
+    Continuous fields are Identity-normalized; turn_signal was scaled
+    (0, 2) -> (0, 1), so the raw chunk is recovered by doubling that column.
+    """
+    chunk = target.reshape(-1, HORIZON, N_FIELDS).clone()
+    chunk[..., TURN_SIGNAL_DIM] *= 2.0
+    return chunk
+
+
+def compute_codes(
+    tokenizer: ActionTokenizer, chunk: Tensor, device: str, batch_size: int = 8192
+) -> Tensor:
+    """GT codes (n, G) int64 on CPU for a raw chunk (n, 6, 4), batched."""
+    codes: list[Tensor] = []
+    with torch.inference_mode():
+        codes.extend(
+            tokenizer(chunk[start : start + batch_size].to(device)).cpu()
+            for start in range(0, chunk.shape[0], batch_size)
+        )
+    return torch.cat(codes).long()
+
+
+def all_combos(device: str) -> Tensor:
+    """All C^G code combinations (N_COMBOS, G), row i = base-C digits of i."""
+    return torch.cartesian_prod(
+        *(torch.arange(C, device=device) for _ in range(G))
+    ).long()
+
+
+def combo_index(codes: Tensor) -> Tensor:
+    """(n, G) codes -> flat combo index matching `all_combos` row order."""
+    weights = C ** torch.arange(G - 1, -1, -1, dtype=torch.long)
+    return (codes.cpu() * weights).sum(dim=-1)
+
+
+def decode_all_combos(
+    tokenizer: ActionTokenizer, device: str, batch_size: int = 8192
+) -> Tensor:
+    """Decode the full codebook: (N_COMBOS, 6, 4) on CPU, normalized space."""
+    combos = all_combos(device)
+    frames: list[Tensor] = []
+    with torch.inference_mode():
+        for start in range(0, N_COMBOS, batch_size):
+            decoded = tokenizer.invert(combos[start : start + batch_size])
+            frames.append(decoded.unflatten(-1, (-1, N_FIELDS)).cpu())
+    return torch.cat(frames)
+
+
+def conflict_frames(frames: Tensor, gas_thresh: float, brake_thresh: float) -> Tensor:
+    """(..., 6, 4) decoded frames -> (..., 6) bool gas+brake conflict mask."""
+    return (frames[..., GAS_DIM] > gas_thresh) & (frames[..., BRAKE_DIM] > brake_thresh)
+
+
+def _conflict_summary(frame_mask: Tensor, weights: Tensor | None = None) -> dict:
+    """Any-frame and per-frame conflict rates, optionally weighted per row."""
+    any_frame = frame_mask.any(dim=-1).float()
+    frame_rate = frame_mask.float().mean(dim=-1)
+    if weights is None:
+        return {
+            "any_frame_rate": float(any_frame.mean()),
+            "frame_rate": float(frame_rate.mean()),
+        }
+    total = float(weights.sum())
+    return {
+        "any_frame_rate": float((any_frame * weights).sum()) / total,
+        "frame_rate": float((frame_rate * weights).sum()) / total,
+    }
+
+
+def _top_usage_stats(
+    counts: Tensor, combo_any_conflict: Tensor, coverage: float = 0.9
+) -> dict[str, Any]:
+    """Concentration of GT usage: combos covering `coverage`, conflicts among them.
+
+    A few conflicting-but-frequent combos matter more than thousands of dead
+    ones; this reports how many distinct combos cover `coverage` of the GT
+    usage, how many of those conflict, and the usage share of the conflicting
+    ones within the whole split.
+    """
+    sorted_counts, order = counts.sort(descending=True)
+    total = float(counts.sum())
+    cumulative = sorted_counts.cumsum(dim=0)
+    k = int((cumulative < coverage * total).sum()) + 1
+    top = order[:k]
+    top_conflict = combo_any_conflict[top]
+    return {
+        "coverage": coverage,
+        "n_combos": k,
+        "n_conflicting": int(top_conflict.sum()),
+        "conflicting_usage_share": float(counts[top][top_conflict].sum() / total),
+    }
+
+
+def _split_stats(
+    counts: Tensor, indices: Tensor, masks: dict[str, Tensor]
+) -> dict[str, Any]:
+    """Per-split usage-weighted, GT-decode, and concentration stats."""
+    n = indices.shape[0]
+    entry: dict[str, Any] = {
+        "n_samples": n,
+        "n_unique_combos": int((counts > 0).sum()),
+        "top_combo_share": float(counts.max() / n),
+    }
+    for set_name, mask in masks.items():
+        entry[set_name] = {
+            "usage_weighted": _conflict_summary(mask, counts),
+            # fraction of samples whose own GT-code decode conflicts (the
+            # codebook floor under perfect code prediction); equals
+            # usage_weighted by construction (consistency check)
+            "gt_decode": _conflict_summary(mask[indices]),
+            "top_usage": _top_usage_stats(counts, mask.any(dim=-1)),
+        }
+    return entry
+
+
+def run_surface(args: argparse.Namespace) -> None:
+    t0 = time.perf_counter()
+    caches: dict[str, tuple[dict[str, Tensor], dict[str, Any]]] = {
+        "val": _load_cache(Path(args.val_cache)),
+        "train": _load_cache(Path(args.train_cache)),
+    }
+    chunks = {
+        split: reconstruct_chunk(data["target"]) for split, (data, _) in caches.items()
+    }
+    for split, (data, meta) in caches.items():
+        print(  # noqa: T201
+            f"[surface] {split} cache: {data['target'].shape[0]} samples "
+            f"(split={meta['split']})"
+        )
+
+    results: dict[str, Any] = {
+        "config": {
+            "val_cache": str(args.val_cache),
+            "train_cache": str(args.train_cache),
+            "cache_meta": {split: meta for split, (_, meta) in caches.items()},
+            "n_combos": N_COMBOS,
+            "thresholds": {
+                name: {"gas": gas, "brake": brake}
+                for name, (gas, brake) in THRESHOLD_SETS.items()
+            },
+            "tokenizers": {k: str(v) for k, v in TOKENIZER_CKPTS.items()},
+        },
+        "tokenizers": {},
+    }
+
+    for name, ckpt in TOKENIZER_CKPTS.items():
+        tokenizer = load_tokenizer(ckpt, args.device)
+
+        # full-codebook decode: is the conflict baked into the codebook?
+        combo_frames = decode_all_combos(tokenizer, args.device)  # (65536, 6, 4)
+        masks = {
+            set_name: conflict_frames(combo_frames, gas, brake)  # (65536, 6)
+            for set_name, (gas, brake) in THRESHOLD_SETS.items()
+        }
+
+        entry: dict[str, Any] = {"ckpt": str(ckpt)}
+        for set_name, mask in masks.items():
+            entry[set_name] = {"unweighted": _conflict_summary(mask)}
+
+        # empirical GT code usage on both cached splits under THIS tokenizer
+        entry["splits"] = {}
+        for split, (data, _) in caches.items():
+            gt_codes = compute_codes(tokenizer, chunks[split], args.device)
+            if name == OLD_TOKENIZER:
+                # round-trip check: the chunk reconstruction is only valid if
+                # the OLD tokenizer reproduces the cached target codes
+                match = (gt_codes == data["target_codes"].long()).all(dim=-1)
+                match_rate = float(match.float().mean())
+                results.setdefault("old_tokenizer_code_match_rate", {})[split] = (
+                    match_rate
+                )
+                print(  # noqa: T201
+                    f"[surface] old-tokenizer round-trip match rate "
+                    f"({split}): {match_rate:.4f}"
+                )
+                if split == "val" and match_rate < MIN_ROUNDTRIP_MATCH_RATE:
+                    msg = (
+                        f"chunk reconstruction failed round-trip: old-tokenizer "
+                        f"code match rate {match_rate:.4f} < "
+                        f"{MIN_ROUNDTRIP_MATCH_RATE}"
+                    )
+                    raise SystemExit(msg)
+
+            indices = combo_index(gt_codes)
+            counts = torch.bincount(indices, minlength=N_COMBOS).float()
+            entry["splits"][split] = _split_stats(counts, indices, masks)
+
+        if name == OLD_TOKENIZER:
+            # policy-side hit rate: which combos does the deployed (bugged)
+            # policy actually visit? cached code logits -> argmax -> decode,
+            # offset-free, val split
+            argmax_idx = combo_index(caches["val"][0]["code_logits"].argmax(dim=-1))
+            entry["policy_argmax_val"] = {
+                set_name: _conflict_summary(mask[argmax_idx])
+                for set_name, mask in masks.items()
+            }
+
+        results["tokenizers"][name] = entry
+        print(  # noqa: T201
+            f"[surface] {name}: unweighted any-frame "
+            f"script={entry['script']['unweighted']['any_frame_rate']:.4f} "
+            f"flat={entry['flat_0.02']['unweighted']['any_frame_rate']:.4f} | "
+            f"usage-weighted any-frame (script) "
+            f"val={entry['splits']['val']['script']['usage_weighted']['any_frame_rate']:.4f} "
+            f"train={entry['splits']['train']['script']['usage_weighted']['any_frame_rate']:.4f}"
+        )
+
+        del tokenizer, combo_frames
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    results["wall_time_s"] = time.perf_counter() - t0
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    print(f"[surface] results written to {out} ({results['wall_time_s']:.1f}s)")  # noqa: T201
+
+
+# --- tier2b ---------------------------------------------------------------------
+
+
+def _bugged_heads(ckpt: str | Path) -> tuple[Module, Module]:
+    """The bugged checkpoint's code and offset heads (CPU); the rest is freed."""
+    model = load_policy(ckpt, "cpu")
+    policy = cast("JointPolicyObjective", model.objectives["policy"])
+    code_head = copy.deepcopy(policy.code_head)
+    offset_head = copy.deepcopy(policy.offset_head)
+    del model, policy
+    gc.collect()
+    return code_head, offset_head
+
+
+def _train_heads(  # noqa: PLR0913, PLR0914, PLR0917
+    variant: str,
+    code_head: Module,
+    offset_head: Module,
+    tokenizer: ActionTokenizer,
+    data: dict[str, Tensor],
+    gt_codes: Tensor,
+    args: argparse.Namespace,
+) -> list[dict[str, float]]:
+    """Jointly retrain both heads on frozen cached features; returns loss history.
+
+    Raises:
+        RuntimeError: if the heads are not trainable or the tokenizer not frozen.
+    """
+    device = torch.device(args.device)
+    n = data["features"].shape[0]
+    code_loss_fn = FocalLoss()  # gamma=2.0, matching the finetune config
+    params = list(code_head.parameters()) + list(offset_head.parameters())
+    if not all(p.requires_grad for p in params) or any(
+        p.requires_grad for p in tokenizer.parameters()
+    ):
+        msg = "heads must be trainable and the tokenizer frozen"
+        raise RuntimeError(msg)
+    optimizer = torch.optim.Adam(params, lr=args.lr)
+    # CPU generator drives batch indices and (sampled variant) multinomial
+    generator = torch.Generator().manual_seed(args.seed)
+
+    history: list[dict[str, float]] = []
+    t0 = time.perf_counter()
+    for step in range(1, args.steps + 1):
+        index = torch.randint(0, n, (args.batch_size,), generator=generator)
+        features = data["features"][index].to(device).float()
+        target = data["target"][index].to(device)
+        target_codes = gt_codes[index].to(device)
+
+        code_logits = rearrange(code_head(features), "b (g c) -> b g c", g=G, c=C)
+        offsets = _rearrange_offsets(offset_head(features))
+
+        code_loss = sum(
+            code_loss_fn(code_logits[:, q, :], target_codes[:, q]) for q in range(G)
+        )
+
+        if variant == "sampled":
+            # the pre-fix signal: offsets supervised at codes sampled from the
+            # (current) head's own logits, independent of the GT action
+            offset_codes = _sample_codes_seeded(code_logits.detach(), generator)
+        else:
+            offset_codes = target_codes
+        with torch.no_grad():
+            decoded = tokenizer.invert(offset_codes)
+        offset_loss = F.l1_loss(decoded + _gather_offset(offsets, offset_codes), target)
+
+        loss = code_loss + offset_loss
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+        if step == 1 or step % args.log_every == 0 or step == args.steps:
+            entry = {
+                "step": step,
+                "loss": float(loss.detach()),
+                "code_loss": float(code_loss.detach()),
+                "offset_loss": float(offset_loss.detach()),
+            }
+            history.append(entry)
+            rate = step / (time.perf_counter() - t0)
+            print(  # noqa: T201
+                f"[tier2b/{variant}] step {step}/{args.steps} "
+                f"loss={entry['loss']:.5f} code={entry['code_loss']:.5f} "
+                f"offset={entry['offset_loss']:.5f} ({rate:.2f} steps/s)"
+            )
+    return history
+
+
+def _eval_heads(  # noqa: PLR0913, PLR0914, PLR0917
+    code_head: Module,
+    offset_head: Module,
+    tokenizer: ActionTokenizer,
+    data: dict[str, Tensor],
+    gt_codes: Tensor,
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    """Val-split eval mirroring `offset_head_retrain eval`, with NEW code logits."""
+    device = torch.device(args.device)
+    n = data["features"].shape[0]
+
+    ratios: list[Tensor] = []
+    entropies: list[Tensor] = []
+    pred_conflicts: list[Tensor] = []
+    pred_conflicts_no_offset: list[Tensor] = []
+    gt_conflicts: list[Tensor] = []
+    code_correct: list[Tensor] = []
+    tf_l1: list[Tensor] = []
+    argmax_l1: list[Tensor] = []
+    abs_argmax_sum = abs_table_sum = 0.0
+    abs_argmax_numel = abs_table_numel = 0
+
+    with torch.inference_mode():
+        for start in range(0, n, args.eval_batch_size):
+            stop = min(start + args.eval_batch_size, n)
+            features = data["features"][start:stop].to(device).float()
+            target = data["target"][start:stop].to(device)
+            target_codes = gt_codes[start:stop].to(device)
+
+            code_logits = rearrange(code_head(features), "b (g c) -> b g c", g=G, c=C)
+            offsets = _rearrange_offsets(offset_head(features))
+
+            # (b) cancellation ratio on the NEW logits + retrained offsets
+            ratio, entropy = _cancellation_batch(tokenizer, code_logits, offsets)
+            ratios.append(ratio.cpu())
+            entropies.append(entropy.cpu())
+
+            # (a) pedal conflicts at argmax (export-time) decoding, with the
+            # gathered offset and offset-free (the pure combo-surface hit rate)
+            argmax_codes = code_logits.argmax(dim=-1)
+            offset_argmax = _gather_offset(offsets, argmax_codes)
+            decoded = tokenizer.invert(argmax_codes)
+            pred = (decoded + offset_argmax).unflatten(-1, (-1, N_FIELDS))
+            gt = target.unflatten(-1, (-1, N_FIELDS))
+            pred_conflicts.append(conflict_frames(pred, GAS_THRESH, BRAKE_THRESH).cpu())
+            pred_conflicts_no_offset.append(
+                conflict_frames(
+                    decoded.unflatten(-1, (-1, N_FIELDS)), GAS_THRESH, BRAKE_THRESH
+                ).cpu()
+            )
+            gt_conflicts.append(conflict_frames(gt, GAS_THRESH, BRAKE_THRESH).cpu())
+
+            # (c) per-quantizer top-1 accuracy vs the new GT codes
+            code_correct.append((argmax_codes == target_codes).cpu())
+
+            # (e) L1 to target, teacher-forced style and argmax decode
+            tf_pred = tokenizer.invert(target_codes) + _gather_offset(
+                offsets, target_codes
+            )
+            tf_l1.append((tf_pred - target).abs().mean(dim=-1).cpu())
+            argmax_l1.append((pred.flatten(-2, -1) - target).abs().mean(dim=-1).cpu())
+
+            # (d) offset magnitudes
+            abs_argmax_sum += float(offset_argmax.abs().sum())
+            abs_argmax_numel += offset_argmax.numel()
+            abs_table_sum += float(offsets.abs().sum())
+            abs_table_numel += offsets.numel()
+
+    entropy_q0 = torch.cat(entropies)
+    correct = torch.cat(code_correct)
+    no_offset = torch.cat(pred_conflicts_no_offset)
+    return {
+        "pedal_conflict": summarize_pedal_conflicts({
+            "pred_conflict": torch.cat(pred_conflicts),
+            "gt_conflict": torch.cat(gt_conflicts),
+            "entropy_q0": entropy_q0,
+        }),
+        # offset-free argmax decode: the clean-codebook analogue of the
+        # surface subcommand's policy-side combo hit rate
+        "pedal_conflict_argmax_offset_free": {
+            "frame_conflict_rate": float(no_offset.float().mean()),
+            "sample_any_frame_rate": float(no_offset.any(dim=-1).float().mean()),
+        },
+        "cancellation": _aggregate_cancellation(torch.cat(ratios), entropy_q0),
+        "code_top1_accuracy": {
+            "overall": float(correct.float().mean()),
+            "per_quantizer": [float(correct[:, q].float().mean()) for q in range(G)],
+        },
+        "offset_magnitude": {
+            "mean_abs_at_argmax": abs_argmax_sum / abs_argmax_numel,
+            "mean_abs_full_table": abs_table_sum / abs_table_numel,
+        },
+        "l1_to_target": {
+            "teacher_forced_style": float(torch.cat(tf_l1).mean()),
+            "argmax_decode": float(torch.cat(argmax_l1).mean()),
+        },
+    }
+
+
+def run_tier2b(args: argparse.Namespace) -> None:  # noqa: PLR0914
+    t0 = time.perf_counter()
+    device = torch.device(args.device)
+    train_data, train_meta = _load_cache(Path(args.train_cache))
+    val_data, val_meta = _load_cache(Path(args.val_cache))
+
+    tokenizer = load_tokenizer(args.tokenizer_ckpt, args.device)
+    print(f"[tier2b] clean tokenizer: {args.tokenizer_ckpt}")  # noqa: T201
+
+    # GT codes under the CLEAN tokenizer, from the reconstructed raw chunks
+    train_codes = compute_codes(
+        tokenizer, reconstruct_chunk(train_data["target"]), args.device
+    )
+    val_codes = compute_codes(
+        tokenizer, reconstruct_chunk(val_data["target"]), args.device
+    )
+    print(  # noqa: T201
+        f"[tier2b] recomputed clean GT codes: train={train_codes.shape[0]} "
+        f"(split={train_meta['split']}), val={val_codes.shape[0]} "
+        f"(split={val_meta['split']})"
+    )
+
+    code_head_src, offset_head_src = _bugged_heads(args.ckpt)
+
+    results: dict[str, Any] = {
+        "config": {
+            "policy_ckpt": str(args.ckpt),
+            "tokenizer_ckpt": str(args.tokenizer_ckpt),
+            "train_cache": str(args.train_cache),
+            "val_cache": str(args.val_cache),
+            "steps": args.steps,
+            "batch_size": args.batch_size,
+            "lr": args.lr,
+            "seed": args.seed,
+            "code_loss": "FocalLoss(gamma=2.0), per quantizer, summed",
+            "offset_loss": "L1(invert(codes) + gather_offset(offsets, codes), target)",
+            "init": "both heads initialized from the bugged checkpoint",
+            "thresholds": {"gas": GAS_THRESH, "brake": BRAKE_THRESH},
+        },
+        "heads": {},
+    }
+
+    for variant in ("teacher_forced", "sampled"):
+        pl.seed_everything(args.seed, workers=True)
+        code_head = copy.deepcopy(code_head_src).to(device).float()
+        offset_head = copy.deepcopy(offset_head_src).to(device).float()
+        code_head.requires_grad_(requires_grad=True).train()
+        offset_head.requires_grad_(requires_grad=True).train()
+
+        history = _train_heads(
+            variant, code_head, offset_head, tokenizer, train_data, train_codes, args
+        )
+
+        code_head.eval()
+        offset_head.eval()
+        entry = _eval_heads(
+            code_head, offset_head, tokenizer, val_data, val_codes, args
+        )
+        entry["loss_history"] = history
+        results["heads"][variant] = entry
+
+        conflict = entry["pedal_conflict"]["predicted"]
+        top_bucket = conflict["buckets"][-1]
+        per_field = entry["cancellation"]["overall"]["per_field"]
+        print(  # noqa: T201
+            f"[tier2b/{variant}] conflict frame rate="
+            f"{conflict['frame_conflict_rate']:.5f} "
+            f"(top entropy quartile {top_bucket['frame_conflict_rate']:.5f}) | "
+            f"R_median gas={per_field['gas_pedal']['median_R']:.4f} "
+            f"brake={per_field['brake_pedal']['median_R']:.4f} | "
+            f"code_acc={entry['code_top1_accuracy']['overall']:.4f} | "
+            f"L1 tf={entry['l1_to_target']['teacher_forced_style']:.5f}"
+        )
+
+        del code_head, offset_head
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    results["wall_time_s"] = time.perf_counter() - t0
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    print(f"[tier2b] results written to {out} ({results['wall_time_s']:.1f}s)")  # noqa: T201
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="codebook_conflict_surface",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="stage", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--device", default="cuda")
+    common.add_argument("--seed", type=int, default=42)
+    common.add_argument(
+        "--val-cache", default=str(REPO_ROOT / "caches" / "offset_head" / "val")
+    )
+    common.add_argument(
+        "--train-cache", default=str(REPO_ROOT / "caches" / "offset_head" / "train")
+    )
+
+    surface = subparsers.add_parser(
+        "surface",
+        parents=[common],
+        help="decode all 65536 code combos per tokenizer; conflict surface stats",
+    )
+    surface.add_argument("--out", default=str(DEFAULT_SURFACE_OUT))
+    surface.set_defaults(func=run_surface)
+
+    tier2b = subparsers.add_parser(
+        "tier2b",
+        parents=[common],
+        help="retrain both heads jointly on frozen features with a clean codebook",
+    )
+    tier2b.add_argument(
+        "--ckpt",
+        default=str(DEFAULT_CKPT),
+        help="bugged policy checkpoint (heads init)",
+    )
+    tier2b.add_argument(
+        "--tokenizer-ckpt",
+        default=str(TOKENIZER_CKPTS[DEFAULT_CLEAN_TOKENIZER]),
+        help="clean ActionTokenizer checkpoint",
+    )
+    tier2b.add_argument("--steps", type=int, default=6000)
+    tier2b.add_argument("--batch-size", type=int, default=4096)
+    tier2b.add_argument("--lr", type=float, default=1e-4)
+    tier2b.add_argument("--log-every", type=int, default=500)
+    tier2b.add_argument("--eval-batch-size", type=int, default=512)
+    tier2b.add_argument("--out", default=str(DEFAULT_TIER2B_OUT))
+    tier2b.set_defaults(func=run_tier2b)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rmind/scripts/offset_cancellation_probe.py
+++ b/src/rmind/scripts/offset_cancellation_probe.py
@@ -1,0 +1,423 @@
+"""Offset-cancellation probe for the JointPolicyObjective offset-supervision bug.
+
+Phase-1 diagnostics (brief 1a + 1b) against the finetuned checkpoint, using
+export-time decoding (`sample_codes=False`, enforced by `load_policy`):
+
+1a (always): for each sample, enumerate residual-VQ code combinations and
+compare the decoded actions with and without the code-conditioned offset.
+With G=4 quantizers and C=16 codes the full product (65536) is too large, so
+per the brief we enumerate all 16 primary (q=0) codes crossed with each
+sample's top-4 most probable secondary (q=1) codes, holding q=2 and q=3 at
+their per-sample argmax — 64 combinations per sample. For every combination
+`c` we compute `decoded[c] = tokenizer.invert(c)` and
+`corrected[c] = decoded[c] + gather_offset(c)`, then the per-action-dimension
+cancellation ratio `R = Var_c(corrected) / Var_c(decoded)`. R << 1 means the
+offset head collapses distinct codes onto the same output (the predicted bug
+signature); R ~ 1 means the offsets preserve cross-code variance. Results are
+aggregated per action field (gas, brake, steering, turn_signal: mean over the
+6 horizon steps) and per raw dimension, overall and bucketed by quartile of
+the primary-code (q=0) softmax entropy.
+
+1b (--audit): per (sample, quantizer) mismatch of the SAMPLED code
+(`torch.multinomial`, seeded — the pre-fix training-time path) vs the
+ground-truth code, plus the L1 magnitude of the offset target
+`|target - tokenizer.invert(sampled_codes)|` split by whether the full code
+tuple matched GT. Mismatched targets spanning cross-mode distances (much
+larger than matched sub-cell residuals) confirm training-signal contamination.
+
+Usage:
+    uv run python -m rmind.scripts.offset_cancellation_probe \
+        --split val --max-batches 63 --audit --wandb
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import pytorch_lightning as pl
+import torch
+
+from rmind.scripts.offset_diag import (
+    DEFAULT_CKPT,
+    REPO_ROOT,
+    build_dataloader,
+    iter_policy_tensors,
+    load_policy,
+)
+
+if TYPE_CHECKING:
+    from torch import Tensor
+
+    from rmind.components.objectives.joint_policy import JointPolicyObjective
+    from rmind.models.action_tokenizer import ActionTokenizer
+
+FIELD_NAMES = ("gas_pedal", "brake_pedal", "steering_angle", "turn_signal")
+N_SECONDARY = 4  # top-k of q=1 crossed with all 16 primary codes -> 64 combos
+VAR_EPS = 1e-10  # dims with Var_c(decoded) below this are excluded (R undefined)
+DEFAULT_OUT = REPO_ROOT / "diag_results" / "offset_cancellation.json"
+WANDB_RUN_NAME = "diag-offset-cancellation"
+WANDB_TAGS = ("diag/joint_policy_offset_bug",)
+
+
+def _enumerate_combos(code_logits: Tensor, n_secondary: int = N_SECONDARY) -> Tensor:
+    """Code combinations (b, 16 * n_secondary, G) per the brief's scheme.
+
+    All C=16 primary (q=0) codes x each sample's top-`n_secondary` q=1 codes;
+    q=2 and q=3 held at their per-sample argmax (full product is too large).
+    """
+    b, g, c = code_logits.shape
+    k = c * n_secondary
+
+    combos = torch.empty(b, k, g, dtype=torch.long, device=code_logits.device)
+    primary = torch.arange(c, device=code_logits.device).repeat_interleave(n_secondary)
+    combos[..., 0] = primary  # (k,) broadcast over batch
+    secondary = code_logits[:, 1].topk(n_secondary, dim=-1).indices  # (b, n_secondary)
+    combos[..., 1] = secondary.repeat(1, c)  # tiles to match primary's interleave
+    combos[..., 2:] = code_logits[:, 2:].argmax(dim=-1)[:, None, :]
+    return combos
+
+
+def _gather_combo_offsets(offsets: Tensor, combos: Tensor) -> Tensor:
+    """Sum each quantizer's offset at `combos`: (b,G,C,A),(b,K,G) -> (b,K,A)."""
+    b, k, g = combos.shape
+    a = offsets.shape[-1]
+    table = offsets.unsqueeze(1).expand(b, k, g, offsets.shape[2], a)
+    index = combos[..., None, None].expand(b, k, g, 1, a)
+    return table.gather(3, index).squeeze(3).sum(dim=2)
+
+
+def _cancellation_batch(
+    tokenizer: ActionTokenizer, code_logits: Tensor, offsets: Tensor
+) -> tuple[Tensor, Tensor]:
+    """Per-sample cancellation ratios (b, action_dim) and q=0 entropy (b,)."""
+    combos = _enumerate_combos(code_logits)
+    decoded = tokenizer.invert(combos)  # (b, K, A), normalized action space
+    corrected = decoded + _gather_combo_offsets(offsets, combos)
+
+    var_decoded = decoded.var(dim=1)  # (b, A), across the K combos
+    var_corrected = corrected.var(dim=1)
+    ratio = torch.where(var_decoded > VAR_EPS, var_corrected / var_decoded, torch.nan)
+
+    probs = code_logits[:, 0].softmax(dim=-1)
+    entropy = -(probs * probs.clamp_min(1e-12).log()).sum(dim=-1)  # nats
+    return ratio, entropy
+
+
+def _sample_codes_seeded(code_logits: Tensor, generator: torch.Generator) -> Tensor:
+    """The pre-fix training-time sampling path (`torch.multinomial`), seeded.
+
+    Sampling runs on CPU with a CPU generator so the audit is deterministic
+    for a given seed regardless of device; the batch is tiny (b*G rows of C
+    probabilities).
+    """
+    b, g, c = code_logits.shape
+    probs = code_logits.softmax(dim=-1).reshape(-1, c).cpu()
+    sampled = torch.multinomial(probs, 1, generator=generator).reshape(b, g)
+    return sampled.to(code_logits.device)
+
+
+def _audit_batch(
+    tokenizer: ActionTokenizer,
+    code_logits: Tensor,
+    target_codes: Tensor,
+    target: Tensor,
+    generator: torch.Generator,
+) -> dict[str, Tensor]:
+    """Sampled-vs-GT code mismatches and offset-target L1 for one batch (on CPU)."""
+    sampled = _sample_codes_seeded(code_logits, generator)
+    mismatch = sampled != target_codes  # (b, G)
+    full_match = ~mismatch.any(dim=-1)  # (b,)
+    # what the offset head was asked to produce at the sampled codes
+    offset_target_l1 = (target - tokenizer.invert(sampled)).abs()  # (b, A)
+    return {
+        "mismatch": mismatch.cpu(),
+        "full_match": full_match.cpu(),
+        "offset_target_l1": offset_target_l1.cpu(),
+    }
+
+
+def _sanitize(value: float) -> float | None:
+    return None if math.isnan(value) else value
+
+
+def _ratio_stats(ratios: Tensor) -> dict[str, Any]:
+    """Mean/median R per field (mean over the 6 horizon steps) and per dim."""
+    n = ratios.shape[0]
+    per_field = ratios.reshape(n, -1, len(FIELD_NAMES)).nanmean(dim=1)  # (n, 4)
+    return {
+        "n_samples": n,
+        "per_field": {
+            name: {
+                "mean_R": _sanitize(float(per_field[:, i].nanmean())),
+                "median_R": _sanitize(float(per_field[:, i].nanmedian())),
+            }
+            for i, name in enumerate(FIELD_NAMES)
+        },
+        "per_dim": {
+            "mean_R": [_sanitize(float(v)) for v in ratios.nanmean(dim=0)],
+            "median_R": [_sanitize(float(v)) for v in ratios.nanmedian(dim=0).values],
+        },
+    }
+
+
+def _aggregate_cancellation(ratios: Tensor, entropies: Tensor) -> dict[str, Any]:
+    edges = torch.quantile(entropies, torch.tensor([0.25, 0.5, 0.75]))
+    buckets = torch.bucketize(entropies, edges)
+
+    by_quartile = []
+    for i in range(4):
+        mask = buckets == i
+        selected = entropies[mask]
+        by_quartile.append({
+            "quartile": i,
+            "entropy_min": float(selected.min()) if mask.any() else None,
+            "entropy_max": float(selected.max()) if mask.any() else None,
+            **_ratio_stats(ratios[mask]),
+        })
+
+    return {
+        "combo_scheme": (
+            "all 16 primary (q=0) codes x per-sample top-4 q=1 codes; "
+            "q=2, q=3 held at per-sample argmax (64 combos; full 16^4 product "
+            "too large)"
+        ),
+        "n_combos": 16 * N_SECONDARY,
+        "invalid_dim_fraction": float(ratios.isnan().float().mean()),
+        "entropy_quartile_edges_nats": [float(v) for v in edges],
+        "overall": _ratio_stats(ratios),
+        "by_entropy_quartile": by_quartile,
+    }
+
+
+def _aggregate_audit(
+    mismatch: Tensor, full_match: Tensor, offset_target_l1: Tensor
+) -> dict[str, Any]:
+    n, g = mismatch.shape
+    matched_l1 = offset_target_l1[full_match]
+    mismatched_l1 = offset_target_l1[~full_match]
+
+    def field_means(l1: Tensor) -> dict[str, float | None]:
+        if l1.shape[0] == 0:
+            return dict.fromkeys(FIELD_NAMES)
+        per_field = l1.reshape(l1.shape[0], -1, len(FIELD_NAMES)).mean(dim=(0, 1))
+        return {name: float(per_field[i]) for i, name in enumerate(FIELD_NAMES)}
+
+    return {
+        "n_samples": n,
+        "code_mismatch_rate_overall": float(mismatch.float().mean()),
+        "code_mismatch_rate_per_quantizer": [
+            float(mismatch[:, q].float().mean()) for q in range(g)
+        ],
+        "full_tuple_match_rate": float(full_match.float().mean()),
+        "n_full_tuple_matched": int(full_match.sum()),
+        "n_full_tuple_mismatched": int((~full_match).sum()),
+        "offset_target_l1_matched": (
+            float(matched_l1.mean()) if matched_l1.shape[0] else None
+        ),
+        "offset_target_l1_mismatched": (
+            float(mismatched_l1.mean()) if mismatched_l1.shape[0] else None
+        ),
+        "offset_target_l1_matched_per_field": field_means(matched_l1),
+        "offset_target_l1_mismatched_per_field": field_means(mismatched_l1),
+    }
+
+
+def run_probe(args: argparse.Namespace) -> dict[str, Any]:
+    pl.seed_everything(args.seed, workers=True)
+    model = load_policy(args.ckpt, args.device)
+    policy = cast("JointPolicyObjective", model.objectives["policy"])
+    tokenizer = cast("ActionTokenizer", policy.tokenizer)
+    loader = build_dataloader(
+        args.split, batch_size=args.batch_size, num_workers=args.num_workers
+    )
+    print(  # noqa: T201
+        f"[probe] split={args.split}: {len(loader.dataset)} samples, "
+        f"{len(loader)} batches of {args.batch_size}; "
+        f"max_batches={args.max_batches}, audit={args.audit}"
+    )
+
+    generator = torch.Generator()  # CPU: see _sample_codes_seeded
+    generator.manual_seed(args.seed)
+
+    ratios: list[Tensor] = []
+    entropies: list[Tensor] = []
+    audit_parts: dict[str, list[Tensor]] = {}
+
+    for batch_idx, tensors in enumerate(
+        iter_policy_tensors(model, loader, args.device, max_batches=args.max_batches)
+    ):
+        ratio, entropy = _cancellation_batch(
+            tokenizer, tensors["code_logits"], tensors["offsets"]
+        )
+        ratios.append(ratio.cpu())
+        entropies.append(entropy.cpu())
+
+        if args.audit:
+            part = _audit_batch(
+                tokenizer,
+                tensors["code_logits"],
+                tensors["target_codes"],
+                tensors["target"],
+                generator,
+            )
+            for key, value in part.items():
+                audit_parts.setdefault(key, []).append(value)
+
+        if (batch_idx + 1) % 10 == 0:
+            print(f"[probe] processed {batch_idx + 1} batches")  # noqa: T201
+
+    results: dict[str, Any] = {
+        "config": {
+            "ckpt": str(args.ckpt),
+            "split": args.split,
+            "batch_size": args.batch_size,
+            "max_batches": args.max_batches,
+            "seed": args.seed,
+            "sample_codes": False,  # export-time argmax decoding
+        },
+        "n_samples": int(sum(r.shape[0] for r in ratios)),
+        "cancellation": _aggregate_cancellation(
+            torch.cat(ratios), torch.cat(entropies)
+        ),
+    }
+    if args.audit:
+        results["audit"] = _aggregate_audit(
+            torch.cat(audit_parts["mismatch"]),
+            torch.cat(audit_parts["full_match"]),
+            torch.cat(audit_parts["offset_target_l1"]),
+        )
+    return results
+
+
+def _log_wandb(results: dict[str, Any]) -> str | None:
+    import wandb  # noqa: PLC0415
+
+    run = wandb.init(
+        entity="yaak",
+        project="rmind",
+        name=WANDB_RUN_NAME,
+        tags=list(WANDB_TAGS),
+        dir=str(REPO_ROOT / "wandb_logs"),
+        config=results["config"] | {"n_samples": results["n_samples"]},
+    )
+
+    cancellation = results["cancellation"]
+    scalars: dict[str, Any] = {}
+    for name, stats in cancellation["overall"]["per_field"].items():
+        scalars[f"cancellation/R_mean/{name}"] = stats["mean_R"]
+        scalars[f"cancellation/R_median/{name}"] = stats["median_R"]
+
+    if (audit := results.get("audit")) is not None:
+        scalars["audit/code_mismatch_rate_overall"] = audit[
+            "code_mismatch_rate_overall"
+        ]
+        for q, rate in enumerate(audit["code_mismatch_rate_per_quantizer"]):
+            scalars[f"audit/code_mismatch_rate/q{q}"] = rate
+        scalars["audit/full_tuple_match_rate"] = audit["full_tuple_match_rate"]
+        scalars["audit/offset_target_l1_matched"] = audit["offset_target_l1_matched"]
+        scalars["audit/offset_target_l1_mismatched"] = audit[
+            "offset_target_l1_mismatched"
+        ]
+
+    table = wandb.Table(
+        columns=[
+            "entropy_quartile",
+            "entropy_min",
+            "entropy_max",
+            "n_samples",
+            "field",
+            "mean_R",
+            "median_R",
+        ]
+    )
+    for bucket in cancellation["by_entropy_quartile"]:
+        for name, stats in bucket["per_field"].items():
+            table.add_data(
+                bucket["quartile"],
+                bucket["entropy_min"],
+                bucket["entropy_max"],
+                bucket["n_samples"],
+                name,
+                stats["mean_R"],
+                stats["median_R"],
+            )
+
+    run.log(scalars | {"cancellation/R_by_entropy_quartile": table})
+    url = run.url
+    run.finish()
+    return url
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", default=str(DEFAULT_CKPT))
+    parser.add_argument(
+        "--split", default="val", choices=["train", "val", "train_debug"]
+    )
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--max-batches", type=int, default=None)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--audit",
+        action="store_true",
+        help="also run the 1b sampled-vs-GT code contamination audit",
+    )
+    parser.add_argument(
+        "--wandb",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="log scalars and the R-by-entropy-quartile table to wandb",
+    )
+    parser.add_argument("--out", default=str(DEFAULT_OUT))
+    args = parser.parse_args()
+
+    results = run_probe(args)
+
+    if args.wandb:
+        results["wandb_url"] = _log_wandb(results)
+        print(f"[probe] wandb run: {results['wandb_url']}")  # noqa: T201
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    print(f"[probe] results written to {out}")  # noqa: T201
+    print(json.dumps(results["cancellation"]["overall"]["per_field"], indent=2))  # noqa: T201
+    if (audit := results.get("audit")) is not None:
+        print(  # noqa: T201
+            json.dumps(
+                {
+                    k: audit[k]
+                    for k in (
+                        "code_mismatch_rate_overall",
+                        "code_mismatch_rate_per_quantizer",
+                        "full_tuple_match_rate",
+                        "offset_target_l1_matched",
+                        "offset_target_l1_mismatched",
+                    )
+                },
+                indent=2,
+            )
+        )
+
+
+if __name__ == "__main__":
+    import multiprocessing as mp
+    import os
+    import sys
+
+    mp.set_forkserver_preload(["rbyte", "polars"])
+    main()
+
+    # torchdata.nodes worker-thread teardown intermittently aborts at
+    # interpreter exit ("terminate called without an active exception",
+    # SIGABRT) even after `shutdown_dataloader`; every output (wandb, JSON,
+    # stdout) is already flushed, so skip interpreter teardown entirely
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)

--- a/src/rmind/scripts/offset_diag.py
+++ b/src/rmind/scripts/offset_diag.py
@@ -1,0 +1,286 @@
+"""Shared diagnostics harness for the JointPolicyObjective offset-head probes.
+
+Provides three building blocks for the Phase-1 diagnostics of the
+offset-supervision bug (offset head trained at sampled instead of
+ground-truth codes):
+
+- `load_policy`: load the finetuned `ControlTransformer` from a local
+  checkpoint file, in eval mode, with `sample_codes=False` on the policy
+  objective so all probes match export-time (argmax) decoding.
+- `build_dataloader`: build the train/val/train_debug dataloader exactly as
+  the finetune experiment does (hydra compose of
+  `experiment=yaak/control_transformer/finetune`); first instantiation of a
+  split builds the rbyte sample cache over NFS.
+- `iter_policy_tensors`: yield per-batch policy tensors (features, code
+  logits, the full offset table, GT chunk, GT codes, normalized GT target)
+  under `torch.inference_mode`.
+
+Usage (smoke test / cache build):
+    uv run python -m rmind.scripts.offset_diag --split val --max-batches 2
+    uv run python -m rmind.scripts.offset_diag --split train --skip-model
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import torch
+from hydra import compose, initialize_config_dir
+from hydra.utils import instantiate
+from omegaconf import OmegaConf
+from torch.utils._pytree import tree_map  # noqa: PLC2701
+
+from rmind.components.objectives.joint_policy import JointPolicyObjective
+from rmind.models.control_transformer import ControlTransformer
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+    from rbyte.dataloader import TorchDataNodeDataLoader
+    from torch import Tensor
+
+    from rmind.models.action_tokenizer import ActionTokenizer
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONFIG_DIR = REPO_ROOT / "config"
+DEFAULT_CKPT = REPO_ROOT / "artifacts" / "model-2gqxhjod:v9" / "model.ckpt"
+
+EXPECTED_NUM_QUANTIZERS = 4
+EXPECTED_CODEBOOK_SIZE = 16
+
+
+def load_policy(
+    ckpt_path: str | Path = DEFAULT_CKPT, device: str | torch.device = "cuda"
+) -> ControlTransformer:
+    """Load the finetuned model from a local checkpoint, ready for probing.
+
+    The model is set to eval, gradients are disabled, and the policy
+    objective decodes with argmax (`sample_codes=False`) to match the export
+    path (`config/export/yaak/control_transformer/finetuned.yaml`).
+
+    Note: the checkpoint hparams reference the frozen action tokenizer as a
+    wandb artifact (`yaak/rmind/model-gkzgn6gk:v9`); resolving it hits the
+    wandb API but reuses the already-downloaded files under `./artifacts`.
+
+    Raises:
+        TypeError: if `objectives['policy']` is not a `JointPolicyObjective`.
+        ValueError: if the tokenizer quantizer geometry is not G=4, C=16.
+    """
+    model = ControlTransformer.load_from_checkpoint(
+        Path(ckpt_path), map_location="cpu", weights_only=False
+    )
+    model = model.to(torch.device(device)).eval().requires_grad_(requires_grad=False)
+
+    policy = model.objectives["policy"]
+    if not isinstance(policy, JointPolicyObjective):
+        msg = f"objectives['policy'] is {type(policy).__name__}, expected JointPolicyObjective"
+        raise TypeError(msg)
+
+    quantizer = cast("ActionTokenizer", policy.tokenizer).quantizer
+    if (quantizer.num_quantizers, quantizer.codebook_size) != (
+        EXPECTED_NUM_QUANTIZERS,
+        EXPECTED_CODEBOOK_SIZE,
+    ):
+        msg = (
+            f"unexpected quantizer geometry: G={quantizer.num_quantizers} "
+            f"C={quantizer.codebook_size}, expected G={EXPECTED_NUM_QUANTIZERS} "
+            f"C={EXPECTED_CODEBOOK_SIZE}"
+        )
+        raise ValueError(msg)
+
+    policy.sample_codes = False  # match export-time (argmax) decoding
+    return model
+
+
+def build_dataloader(
+    split: str,
+    batch_size: int = 32,
+    num_workers: int = 2,
+    *,
+    shuffle: bool | None = None,
+) -> TorchDataNodeDataLoader[dict[str, Any]]:
+    """Instantiate a dataloader of the finetune experiment for `split`.
+
+    `split` is one of 'train', 'val', 'train_debug'. The 3hz episode
+    geometry (episode_length=6, episode_step=10, clip_length=11, ...) comes
+    from the composed experiment config and is left untouched. First call
+    per split builds the rbyte sample cache under `.rbyte_cache` (slow, NFS).
+    `shuffle=None` keeps the experiment default (train: True, val: True).
+
+    Raises:
+        ValueError: if `split` is not a known split name.
+    """
+    if split not in {"train", "val", "train_debug"}:
+        msg = f"unknown split: {split!r}"
+        raise ValueError(msg)
+
+    overrides = [
+        "experiment=yaak/control_transformer/finetune",
+        # only cfg.datamodule is consumed; these just satisfy mandatory keys
+        "model.artifact=placeholder/placeholder:v0",
+        "action_tokenizer_artifact=placeholder/placeholder:v0",
+    ]
+
+    with initialize_config_dir(config_dir=str(CONFIG_DIR), version_base=None):
+        cfg = compose(config_name="train", overrides=overrides)
+
+    if split == "train_debug":
+        # graft the debug dataset into the composed tree; its interpolations
+        # (${paths.*}, ${clip_length}, ...) resolve against the root config
+        cfg.datamodule.train.dataset = OmegaConf.load(
+            CONFIG_DIR / "dataset" / "yaak" / "train_debug.yaml"
+        )
+
+    # make the cache path independent of the caller's working directory
+    cfg.paths.rbyte.cache = str(REPO_ROOT / ".rbyte_cache")
+
+    node = cfg.datamodule.val if split == "val" else cfg.datamodule.train
+    node.batch_size = batch_size
+    node.num_workers = num_workers
+    if shuffle is not None:
+        node.shuffle = shuffle
+
+    return instantiate(node)
+
+
+def shutdown_dataloader(dataloader: Any) -> None:
+    """Best-effort shutdown of `TorchDataNodeDataLoader` worker threads.
+
+    torchdata.nodes has no public shutdown API; abandoning an iterator
+    mid-epoch can abort the process at interpreter exit ("terminate called
+    without an active exception"). Walking the node graph and calling the
+    private `_shutdown` hooks joins the threads; a later `iter()` on the
+    same loader resets and restarts them, so the loader stays reusable.
+    """
+    root = getattr(getattr(dataloader, "_loader", None), "root", None)
+    stack: list[Any] = [root]
+    seen: set[int] = set()
+    while stack:
+        node = stack.pop()
+        if node is None or id(node) in seen:
+            continue
+        seen.add(id(node))
+        shutdown = getattr(node, "_shutdown", None)
+        if callable(shutdown):
+            shutdown()
+        stack.extend(getattr(node, attr, None) for attr in ("_it", "source", "root"))
+
+
+def _to_device(batch: Any, device: torch.device) -> Any:
+    return tree_map(
+        lambda x: x.to(device, non_blocking=True) if isinstance(x, torch.Tensor) else x,
+        batch,
+    )
+
+
+def iter_policy_tensors(
+    model: ControlTransformer,
+    dataloader: Iterable[dict[str, Any]],
+    device: str | torch.device = "cuda",
+    max_batches: int | None = None,
+) -> Iterator[dict[str, Tensor]]:
+    """Yield per-batch policy tensors for offset diagnostics.
+
+    Yields:
+    - `features`     (b, 1152): policy features, built exactly like
+                     `ControlTransformer.validation_step` (episode_builder +
+                     encoder) followed by `JointPolicyObjective._features`
+    - `code_logits`  (b, 4, 16): per-quantizer code logits
+    - `offsets`      (b, 4, 16, 24): the full per-(quantizer, code) offset table
+    - `chunk`        (b, 6, 4): raw GT action chunk of the last timestep
+    - `target_codes` (b, 4): GT residual-VQ codes, `tokenizer(chunk)`
+    - `target`       (b, 24): normalized GT action vector
+    """
+    device = torch.device(device)
+    policy = cast("JointPolicyObjective", model.objectives["policy"])
+    tokenizer = cast("ActionTokenizer", policy.tokenizer)
+
+    try:
+        with torch.inference_mode():
+            for batch_idx, batch_cpu in enumerate(dataloader):
+                if max_batches is not None and batch_idx >= max_batches:
+                    break
+
+                batch = _to_device(batch_cpu, device)
+                episode = model.episode_builder(batch)
+                embedding = model.encoder(
+                    src=episode.embeddings_flattened, mask=episode.attention_mask
+                )
+
+                features = policy._features(episode, embedding)  # noqa: SLF001
+                code_logits, offsets = policy._heads(features)  # noqa: SLF001
+
+                chunk = episode.get(policy.chunk)[:, -1]  # (b, horizon, fields)
+                target_codes = tokenizer(chunk)
+                target = tokenizer._normalize(chunk.flatten(-2, -1))  # noqa: SLF001
+
+                yield {
+                    "features": features,
+                    "code_logits": code_logits,
+                    "offsets": offsets,
+                    "chunk": chunk,
+                    "target_codes": target_codes,
+                    "target": target,
+                }
+    finally:
+        # join worker threads on early exit (incl. caller break -> GeneratorExit)
+        # so abandoned iterators cannot abort the process at interpreter exit
+        shutdown_dataloader(dataloader)
+
+
+def _smoke(args: argparse.Namespace) -> None:
+    t0 = time.perf_counter()
+    loader = build_dataloader(
+        args.split, batch_size=args.batch_size, num_workers=args.num_workers
+    )
+    t_build = time.perf_counter() - t0
+    n_samples = len(loader.dataset)
+    print(  # noqa: T201
+        f"[offset_diag] split={args.split} dataset built in {t_build:.1f}s: "
+        f"{n_samples} samples, {len(loader)} batches of {args.batch_size}"
+    )
+
+    if args.skip_model:
+        return
+
+    model = load_policy(args.ckpt, args.device)
+    print(f"[offset_diag] model loaded from {args.ckpt} on {args.device}")  # noqa: T201
+
+    t1 = time.perf_counter()
+    n_batches = 0
+    for tensors in iter_policy_tensors(
+        model, loader, device=args.device, max_batches=args.max_batches
+    ):
+        n_batches += 1
+        shapes = {k: tuple(v.shape) for k, v in tensors.items()}
+        checksums = {k: float(v.float().abs().sum()) for k, v in tensors.items()}
+        print(f"[offset_diag] batch {n_batches} shapes: {shapes}")  # noqa: T201
+        print(f"[offset_diag] batch {n_batches} |sum|: {checksums}")  # noqa: T201
+    t_iter = time.perf_counter() - t1
+    print(  # noqa: T201
+        f"[offset_diag] {n_batches} batches in {t_iter:.2f}s "
+        f"({n_batches / t_iter:.2f} batches/s)"
+    )
+
+
+if __name__ == "__main__":
+    import multiprocessing as mp
+
+    mp.set_forkserver_preload(["rbyte", "polars"])
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--split", default="val", choices=["train", "val", "train_debug"]
+    )
+    parser.add_argument("--ckpt", default=str(DEFAULT_CKPT))
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--num-workers", type=int, default=2)
+    parser.add_argument("--max-batches", type=int, default=2)
+    parser.add_argument(
+        "--skip-model", action="store_true", help="only build the dataset cache"
+    )
+    _smoke(parser.parse_args())

--- a/src/rmind/scripts/offset_head_retrain.py
+++ b/src/rmind/scripts/offset_head_retrain.py
@@ -1,0 +1,641 @@
+"""Offset-head-only retraining experiment for the offset-supervision bug.
+
+Isolates the training-signal contamination (offset head supervised at SAMPLED
+codes, brief section 1) on the bugged finetuned checkpoint
+(`artifacts/model-2gqxhjod:v9/model.ckpt`): everything except the offset head
+stays frozen at checkpoint weights, and only the offset head is retrained from
+cached features under the two supervision variants. Because features and code
+logits are fixed, any difference between the variants is attributable to the
+offset supervision alone.
+
+Stages (subcommands):
+
+- `extract`: run the frozen model over a split once (via `offset_diag`) and
+  cache per-sample tensors to disk as `torch.save` shards + `meta.json`:
+  `features` (b, 1152) fp16, `code_logits` (b, 4, 16) fp16, `target_codes`
+  (b, 4) int8, `target` (b, 24) fp32. Refuses to overwrite a non-empty cache.
+
+- `train`: deep-copy the checkpoint's `offset_head` (initialization = the
+  contaminated weights) and retrain it on the cached tensors with
+  `L1(tokenizer.invert(codes) + gather_offset(offsets, codes), target)`,
+  where `codes` are either re-sampled per step from the cached (frozen) code
+  logits' softmax with a seeded generator (`--variant sampled`, mirroring the
+  pre-fix training signal) or the ground-truth codes
+  (`--variant teacher_forced`, mirroring the fix). Code logits are inputs,
+  never trained; the only trainable parameters are the offset head's.
+
+- `eval`: for the checkpoint's own head (`original`) and any retrained heads,
+  on a cached val split: (a) cancellation ratio R per action field with the
+  exact combo scheme of `offset_cancellation_probe`, (b) predicted
+  pedal-conflict rates overall and per entropy quartile with the thresholds
+  of `pedal_conflict_stats` (as `pedal_conflict_probe`), (c) teacher-forced-
+  and sampled-style offset L1 (metrics only), (d) mean |gathered offset| at
+  argmax codes and over the full table. One JSON, all heads side by side.
+
+Usage:
+    uv run python -m rmind.scripts.offset_head_retrain extract \\
+        --split val --out caches/offset_head/val
+    uv run python -m rmind.scripts.offset_head_retrain train \\
+        --cache caches/offset_head/train --variant teacher_forced \\
+        --out heads/teacher_forced.pt
+    uv run python -m rmind.scripts.offset_head_retrain eval \\
+        --cache caches/offset_head/val \\
+        --heads original,heads/sampled.pt,heads/teacher_forced.pt
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import gc
+import json
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+import pytorch_lightning as pl
+import torch
+from einops import rearrange
+from torch.nn import functional as F
+from torch.optim.lr_scheduler import CosineAnnealingLR
+
+from rmind.components.objectives.joint_policy import JointPolicyObjective
+from rmind.scripts.offset_cancellation_probe import (
+    FIELD_NAMES,
+    _aggregate_cancellation,
+    _cancellation_batch,
+    _sample_codes_seeded,
+)
+from rmind.scripts.offset_diag import (
+    DEFAULT_CKPT,
+    EXPECTED_CODEBOOK_SIZE,
+    EXPECTED_NUM_QUANTIZERS,
+    REPO_ROOT,
+    build_dataloader,
+    iter_policy_tensors,
+    load_policy,
+)
+from rmind.scripts.pedal_conflict_probe import BRAKE_DIM, GAS_DIM
+from rmind.scripts.pedal_conflict_probe import summarize as summarize_pedal_conflicts
+from rmind.scripts.pedal_conflict_stats import BRAKE_THRESH, GAS_THRESH
+
+if TYPE_CHECKING:
+    from torch import Tensor
+    from torch.nn import Module
+
+    from rmind.models.action_tokenizer import ActionTokenizer
+
+FEATURE_DIM = 1152
+ACTION_DIM = 24
+N_FIELDS = len(FIELD_NAMES)
+
+CACHE_DTYPES: dict[str, torch.dtype] = {
+    "features": torch.float16,
+    "code_logits": torch.float16,
+    "target_codes": torch.int8,
+    "target": torch.float32,
+}
+CACHE_SHAPES: dict[str, tuple[int, ...]] = {
+    "features": (FEATURE_DIM,),
+    "code_logits": (EXPECTED_NUM_QUANTIZERS, EXPECTED_CODEBOOK_SIZE),
+    "target_codes": (EXPECTED_NUM_QUANTIZERS,),
+    "target": (ACTION_DIM,),
+}
+SHARD_SIZE = 8192
+DEFAULT_TRAIN_MAX_SAMPLES = 150_000
+LOG_EVERY = 200
+DEFAULT_EVAL_OUT = REPO_ROOT / "diag_results" / "offset_head_retrain.json"
+
+_gather_offset = JointPolicyObjective._gather_offset  # noqa: SLF001
+
+
+def _policy_parts(ckpt: str | Path, device: str) -> tuple[ActionTokenizer, Module]:
+    """Checkpoint's frozen tokenizer and offset head; the rest of the model is freed."""
+    model = load_policy(ckpt, device)
+    policy = cast("JointPolicyObjective", model.objectives["policy"])
+    tokenizer = cast("ActionTokenizer", policy.tokenizer)
+    offset_head = policy.offset_head
+    del model, policy  # drop encoder/episode_builder/code_head references
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return tokenizer, offset_head
+
+
+def _rearrange_offsets(flat: Tensor) -> Tensor:
+    """(b, G*C*A) offset-head output -> (b, G, C, A) table."""
+    return rearrange(
+        flat,
+        "b (g c a) -> b g c a",
+        g=EXPECTED_NUM_QUANTIZERS,
+        c=EXPECTED_CODEBOOK_SIZE,
+    )
+
+
+# --- extract ------------------------------------------------------------------
+
+
+def _flush_shard(
+    out_dir: Path, shard_idx: int, buffers: dict[str, list[Tensor]]
+) -> None:
+    shard = {key: torch.cat(parts) for key, parts in buffers.items()}
+    torch.save(shard, out_dir / f"shard_{shard_idx:05d}.pt")
+    for parts in buffers.values():
+        parts.clear()
+
+
+def run_extract(args: argparse.Namespace) -> None:
+    out_dir = Path(args.out)
+    if out_dir.exists() and any(out_dir.iterdir()):
+        msg = (
+            f"{out_dir} already exists and is not empty; refusing to overwrite "
+            f"(delete it or pick a new --out)"
+        )
+        raise SystemExit(msg)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    max_samples: int | None = args.max_samples
+    if max_samples is None and args.split == "train":
+        max_samples = DEFAULT_TRAIN_MAX_SAMPLES
+
+    pl.seed_everything(args.seed, workers=True)
+    loader = build_dataloader(
+        args.split, batch_size=args.batch_size, num_workers=args.num_workers
+    )
+    print(  # noqa: T201
+        f"[extract] split={args.split}: {len(loader.dataset)} samples, "
+        f"{len(loader)} batches of {args.batch_size}; max_samples={max_samples}"
+    )
+    model = load_policy(args.ckpt, args.device)
+
+    buffers: dict[str, list[Tensor]] = {key: [] for key in CACHE_DTYPES}
+    n_total = n_buffered = n_shards = 0
+    t0 = time.perf_counter()
+    for batch_idx, tensors in enumerate(
+        iter_policy_tensors(model, loader, device=args.device)
+    ):
+        batch = {
+            key: tensors[key].to(dtype).cpu() for key, dtype in CACHE_DTYPES.items()
+        }
+        if (
+            max_samples is not None
+            and n_total + batch["features"].shape[0] > max_samples
+        ):
+            keep = max_samples - n_total
+            batch = {key: value[:keep] for key, value in batch.items()}
+        for key, value in batch.items():
+            buffers[key].append(value)
+        n_total += batch["features"].shape[0]
+        n_buffered += batch["features"].shape[0]
+
+        if n_buffered >= SHARD_SIZE:
+            _flush_shard(out_dir, n_shards, buffers)
+            n_shards += 1
+            n_buffered = 0
+
+        if (batch_idx + 1) % 50 == 0:
+            rate = n_total / (time.perf_counter() - t0)
+            print(  # noqa: T201
+                f"[extract] {n_total} samples ({batch_idx + 1} batches, "
+                f"{rate:.1f} samples/s)"
+            )
+
+        if max_samples is not None and n_total >= max_samples:
+            break
+
+    if n_buffered > 0:
+        _flush_shard(out_dir, n_shards, buffers)
+        n_shards += 1
+
+    elapsed = time.perf_counter() - t0
+    meta = {
+        "split": args.split,
+        "ckpt": str(args.ckpt),
+        "seed": args.seed,
+        "batch_size": args.batch_size,
+        "max_samples": max_samples,
+        "n_samples": n_total,
+        "n_shards": n_shards,
+        "fields": {key: str(dtype) for key, dtype in CACHE_DTYPES.items()},
+    }
+    (out_dir / "meta.json").write_text(
+        json.dumps(meta, indent=2) + "\n", encoding="utf-8"
+    )
+    print(  # noqa: T201
+        f"[extract] done: {n_total} samples in {n_shards} shards -> {out_dir} "
+        f"({elapsed:.1f}s, {n_total / elapsed:.1f} samples/s)"
+    )
+
+
+# --- cache loading ------------------------------------------------------------
+
+
+def _load_cache(cache_dir: Path) -> tuple[dict[str, Tensor], dict[str, Any]]:
+    meta = json.loads((cache_dir / "meta.json").read_text(encoding="utf-8"))
+    shard_paths = sorted(cache_dir.glob("shard_*.pt"))
+    if not shard_paths:
+        msg = f"no shards found in {cache_dir}"
+        raise SystemExit(msg)
+    shards = [
+        torch.load(path, map_location="cpu", weights_only=True) for path in shard_paths
+    ]
+    data = {key: torch.cat([shard[key] for shard in shards]) for key in CACHE_DTYPES}
+
+    n = data["features"].shape[0]
+    if n != meta["n_samples"]:
+        msg = (
+            f"cache {cache_dir}: meta says {meta['n_samples']} samples, shards have {n}"
+        )
+        raise SystemExit(msg)
+    for key, trailing in CACHE_SHAPES.items():
+        if tuple(data[key].shape) != (n, *trailing):
+            msg = f"cache {cache_dir}: {key} has shape {tuple(data[key].shape)}, expected {(n, *trailing)}"
+            raise SystemExit(msg)
+    return data, meta
+
+
+# --- train --------------------------------------------------------------------
+
+
+def _check_only_head_trainable(
+    head: Module, tokenizer: Module, data: dict[str, Tensor]
+) -> int:
+    """The only trainable params are the offset head's; cached inputs carry no grad.
+
+    Raises:
+        RuntimeError: if the offset head is not fully trainable, the tokenizer
+            is not frozen, or any cached tensor (incl. `code_logits`, which are
+            frozen inputs by construction) requires grad.
+    """
+    head_params = list(head.parameters())
+    if not head_params or not all(p.requires_grad for p in head_params):
+        msg = "offset head parameters must all be trainable"
+        raise RuntimeError(msg)
+    if any(p.requires_grad for p in tokenizer.parameters()):
+        msg = "tokenizer parameters must stay frozen"
+        raise RuntimeError(msg)
+    if any(value.requires_grad for value in data.values()):
+        msg = "cached tensors (incl. code_logits) must not require grad"
+        raise RuntimeError(msg)
+    return sum(p.numel() for p in head_params)
+
+
+def run_train(args: argparse.Namespace) -> None:  # noqa: PLR0914
+    pl.seed_everything(args.seed, workers=True)
+    device = torch.device(args.device)
+    data, meta = _load_cache(Path(args.cache))
+    n = data["features"].shape[0]
+
+    tokenizer, head_src = _policy_parts(args.ckpt, args.device)
+    # initialization = the checkpoint's contaminated offset-head weights
+    head = copy.deepcopy(head_src).to(device).float()
+    head.requires_grad_(requires_grad=True)
+    head.train()
+    n_trainable = _check_only_head_trainable(head, tokenizer, data)
+    print(  # noqa: T201
+        f"[train] variant={args.variant}: {n} cached samples "
+        f"(split={meta['split']}), {n_trainable} trainable offset-head params; "
+        f"code logits are frozen cache inputs"
+    )
+
+    optimizer = torch.optim.Adam(head.parameters(), lr=args.lr)
+    scheduler = (
+        CosineAnnealingLR(optimizer, T_max=args.steps)
+        if args.lr_schedule == "cosine"
+        else None
+    )
+    # CPU generator drives both batch indices and (sampled variant) multinomial
+    generator = torch.Generator().manual_seed(args.seed)
+
+    loss_history: list[dict[str, float]] = []
+    t0 = time.perf_counter()
+    for step in range(1, args.steps + 1):
+        index = torch.randint(0, n, (args.batch_size,), generator=generator)
+        features = data["features"][index].to(device).float()
+        target = data["target"][index].to(device)
+        if args.variant == "sampled":
+            # re-sample codes from the frozen cached logits each step: the
+            # pre-fix training signal (code independent of the GT action)
+            codes = _sample_codes_seeded(
+                data["code_logits"][index].float(), generator
+            ).to(device)
+        else:
+            codes = data["target_codes"][index].long().to(device)
+
+        with torch.no_grad():
+            decoded = tokenizer.invert(codes)
+
+        offsets = _rearrange_offsets(head(features))
+        loss = F.l1_loss(decoded + _gather_offset(offsets, codes), target)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+        if scheduler is not None:
+            scheduler.step()
+
+        if step == 1 or step % LOG_EVERY == 0 or step == args.steps:
+            lr = optimizer.param_groups[0]["lr"]
+            rate = step / (time.perf_counter() - t0)
+            loss_value = float(loss.detach())
+            loss_history.append({"step": step, "loss": loss_value, "lr": lr})
+            print(  # noqa: T201
+                f"[train] step {step}/{args.steps} loss={loss_value:.5f} "
+                f"lr={lr:.2e} ({rate:.2f} steps/s)"
+            )
+
+    config = {
+        "variant": args.variant,
+        "steps": args.steps,
+        "batch_size": args.batch_size,
+        "lr": args.lr,
+        "lr_schedule": args.lr_schedule,
+        "seed": args.seed,
+        "cache": str(args.cache),
+        "cache_meta": meta,
+        "ckpt": str(args.ckpt),
+        "n_trainable_params": n_trainable,
+        "first_loss": loss_history[0]["loss"],
+        "final_loss": loss_history[-1]["loss"],
+        "loss_history": loss_history,
+    }
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    state_dict = {key: value.detach().cpu() for key, value in head.state_dict().items()}
+    torch.save({"state_dict": state_dict, "config": config}, out)
+    sidecar = out.with_suffix(".json")
+    sidecar.write_text(json.dumps(config, indent=2) + "\n", encoding="utf-8")
+    print(f"[train] saved retrained offset head -> {out} (config: {sidecar})")  # noqa: T201
+
+
+# --- eval ---------------------------------------------------------------------
+
+
+def _build_heads(
+    specs: str, template: Module
+) -> dict[str, tuple[Module, dict[str, Any] | None]]:
+    """Parse --heads: 'original' and/or paths to retrained-head .pt files.
+
+    Raises:
+        SystemExit: on duplicate head names or an empty --heads value.
+    """
+    heads: dict[str, tuple[Module, dict[str, Any] | None]] = {}
+    for raw in specs.split(","):
+        spec = raw.strip()
+        if not spec:
+            continue
+        head = copy.deepcopy(template)
+        if spec == "original":
+            name, config = "original", None
+        else:
+            path = Path(spec)
+            payload = torch.load(path, map_location="cpu", weights_only=True)
+            head.load_state_dict(payload["state_dict"])
+            name, config = path.stem, payload.get("config")
+        if name in heads:
+            msg = f"duplicate head name {name!r} in --heads"
+            raise SystemExit(msg)
+        heads[name] = (head, config)
+    if not heads:
+        msg = "--heads resolved to no heads"
+        raise SystemExit(msg)
+    return heads
+
+
+def _eval_head(  # noqa: PLR0913, PLR0914, PLR0917
+    head: Module,
+    tokenizer: ActionTokenizer,
+    data: dict[str, Tensor],
+    device: torch.device,
+    batch_size: int,
+    seed: int,
+) -> dict[str, Any]:
+    n = data["features"].shape[0]
+    # fresh seeded generator per head -> identical sampled codes across heads
+    generator = torch.Generator().manual_seed(seed)
+
+    ratios: list[Tensor] = []
+    entropies: list[Tensor] = []
+    pred_conflicts: list[Tensor] = []
+    gt_conflicts: list[Tensor] = []
+    tf_l1: list[Tensor] = []
+    sampled_l1: list[Tensor] = []
+    abs_argmax_sum = abs_table_sum = 0.0
+    abs_argmax_numel = abs_table_numel = 0
+
+    with torch.inference_mode():
+        for start in range(0, n, batch_size):
+            stop = min(start + batch_size, n)
+            features = data["features"][start:stop].to(device).float()
+            code_logits = data["code_logits"][start:stop].to(device).float()
+            target_codes = data["target_codes"][start:stop].long().to(device)
+            target = data["target"][start:stop].to(device)
+
+            offsets = _rearrange_offsets(head(features))
+
+            # (a) cancellation ratio, same combo scheme as offset_cancellation_probe
+            ratio, entropy = _cancellation_batch(tokenizer, code_logits, offsets)
+            ratios.append(ratio.cpu())
+            entropies.append(entropy.cpu())
+
+            # (b) pedal conflicts at argmax (export-time) decoding
+            argmax_codes = code_logits.argmax(dim=-1)
+            offset_argmax = _gather_offset(offsets, argmax_codes)
+            pred = (tokenizer.invert(argmax_codes) + offset_argmax).unflatten(
+                -1, (-1, N_FIELDS)
+            )
+            gt = target.unflatten(-1, (-1, N_FIELDS))
+            pred_conflicts.append(
+                (
+                    (pred[..., GAS_DIM] > GAS_THRESH)
+                    & (pred[..., BRAKE_DIM] > BRAKE_THRESH)
+                ).cpu()
+            )
+            gt_conflicts.append(
+                (
+                    (gt[..., GAS_DIM] > GAS_THRESH)
+                    & (gt[..., BRAKE_DIM] > BRAKE_THRESH)
+                ).cpu()
+            )
+
+            # (c) offset L1 under both supervision styles (metrics only)
+            tf_pred = tokenizer.invert(target_codes) + _gather_offset(
+                offsets, target_codes
+            )
+            tf_l1.append((tf_pred - target).abs().mean(dim=-1).cpu())
+            sampled_codes = _sample_codes_seeded(code_logits, generator)
+            sampled_pred = tokenizer.invert(sampled_codes) + _gather_offset(
+                offsets, sampled_codes
+            )
+            sampled_l1.append((sampled_pred - target).abs().mean(dim=-1).cpu())
+
+            # (d) offset magnitudes
+            abs_argmax_sum += float(offset_argmax.abs().sum())
+            abs_argmax_numel += offset_argmax.numel()
+            abs_table_sum += float(offsets.abs().sum())
+            abs_table_numel += offsets.numel()
+
+    entropy_q0 = torch.cat(entropies)
+    return {
+        "cancellation": _aggregate_cancellation(torch.cat(ratios), entropy_q0),
+        "pedal_conflict": summarize_pedal_conflicts({
+            "pred_conflict": torch.cat(pred_conflicts),
+            "gt_conflict": torch.cat(gt_conflicts),
+            "entropy_q0": entropy_q0,
+        }),
+        "offset_l1": {
+            "teacher_forced_style": float(torch.cat(tf_l1).mean()),
+            "sampled_style": float(torch.cat(sampled_l1).mean()),
+        },
+        "offset_magnitude": {
+            "mean_abs_at_argmax": abs_argmax_sum / abs_argmax_numel,
+            "mean_abs_full_table": abs_table_sum / abs_table_numel,
+        },
+    }
+
+
+def _fmt(value: float | None) -> str:
+    return "nan" if value is None else f"{value:.4f}"
+
+
+def run_eval(args: argparse.Namespace) -> None:
+    pl.seed_everything(args.seed, workers=True)
+    device = torch.device(args.device)
+    data, meta = _load_cache(Path(args.cache))
+    tokenizer, template = _policy_parts(args.ckpt, args.device)
+    heads = _build_heads(args.heads, template)
+    print(  # noqa: T201
+        f"[eval] {data['features'].shape[0]} cached samples "
+        f"(split={meta['split']}), heads: {list(heads)}"
+    )
+
+    results: dict[str, Any] = {
+        "config": {
+            "ckpt": str(args.ckpt),
+            "cache": str(args.cache),
+            "cache_meta": meta,
+            "batch_size": args.batch_size,
+            "seed": args.seed,
+            "decoding": (
+                "argmax (export parity) for cancellation/conflict; sampled-style "
+                "L1 uses seeded multinomial over cached code logits"
+            ),
+            "thresholds": {"gas": GAS_THRESH, "brake": BRAKE_THRESH},
+        },
+        "heads": {},
+    }
+    for name, (head, train_config) in heads.items():
+        head.to(device).float().eval()
+        t0 = time.perf_counter()
+        entry = _eval_head(head, tokenizer, data, device, args.batch_size, args.seed)
+        if train_config is not None:
+            entry["train_config"] = {
+                key: value
+                for key, value in train_config.items()
+                if key != "loss_history"
+            }
+        results["heads"][name] = entry
+
+        per_field = entry["cancellation"]["overall"]["per_field"]
+        print(  # noqa: T201
+            f"[eval] {name}: R_median gas={_fmt(per_field['gas_pedal']['median_R'])} "
+            f"brake={_fmt(per_field['brake_pedal']['median_R'])} "
+            f"steer={_fmt(per_field['steering_angle']['median_R'])} | "
+            f"pred_frame_conflict_rate="
+            f"{entry['pedal_conflict']['predicted']['frame_conflict_rate']:.5f} | "
+            f"L1 tf={entry['offset_l1']['teacher_forced_style']:.5f} "
+            f"sampled={entry['offset_l1']['sampled_style']:.5f} "
+            f"({time.perf_counter() - t0:.1f}s)"
+        )
+
+    out = Path(args.out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    print(f"[eval] results written to {out}")  # noqa: T201
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="offset_head_retrain",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    subparsers = parser.add_subparsers(dest="stage", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--ckpt", default=str(DEFAULT_CKPT))
+    common.add_argument("--device", default="cuda")
+    common.add_argument("--seed", type=int, default=42)
+
+    extract = subparsers.add_parser(
+        "extract", parents=[common], help="cache per-sample policy tensors to disk"
+    )
+    extract.add_argument("--split", required=True, choices=["train", "val"])
+    extract.add_argument(
+        "--max-samples",
+        type=int,
+        default=None,
+        help="cap on cached samples (default: 150000 for train, full split for val)",
+    )
+    extract.add_argument(
+        "--out", required=True, help="cache directory (refused if non-empty)"
+    )
+    extract.add_argument("--batch-size", type=int, default=48)
+    extract.add_argument("--num-workers", type=int, default=3)
+    extract.set_defaults(func=run_extract)
+
+    train = subparsers.add_parser(
+        "train",
+        parents=[common],
+        help="retrain a copy of the checkpoint's offset head on cached tensors",
+    )
+    train.add_argument("--cache", required=True, help="extract-stage cache directory")
+    train.add_argument(
+        "--variant", required=True, choices=["sampled", "teacher_forced"]
+    )
+    train.add_argument("--steps", type=int, default=6000)
+    train.add_argument("--batch-size", type=int, default=4096)
+    train.add_argument("--lr", type=float, default=1e-4)
+    train.add_argument(
+        "--lr-schedule", default="cosine", choices=["cosine", "constant"]
+    )
+    train.add_argument("--out", required=True, help="output .pt for the retrained head")
+    train.set_defaults(func=run_train)
+
+    evaluate = subparsers.add_parser(
+        "eval",
+        parents=[common],
+        help="compare offset heads side by side on a cached val split",
+    )
+    evaluate.add_argument(
+        "--cache", required=True, help="extract-stage VAL cache directory"
+    )
+    evaluate.add_argument(
+        "--heads",
+        required=True,
+        help="comma-separated: 'original' and/or retrained-head .pt paths",
+    )
+    evaluate.add_argument("--batch-size", type=int, default=512)
+    evaluate.add_argument("--out", default=str(DEFAULT_EVAL_OUT))
+    evaluate.set_defaults(func=run_eval)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    import multiprocessing as mp
+    import os
+    import sys
+
+    mp.set_forkserver_preload(["rbyte", "polars"])
+    main()
+
+    # same rationale as offset_cancellation_probe: torchdata.nodes worker-thread
+    # teardown intermittently aborts at interpreter exit; all outputs are
+    # flushed by now, so skip interpreter teardown entirely
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(0)

--- a/src/rmind/scripts/pedal_conflict_probe.py
+++ b/src/rmind/scripts/pedal_conflict_probe.py
@@ -1,0 +1,309 @@
+"""Model-side pedal-conflict probe (brief 1c) for the offset-supervision bug.
+
+Runs the finetuned `ControlTransformer` over the val split with export-time
+decoding (`sample_codes=False`, argmax) and measures how often the predicted
+action chunks command gas and brake simultaneously, using the exact sensor-side
+thresholds from `rmind.scripts.pedal_conflict_stats`. Ground-truth conflict
+rates are computed on the same frames in the same pass (the within-dataset
+floor). Rates are bucketed by the entropy of the primary-quantizer (q=0) code
+logits: the offset-cancellation mechanism predicts conflicts concentrated in
+high-entropy states.
+
+Before comparing, the probe verifies that the tokenizer's input transform for
+the pedal fields is `Identity`, i.e. predictions live in the same [0, 1]
+normalized pedal space as the raw sensor fields the thresholds were derived in.
+
+Usage:
+    uv run python -m rmind.scripts.pedal_conflict_probe --split val --max-batches 3 --no-wandb
+    uv run python -m rmind.scripts.pedal_conflict_probe --split val --wandb
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from typing import TYPE_CHECKING, Any, cast
+
+import torch
+
+from rmind.scripts.offset_diag import (
+    DEFAULT_CKPT,
+    REPO_ROOT,
+    build_dataloader,
+    iter_policy_tensors,
+    load_policy,
+)
+from rmind.scripts.pedal_conflict_stats import BRAKE_THRESH, GAS_THRESH
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from torch import Tensor
+
+    from rmind.components.containers import ModuleDict
+    from rmind.components.objectives.joint_policy import JointPolicyObjective
+    from rmind.models.action_tokenizer import ActionTokenizer
+    from rmind.models.control_transformer import ControlTransformer
+
+GAS_DIM = 0  # action-chunk field order: gas, brake, steering, turn_signal
+BRAKE_DIM = 1
+N_BUCKETS = 4
+
+DEFAULT_OUT = REPO_ROOT / "diag_results" / "pedal_conflict_model.json"
+
+
+def check_pedal_normalization(
+    tokenizer: ActionTokenizer, device: torch.device
+) -> dict[str, Any]:
+    """Confirm predictions share the sensor fields' normalized pedal space.
+
+    The thresholds from `pedal_conflict_stats` are defined on the raw
+    `*_pedal_normalized` sensor fields. The model reconstructs
+    `tokenizer._normalize(chunk)`, so the two are comparable iff the
+    tokenizer's per-field input transform is `Identity` on the pedal dims.
+    Checked structurally (transform module types) and numerically
+    (`_normalize` round-trip on a random chunk).
+
+    Raises:
+        TypeError: if a pedal field's transform is not `torch.nn.Identity`.
+        ValueError: if `_normalize` changes the pedal dims numerically.
+    """
+    norm = cast("ModuleDict", tokenizer.input_transform[-1])
+    transforms = {
+        field: norm.get_deepest(("continuous", field))
+        for field in ("gas_pedal", "brake_pedal")
+    }
+    for field, module in transforms.items():
+        if not isinstance(module, torch.nn.Identity):
+            msg = (
+                f"tokenizer input_transform for {field} is "
+                f"{type(module).__name__}, expected Identity: predictions are "
+                f"not in raw sensor pedal space, thresholds do not transfer"
+            )
+            raise TypeError(msg)
+
+    probe = torch.rand(8, 6, 4, device=device)
+    normalized = tokenizer._normalize(probe.flatten(-2, -1)).unflatten(  # noqa: SLF001
+        -1, (-1, 4)
+    )
+    max_abs_err = float(
+        (normalized[..., [GAS_DIM, BRAKE_DIM]] - probe[..., [GAS_DIM, BRAKE_DIM]])
+        .abs()
+        .max()
+    )
+    if max_abs_err > 0.0:
+        msg = f"_normalize changed pedal dims (max abs err {max_abs_err})"
+        raise ValueError(msg)
+
+    return {
+        "gas_transform": type(transforms["gas_pedal"]).__name__,
+        "brake_transform": type(transforms["brake_pedal"]).__name__,
+        "normalize_pedal_max_abs_err": max_abs_err,
+        "pedal_space": "identity: normalized == raw sensor [0, 1]",
+    }
+
+
+def collect(
+    model: ControlTransformer,
+    dataloader: Any,
+    device: str | torch.device,
+    max_batches: int | None,
+) -> dict[str, Tensor]:
+    """Run the model over the split; return per-sample conflict masks and entropy.
+
+    Returns CPU tensors: `pred_conflict` (n, horizon) bool, `gt_conflict`
+    (n, horizon) bool, `entropy_q0` (n,) float (nats, over softmax of the
+    q=0 code logits).
+
+    Raises:
+        RuntimeError: if the policy objective is not in argmax decoding mode.
+    """
+    policy = cast("JointPolicyObjective", model.objectives["policy"])
+    tokenizer = cast("ActionTokenizer", policy.tokenizer)
+    if policy.sample_codes:
+        msg = "policy.sample_codes must be False (export-time argmax decoding)"
+        raise RuntimeError(msg)
+
+    pred_conflicts: list[Tensor] = []
+    gt_conflicts: list[Tensor] = []
+    entropies: list[Tensor] = []
+
+    t0 = time.perf_counter()
+    for batch_idx, tensors in enumerate(
+        iter_policy_tensors(model, dataloader, device=device, max_batches=max_batches)
+    ):
+        code_logits = tensors["code_logits"]  # (b, g, c)
+        codes = policy._sample_codes(code_logits)  # noqa: SLF001  # argmax
+        offset = policy._gather_offset(tensors["offsets"], codes)  # noqa: SLF001
+        pred = (tokenizer.invert(codes) + offset).unflatten(-1, (-1, 4))  # (b, 6, 4)
+        gt = tensors["target"].unflatten(-1, (-1, 4))  # (b, 6, 4), normalized GT
+
+        pred_conflicts.append(
+            (
+                (pred[..., GAS_DIM] > GAS_THRESH)
+                & (pred[..., BRAKE_DIM] > BRAKE_THRESH)
+            ).cpu()
+        )
+        gt_conflicts.append(
+            (
+                (gt[..., GAS_DIM] > GAS_THRESH) & (gt[..., BRAKE_DIM] > BRAKE_THRESH)
+            ).cpu()
+        )
+
+        probs = code_logits[:, 0, :].softmax(dim=-1)
+        entropies.append(-(probs * probs.clamp_min(1e-12).log()).sum(dim=-1).cpu())
+
+        if (batch_idx + 1) % 50 == 0:
+            rate = (batch_idx + 1) / (time.perf_counter() - t0)
+            print(  # noqa: T201
+                f"[pedal_conflict_probe] {batch_idx + 1} batches ({rate:.2f}/s)"
+            )
+
+    return {
+        "pred_conflict": torch.cat(pred_conflicts),
+        "gt_conflict": torch.cat(gt_conflicts),
+        "entropy_q0": torch.cat(entropies),
+    }
+
+
+def _conflict_stats(conflict: Tensor) -> dict[str, Any]:
+    """Frame-level and sample-level (any-frame) conflict rates for a (n, h) mask."""
+    return {
+        "n_samples": int(conflict.shape[0]),
+        "n_frames": int(conflict.numel()),
+        "conflict_frames": int(conflict.sum()),
+        "frame_conflict_rate": float(conflict.float().mean()),
+        "conflict_samples": int(conflict.any(dim=-1).sum()),
+        "sample_any_frame_rate": float(conflict.any(dim=-1).float().mean()),
+    }
+
+
+def summarize(collected: dict[str, Tensor]) -> dict[str, Any]:
+    """Aggregate collected masks into overall and entropy-quartile-bucketed rates."""
+    entropy = collected["entropy_q0"]
+    edges = torch.quantile(entropy, torch.tensor([0.25, 0.5, 0.75]))
+    bucket_ids = torch.bucketize(entropy, edges)
+
+    def bucketed(conflict: Tensor) -> list[dict[str, Any]]:
+        buckets = []
+        for b in range(N_BUCKETS):
+            mask = bucket_ids == b
+            buckets.append({
+                "bucket": b,
+                "entropy_mean_nats": float(entropy[mask].mean()),
+                **_conflict_stats(conflict[mask]),
+            })
+        return buckets
+
+    pred = _conflict_stats(collected["pred_conflict"])
+    gt = _conflict_stats(collected["gt_conflict"])
+    gt_floor = gt["frame_conflict_rate"]
+    return {
+        "entropy_q0_quartile_edges_nats": [float(e) for e in edges],
+        "entropy_q0_mean_nats": float(entropy.mean()),
+        "predicted": {**pred, "buckets": bucketed(collected["pred_conflict"])},
+        "ground_truth": {**gt, "buckets": bucketed(collected["gt_conflict"])},
+        "predicted_over_gt_frame_rate": (
+            pred["frame_conflict_rate"] / gt_floor if gt_floor > 0 else None
+        ),
+    }
+
+
+def _log_wandb(results: dict[str, Any], out_path: Path) -> str:
+    import wandb  # noqa: PLC0415
+
+    run = wandb.init(
+        entity="yaak",
+        project="rmind",
+        name="diag-pedal-conflict",
+        tags=["diag/joint_policy_offset_bug"],
+        dir=str(REPO_ROOT / "wandb_logs"),
+        config={
+            k: results[k]
+            for k in ("ckpt", "split", "decoding", "thresholds", "normalization_check")
+        },
+    )
+    flat: dict[str, float] = {}
+    for side in ("predicted", "ground_truth"):
+        stats = results[side]
+        flat[f"{side}/frame_conflict_rate"] = stats["frame_conflict_rate"]
+        flat[f"{side}/sample_any_frame_rate"] = stats["sample_any_frame_rate"]
+        for bucket in stats["buckets"]:
+            b = bucket["bucket"]
+            flat[f"{side}/frame_conflict_rate/entropy_q{b}"] = bucket[
+                "frame_conflict_rate"
+            ]
+            flat[f"{side}/sample_any_frame_rate/entropy_q{b}"] = bucket[
+                "sample_any_frame_rate"
+            ]
+    run.log(flat)
+    run.summary["results"] = results
+    run.save(str(out_path), base_path=str(out_path.parent), policy="now")
+    url = run.url
+    run.finish()
+    return url
+
+
+def main(args: argparse.Namespace) -> None:
+    model = load_policy(args.ckpt, args.device)
+    policy = cast("JointPolicyObjective", model.objectives["policy"])
+    tokenizer = cast("ActionTokenizer", policy.tokenizer)
+
+    normalization_check = check_pedal_normalization(
+        tokenizer, torch.device(args.device)
+    )
+    print(f"[pedal_conflict_probe] normalization check: {normalization_check}")  # noqa: T201
+
+    loader = build_dataloader(
+        args.split,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        shuffle=False,
+    )
+    print(  # noqa: T201
+        f"[pedal_conflict_probe] split={args.split}: {len(loader.dataset)} samples, "
+        f"{len(loader)} batches of {args.batch_size}"
+        + (f" (capped at {args.max_batches})" if args.max_batches else "")
+    )
+
+    collected = collect(model, loader, args.device, args.max_batches)
+    results: dict[str, Any] = {
+        "ckpt": str(args.ckpt),
+        "split": args.split,
+        "decoding": "argmax (sample_codes=False, export parity)",
+        "thresholds": {"gas": GAS_THRESH, "brake": BRAKE_THRESH},
+        "normalization_check": normalization_check,
+        **summarize(collected),
+    }
+
+    out_path = args.out.resolve()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    print(f"[pedal_conflict_probe] results written to {out_path}")  # noqa: T201
+
+    if args.wandb:
+        url = _log_wandb(results, out_path)
+        print(f"[pedal_conflict_probe] wandb run: {url}")  # noqa: T201
+
+    print(json.dumps(results, indent=2))  # noqa: T201
+
+
+if __name__ == "__main__":
+    import multiprocessing as mp
+    from pathlib import Path as _Path
+
+    mp.set_forkserver_preload(["rbyte", "polars"])
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", type=_Path, default=DEFAULT_CKPT)
+    parser.add_argument(
+        "--split", default="val", choices=["train", "val", "train_debug"]
+    )
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--batch-size", type=int, default=32)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--max-batches", type=int, default=None)
+    parser.add_argument("--wandb", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--out", type=_Path, default=DEFAULT_OUT)
+    main(parser.parse_args())

--- a/src/rmind/scripts/pedal_conflict_probe.py
+++ b/src/rmind/scripts/pedal_conflict_probe.py
@@ -128,6 +128,7 @@ def collect(
     pred_conflicts: list[Tensor] = []
     gt_conflicts: list[Tensor] = []
     entropies: list[Tensor] = []
+    pedal_values: list[Tensor] = []  # (b, h, 4): pred gas/brake, gt gas/brake
 
     t0 = time.perf_counter()
     for batch_idx, tensors in enumerate(
@@ -150,6 +151,17 @@ def collect(
                 (gt[..., GAS_DIM] > GAS_THRESH) & (gt[..., BRAKE_DIM] > BRAKE_THRESH)
             ).cpu()
         )
+        pedal_values.append(
+            torch.stack(
+                [
+                    pred[..., GAS_DIM],
+                    pred[..., BRAKE_DIM],
+                    gt[..., GAS_DIM],
+                    gt[..., BRAKE_DIM],
+                ],
+                dim=-1,
+            ).cpu()
+        )
 
         probs = code_logits[:, 0, :].softmax(dim=-1)
         entropies.append(-(probs * probs.clamp_min(1e-12).log()).sum(dim=-1).cpu())
@@ -164,6 +176,7 @@ def collect(
         "pred_conflict": torch.cat(pred_conflicts),
         "gt_conflict": torch.cat(gt_conflicts),
         "entropy_q0": torch.cat(entropies),
+        "pedal_values": torch.cat(pedal_values),
     }
 
 
@@ -199,6 +212,32 @@ def summarize(collected: dict[str, Tensor]) -> dict[str, Any]:
     pred = _conflict_stats(collected["pred_conflict"])
     gt = _conflict_stats(collected["gt_conflict"])
     gt_floor = gt["frame_conflict_rate"]
+
+    # pedal activation rates + multi-threshold conflicts from raw values:
+    # a median-collapsed head suppresses minority-mode activations, so the
+    # predicted gas-activation rate falling below GT is the lock-in signature
+    vals = collected["pedal_values"]  # (n, h, 4): pred gas/brake, gt gas/brake
+    activation: dict[str, Any] = {}
+    for side, (gi, bi) in {"predicted": (0, 1), "ground_truth": (2, 3)}.items():
+        act = {}
+        for tname, (tg, tb) in {
+            "sensor": (GAS_THRESH, BRAKE_THRESH),
+            "t02": (0.02, 0.02),
+            "t05": (0.05, 0.05),
+        }.items():
+            gas_on = vals[..., gi] > tg
+            brake_on = vals[..., bi] > tb
+            act[tname] = {
+                "gas_frame_rate": float(gas_on.float().mean()),
+                "brake_frame_rate": float(brake_on.float().mean()),
+                "gas_rate_by_entropy_bucket": [
+                    float(gas_on[bucket_ids == b].float().mean())
+                    for b in range(N_BUCKETS)
+                ],
+                "conflict_frame_rate": float((gas_on & brake_on).float().mean()),
+            }
+        activation[side] = act
+
     return {
         "entropy_q0_quartile_edges_nats": [float(e) for e in edges],
         "entropy_q0_mean_nats": float(entropy.mean()),
@@ -207,6 +246,7 @@ def summarize(collected: dict[str, Tensor]) -> dict[str, Any]:
         "predicted_over_gt_frame_rate": (
             pred["frame_conflict_rate"] / gt_floor if gt_floor > 0 else None
         ),
+        "activation": activation,
     }
 
 

--- a/src/rmind/scripts/pedal_conflict_probe.py
+++ b/src/rmind/scripts/pedal_conflict_probe.py
@@ -109,21 +109,20 @@ def collect(
     dataloader: Any,
     device: str | torch.device,
     max_batches: int | None,
+    *,
+    decoding: str = "argmax",
 ) -> dict[str, Tensor]:
     """Run the model over the split; return per-sample conflict masks and entropy.
 
     Returns CPU tensors: `pred_conflict` (n, horizon) bool, `gt_conflict`
     (n, horizon) bool, `entropy_q0` (n,) float (nats, over softmax of the
     q=0 code logits).
-
-    Raises:
-        RuntimeError: if the policy objective is not in argmax decoding mode.
     """
     policy = cast("JointPolicyObjective", model.objectives["policy"])
     tokenizer = cast("ActionTokenizer", policy.tokenizer)
-    if policy.sample_codes:
-        msg = "policy.sample_codes must be False (export-time argmax decoding)"
-        raise RuntimeError(msg)
+    # load_policy forces sample_codes=False; for the sampled-decoding variant we
+    # re-enable it here (seeded by the caller) to measure stochastic deployment
+    policy.sample_codes = decoding == "sampled"
 
     pred_conflicts: list[Tensor] = []
     gt_conflicts: list[Tensor] = []
@@ -135,7 +134,7 @@ def collect(
         iter_policy_tensors(model, dataloader, device=device, max_batches=max_batches)
     ):
         code_logits = tensors["code_logits"]  # (b, g, c)
-        codes = policy._sample_codes(code_logits)  # noqa: SLF001  # argmax
+        codes = policy._sample_codes(code_logits)  # noqa: SLF001  # per decoding mode
         offset = policy._gather_offset(tensors["offsets"], codes)  # noqa: SLF001
         pred = (tokenizer.invert(codes) + offset).unflatten(-1, (-1, 4))  # (b, 6, 4)
         gt = tensors["target"].unflatten(-1, (-1, 4))  # (b, 6, 4), normalized GT
@@ -286,6 +285,7 @@ def _log_wandb(results: dict[str, Any], out_path: Path) -> str:
 
 
 def main(args: argparse.Namespace) -> None:
+    torch.manual_seed(args.seed)
     model = load_policy(args.ckpt, args.device)
     policy = cast("JointPolicyObjective", model.objectives["policy"])
     tokenizer = cast("ActionTokenizer", policy.tokenizer)
@@ -307,11 +307,14 @@ def main(args: argparse.Namespace) -> None:
         + (f" (capped at {args.max_batches})" if args.max_batches else "")
     )
 
-    collected = collect(model, loader, args.device, args.max_batches)
+    collected = collect(
+        model, loader, args.device, args.max_batches, decoding=args.decoding
+    )
     results: dict[str, Any] = {
         "ckpt": str(args.ckpt),
         "split": args.split,
-        "decoding": "argmax (sample_codes=False, export parity)",
+        "decoding": args.decoding,
+        "seed": args.seed,
         "thresholds": {"gas": GAS_THRESH, "brake": BRAKE_THRESH},
         "normalization_check": normalization_check,
         **summarize(collected),
@@ -341,6 +344,8 @@ if __name__ == "__main__":
         "--split", default="val", choices=["train", "val", "train_debug"]
     )
     parser.add_argument("--device", default="cuda")
+    parser.add_argument("--decoding", choices=["argmax", "sampled"], default="argmax")
+    parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--batch-size", type=int, default=32)
     parser.add_argument("--num-workers", type=int, default=4)
     parser.add_argument("--max-batches", type=int, default=None)

--- a/src/rmind/scripts/pedal_conflict_stats.py
+++ b/src/rmind/scripts/pedal_conflict_stats.py
@@ -33,7 +33,7 @@ from rbyte.io import YaakMetadataDataFrameBuilder
 from rbyte.io.yaak.proto import can_pb2, sensor_pb2
 
 DATA_ROOT = Path("/nasa/drives/yaak/data")
-CONFIG_ROOT = Path(__file__).parents[4] / "rmind-main/config/_templates/dataset/yaak"
+CONFIG_ROOT = Path(__file__).parents[3] / "config/_templates/dataset/yaak"
 
 # One quantisation step above zero — matches existing idle-filter thresholds
 GAS_THRESH: float = 1.0 / 255 + 0.001  # ≈ 0.0049
@@ -199,14 +199,22 @@ def main(splits: dict[str, list[str]], workers: int = 8) -> None:
         n_drives = s.height
         n_conflict_drives = int(s["has_conflict"].sum())
         total_frames = int(s["frames"].sum())
-        int(s["conflict_frames"].sum())
+        conflict_frames = int(s["conflict_frames"].sum())
         total_ep = int(s["estimated_episodes"].sum())
-        int(s["estimated_conflict_episodes"].sum())
+        conflict_ep = int(s["estimated_conflict_episodes"].sum())
 
         print(f"\n[{split}]")  # noqa: T201
         print(f"  Drives with any conflict : {n_conflict_drives:>5} / {n_drives}")  # noqa: T201
         print(f"  Frames (quality-filtered): {total_frames:>10,}")  # noqa: T201
+        print(  # noqa: T201
+            f"  Conflict frames          : {conflict_frames:>10,}"
+            f"  ({conflict_frames / total_frames if total_frames else 0.0:.4%})"
+        )
         print(f"  Estimated episodes       : {total_ep:>10,}")  # noqa: T201
+        print(  # noqa: T201
+            f"  Conflict episodes        : {conflict_ep:>10,}"
+            f"  ({conflict_ep / total_ep if total_ep else 0.0:.4%})"
+        )
 
     print(f"\n{'Per-drive breakdown (conflict drives only)'!s}")  # noqa: T201
     conflicting = (

--- a/src/rmind/scripts/residual_unimodality_probe.py
+++ b/src/rmind/scripts/residual_unimodality_probe.py
@@ -1,0 +1,465 @@
+"""Within-code residual unimodality check (offset-bug brief, Phase 1d).
+
+Separates the offset-supervision loss bug from genuine within-cell
+multimodality, which teacher forcing will *not* cure. Needs only the frozen
+action tokenizer and the action-chunk dataset (no policy model, no images).
+
+For every train-split action chunk:
+
+    target   = tokenizer._normalize(chunk.flatten(-2, -1))     # (b, 24)
+    gt_codes = tokenizer(chunk)                                # (b, G)
+    residual = target - tokenizer.invert(gt_codes)             # (b, 24)
+
+The residual is reshaped to (b, horizon, fields) and the gas / brake pedal
+dims (all horizon steps pooled) are histogrammed per PRIMARY code (q=0).
+A code is flagged bimodal if >5% of its residual mass lies beyond 3x the
+within-code IQR from the median on either pedal dim; a smoothed-histogram
+mode count is logged as a dip-test-like proxy. Top-10 codes by frequency
+get matplotlib histograms logged to wandb.
+
+Usage:
+    uv run python -m rmind.scripts.residual_unimodality_probe
+    uv run python -m rmind.scripts.residual_unimodality_probe \
+        --max-batches 20 --no-wandb --out diag_results/residual_unimodality.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import matplotlib as mpl
+import numpy as np
+import torch
+from hydra import compose, initialize_config_dir
+from hydra.utils import instantiate
+from torch.utils._pytree import MappingKey, tree_leaves, tree_map  # noqa: PLC2701
+
+from rmind.models.action_tokenizer import ActionTokenizer
+from rmind.scripts.offset_diag import shutdown_dataloader
+from rmind.utils.pytree import key_get_default
+
+mpl.use("Agg")
+import matplotlib.pyplot as plt
+
+if TYPE_CHECKING:
+    from rbyte.dataloader import TorchDataNodeDataLoader
+    from torch import Tensor
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CONFIG_DIR = REPO_ROOT / "config"
+DEFAULT_TOKENIZER_CKPT = REPO_ROOT / "artifacts" / "model-gkzgn6gk:v9" / "model.ckpt"
+
+EXPECTED_NUM_QUANTIZERS = 4
+EXPECTED_CODEBOOK_SIZE = 16
+
+PEDAL_FIELDS = ("gas_pedal", "brake_pedal")
+TAIL_IQR_MULTIPLIER = 3.0
+TAIL_MASS_THRESHOLD = 0.05
+MIN_CODE_COUNT = 100  # codes with fewer samples are excluded from the verdict
+TOP_K_HISTOGRAMS = 10
+
+
+def load_tokenizer(
+    ckpt_path: str | Path = DEFAULT_TOKENIZER_CKPT, device: str | torch.device = "cuda"
+) -> ActionTokenizer:
+    """Load the frozen action tokenizer from a local checkpoint, eval mode.
+
+    Raises:
+        ValueError: if the quantizer geometry is not G=4, C=16.
+    """
+    tokenizer = ActionTokenizer.load_from_checkpoint(
+        Path(ckpt_path), map_location="cpu", weights_only=False
+    )
+    tokenizer = (
+        tokenizer.to(torch.device(device)).eval().requires_grad_(requires_grad=False)
+    )
+
+    quantizer = tokenizer.quantizer
+    if (quantizer.num_quantizers, quantizer.codebook_size) != (
+        EXPECTED_NUM_QUANTIZERS,
+        EXPECTED_CODEBOOK_SIZE,
+    ):
+        msg = (
+            f"unexpected quantizer geometry: G={quantizer.num_quantizers} "
+            f"C={quantizer.codebook_size}, expected G={EXPECTED_NUM_QUANTIZERS} "
+            f"C={EXPECTED_CODEBOOK_SIZE}"
+        )
+        raise ValueError(msg)
+
+    return tokenizer
+
+
+def build_dataloader(
+    batch_size: int = 2048, num_workers: int = 2
+) -> TorchDataNodeDataLoader[dict[str, Any]]:
+    """Instantiate the action-tokenizer TRAIN dataloader (actions only).
+
+    Composes `experiment=yaak/action_tokenizer/pretrain` (action_clip=6,
+    action_step=10, action_stride=10 - the 3hz geometry the tokenizer was
+    trained with). First instantiation builds the rbyte sample cache under
+    `.rbyte_cache/yaak/action_train/t6d10s10` (metadata-only, NFS-bound).
+    Shuffle is disabled and `drop_last` is off so a pass covers the split.
+    """
+    with initialize_config_dir(config_dir=str(CONFIG_DIR), version_base=None):
+        cfg = compose(
+            config_name="train", overrides=["experiment=yaak/action_tokenizer/pretrain"]
+        )
+
+    # make the cache path independent of the caller's working directory
+    cfg.paths.rbyte.cache = str(REPO_ROOT / ".rbyte_cache")
+
+    node = cfg.datamodule.train
+    node.batch_size = batch_size
+    node.num_workers = num_workers
+    node.shuffle = False
+    node.drop_last = False
+
+    return instantiate(node)
+
+
+def gather_chunk(tokenizer: ActionTokenizer, batch: dict[str, Any]) -> Tensor:
+    """Extract the raw action chunk (b, horizon, fields) from a batch.
+
+    Mirrors `ActionTokenizer._gather_actions` field ordering (pytree leaves
+    of `tokenizer.targets`), but reads the RAW values through the Remapper
+    only - normalization is left to `tokenizer._normalize` / `tokenizer()`.
+    """
+    remapped = tokenizer.input_transform[0](batch)
+    gathered = tree_map(
+        lambda path: key_get_default(
+            remapped, tuple(MappingKey(part) for part in path), None
+        ),
+        tokenizer.targets,
+        is_leaf=lambda x: isinstance(x, tuple),
+    )
+    columns = [t.float() for t in tree_leaves(gathered)]
+    return torch.stack(columns, dim=-1)  # (b, horizon, fields)
+
+
+def pedal_field_indices(tokenizer: ActionTokenizer) -> dict[str, int]:
+    """Map pedal field name -> index in the stacked action field dim."""
+    leaves = tree_leaves(tokenizer.targets, is_leaf=lambda x: isinstance(x, tuple))
+    field_names = [leaf[-1] for leaf in leaves]
+    return {field: field_names.index(field) for field in PEDAL_FIELDS}
+
+
+def count_modes(values: np.ndarray, bins: int = 128, smooth: int = 5) -> int:
+    """Dip-test-like proxy: count prominent modes of a smoothed histogram.
+
+    A local maximum counts as a separate mode if it reaches >=5% of the peak
+    density and is separated from the previous accepted mode by a valley
+    below 60% of the smaller of the two peaks.
+    """
+    lo, hi = np.quantile(values, [0.005, 0.995])
+    if hi <= lo:
+        return 1
+    hist, _ = np.histogram(values, bins=bins, range=(float(lo), float(hi)))
+    kernel = np.ones(smooth) / smooth
+    density = np.convolve(hist.astype(np.float64), kernel, mode="same")
+
+    peak = float(density.max())
+    if peak <= 0.0:
+        return 1
+
+    modes = 0
+    last_mode_height = 0.0
+    valley = np.inf
+    for i in range(len(density)):
+        left = density[i - 1] if i > 0 else -np.inf
+        right = density[i + 1] if i < len(density) - 1 else -np.inf
+        valley = min(valley, float(density[i]))
+        is_max = density[i] >= left and density[i] > right
+        if not (is_max and density[i] >= 0.05 * peak):
+            continue
+        height = float(density[i])
+        if modes == 0 or valley < 0.6 * min(height, last_mode_height):
+            modes += 1
+            last_mode_height = height
+            valley = np.inf
+    return max(modes, 1)
+
+
+def pedal_stats(values: np.ndarray) -> dict[str, float | int | bool]:
+    """Robust per-(code, pedal) residual stats and the tail-mass flag."""
+    q25, median, q75 = np.quantile(values, [0.25, 0.5, 0.75])
+    iqr = float(q75 - q25)
+    if iqr > 0.0:
+        tail_frac = float(np.mean(np.abs(values - median) > TAIL_IQR_MULTIPLIER * iqr))
+        iqr_degenerate = False
+    else:  # degenerate spread: any deviation from the median is "tail"
+        tail_frac = float(np.mean(values != median))
+        iqr_degenerate = True
+
+    return {
+        "n_values": int(values.size),
+        "mean": float(values.mean()),
+        "std": float(values.std()),
+        "median": float(median),
+        "q25": float(q25),
+        "q75": float(q75),
+        "iqr": iqr,
+        "min": float(values.min()),
+        "max": float(values.max()),
+        "tail_frac_beyond_3iqr": tail_frac,
+        "iqr_degenerate": iqr_degenerate,
+        "n_modes_proxy": count_modes(values),
+    }
+
+
+def plot_code_histograms(
+    code: int, residuals: dict[str, np.ndarray], stats: dict[str, Any]
+) -> plt.Figure:
+    """Side-by-side gas / brake residual histograms for one primary code."""
+    fig, axes = plt.subplots(1, len(PEDAL_FIELDS), figsize=(11, 4))
+    for ax, field in zip(axes, PEDAL_FIELDS, strict=True):
+        values = residuals[field]
+        field_stats = stats["pedals"][field]
+        ax.hist(values, bins=100, color="tab:blue", alpha=0.85)
+        ax.axvline(field_stats["median"], color="black", lw=1, label="median")
+        for sign in (-1, 1):
+            ax.axvline(
+                field_stats["median"] + sign * TAIL_IQR_MULTIPLIER * field_stats["iqr"],
+                color="red",
+                lw=1,
+                ls="--",
+                label="median +- 3*IQR" if sign < 0 else None,
+            )
+        ax.set_yscale("log")
+        ax.set_title(
+            f"{field} | tail={field_stats['tail_frac_beyond_3iqr']:.3%} "
+            f"modes={field_stats['n_modes_proxy']}"
+        )
+        ax.set_xlabel("residual (normalized units)")
+        ax.legend(fontsize=8)
+    fig.suptitle(
+        f"primary code {code} | n={stats['count']} chunks "
+        f"({stats['frequency']:.2%} of split) | bimodal={stats['bimodal']}"
+    )
+    fig.tight_layout()
+    return fig
+
+
+def run_probe(args: argparse.Namespace) -> dict[str, Any]:  # noqa: C901, PLR0912, PLR0914, PLR0915
+    device = torch.device(args.device)
+    tokenizer = load_tokenizer(args.ckpt, device)
+    pedal_idx = pedal_field_indices(tokenizer)
+    horizon = None
+
+    loader = build_dataloader(args.batch_size, args.num_workers)
+    n_samples_split = len(loader.dataset)
+    print(  # noqa: T201
+        f"[residual_unimodality] train action split: {n_samples_split} chunks, "
+        f"{len(loader)} batches of {args.batch_size}"
+    )
+
+    num_codes = tokenizer.quantizer.codebook_size
+    per_code: dict[str, list[list[np.ndarray]]] = {
+        field: [[] for _ in range(num_codes)] for field in PEDAL_FIELDS
+    }
+    counts = np.zeros(num_codes, dtype=np.int64)
+    residual_l1_sum = 0.0
+    n_chunks = 0
+
+    t0 = time.perf_counter()
+    try:
+        with torch.inference_mode():
+            for batch_idx, batch in enumerate(loader):
+                if args.max_batches is not None and batch_idx >= args.max_batches:
+                    break
+
+                chunk = gather_chunk(tokenizer, batch).to(device)  # (b, h, f)
+                horizon = chunk.shape[1]
+                target = tokenizer._normalize(chunk.flatten(-2, -1))  # noqa: SLF001
+                gt_codes = tokenizer(chunk)
+                residual = target - tokenizer.invert(gt_codes)  # (b, h*f)
+                residual = residual.reshape(chunk.shape)  # (b, h, f)
+
+                primary = gt_codes[:, 0].cpu().numpy()
+                residual_np = residual.cpu().numpy()
+                residual_l1_sum += float(np.abs(residual_np).sum())
+                n_chunks += residual_np.shape[0]
+
+                for code in np.unique(primary):
+                    mask = primary == code
+                    counts[code] += int(mask.sum())
+                    for field, idx in pedal_idx.items():
+                        per_code[field][code].append(
+                            residual_np[mask][:, :, idx].reshape(-1)
+                        )
+
+                if (batch_idx + 1) % 100 == 0:
+                    rate = n_chunks / (time.perf_counter() - t0)
+                    print(  # noqa: T201
+                        f"[residual_unimodality] batch {batch_idx + 1}/{len(loader)} "
+                        f"({n_chunks} chunks, {rate:.0f} chunks/s)"
+                    )
+    finally:
+        shutdown_dataloader(loader)
+
+    elapsed = time.perf_counter() - t0
+    print(  # noqa: T201
+        f"[residual_unimodality] processed {n_chunks} chunks in {elapsed:.1f}s"
+    )
+
+    code_residuals: dict[int, dict[str, np.ndarray]] = {
+        code: {
+            field: (
+                np.concatenate(per_code[field][code])
+                if per_code[field][code]
+                else np.empty(0, dtype=np.float32)
+            )
+            for field in PEDAL_FIELDS
+        }
+        for code in range(num_codes)
+    }
+
+    code_stats: dict[int, dict[str, Any]] = {}
+    for code in range(num_codes):
+        count = int(counts[code])
+        stats: dict[str, Any] = {
+            "count": count,
+            "frequency": count / n_chunks if n_chunks else 0.0,
+            "pedals": {},
+            "bimodal": False,
+        }
+        if count > 0:
+            stats["pedals"] = {
+                field: pedal_stats(code_residuals[code][field])
+                for field in PEDAL_FIELDS
+            }
+            stats["bimodal"] = any(
+                stats["pedals"][field]["tail_frac_beyond_3iqr"] > TAIL_MASS_THRESHOLD
+                for field in PEDAL_FIELDS
+            )
+        code_stats[code] = stats
+
+    eligible = [c for c in range(num_codes) if counts[c] >= MIN_CODE_COUNT]
+    bimodal_codes = [c for c in eligible if code_stats[c]["bimodal"]]
+    bimodal_fraction = len(bimodal_codes) / len(eligible) if eligible else 0.0
+
+    result: dict[str, Any] = {
+        "tokenizer_ckpt": str(args.ckpt),
+        "split": "train (action_tokenizer pretrain datamodule, 3hz t6d10s10)",
+        "n_chunks_split": n_samples_split,
+        "n_chunks_processed": n_chunks,
+        "horizon": horizon,
+        "residual_l1_mean_per_dim": (
+            residual_l1_sum / (n_chunks * (horizon or 1) * tokenizer._action_features)  # noqa: SLF001
+            if n_chunks
+            else None
+        ),
+        "tail_iqr_multiplier": TAIL_IQR_MULTIPLIER,
+        "tail_mass_threshold": TAIL_MASS_THRESHOLD,
+        "min_code_count": MIN_CODE_COUNT,
+        "eligible_codes": eligible,
+        "bimodal_codes": bimodal_codes,
+        "bimodal_code_fraction": bimodal_fraction,
+        "verdict": (
+            "bimodal" if bimodal_fraction > TAIL_MASS_THRESHOLD else "unimodal"
+        ),
+        "per_code": {str(c): code_stats[c] for c in range(num_codes)},
+    }
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    print(f"[residual_unimodality] wrote {out_path}")  # noqa: T201
+
+    top_codes = sorted(range(num_codes), key=lambda c: -counts[c])[:TOP_K_HISTOGRAMS]
+    figures = {
+        code: plot_code_histograms(code, code_residuals[code], code_stats[code])
+        for code in top_codes
+        if counts[code] > 0
+    }
+    for code, fig in figures.items():
+        fig.savefig(out_path.parent / f"residual_hist_code{code:02d}.png", dpi=120)
+
+    if args.wandb:
+        os.environ.setdefault("WANDB_DIR", "wandb_logs")
+        Path(os.environ["WANDB_DIR"]).mkdir(parents=True, exist_ok=True)
+        import wandb  # noqa: PLC0415
+
+        run = wandb.init(
+            entity="yaak",
+            project="rmind",
+            name="diag-residual-unimodality",
+            tags=["diag/joint_policy_offset_bug"],
+            job_type="diagnostics",
+            config={k: v for k, v in result.items() if k != "per_code"},
+        )
+        table = wandb.Table(
+            columns=[
+                "code",
+                "count",
+                "frequency",
+                *(
+                    f"{field}/{stat}"
+                    for field in PEDAL_FIELDS
+                    for stat in (
+                        "median",
+                        "iqr",
+                        "tail_frac_beyond_3iqr",
+                        "n_modes_proxy",
+                    )
+                ),
+                "bimodal",
+            ]
+        )
+        for code in range(num_codes):
+            stats = code_stats[code]
+            row: list[Any] = [code, stats["count"], stats["frequency"]]
+            for field in PEDAL_FIELDS:
+                pedal = stats["pedals"].get(field, {})
+                row.extend(
+                    pedal.get(k)
+                    for k in ("median", "iqr", "tail_frac_beyond_3iqr", "n_modes_proxy")
+                )
+            row.append(stats["bimodal"])
+            table.add_data(*row)
+
+        run.log({
+            "per_code_stats": table,
+            "bimodal_code_fraction": bimodal_fraction,
+            "n_chunks_processed": n_chunks,
+            **{
+                f"residual_hist/code{code:02d}": wandb.Image(fig)
+                for code, fig in figures.items()
+            },
+        })
+        run.summary["verdict"] = result["verdict"]
+        run.summary["bimodal_codes"] = bimodal_codes
+        result["wandb_url"] = run.url
+        run.finish()
+        print(f"[residual_unimodality] wandb: {result['wandb_url']}")  # noqa: T201
+        out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+    for fig in figures.values():
+        plt.close(fig)
+
+    return result
+
+
+if __name__ == "__main__":
+    import multiprocessing as mp
+
+    mp.set_forkserver_preload(["rbyte", "polars"])
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--ckpt", default=str(DEFAULT_TOKENIZER_CKPT))
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument("--batch-size", type=int, default=2048)
+    parser.add_argument("--num-workers", type=int, default=2)
+    parser.add_argument("--max-batches", type=int, default=None)
+    parser.add_argument("--wandb", action=argparse.BooleanOptionalAction, default=True)
+    parser.add_argument("--out", default="diag_results/residual_unimodality.json")
+    final = run_probe(parser.parse_args())
+    print(  # noqa: T201
+        f"[residual_unimodality] verdict={final['verdict']} "
+        f"bimodal_code_fraction={final['bimodal_code_fraction']:.3f} "
+        f"bimodal_codes={final['bimodal_codes']}"
+    )

--- a/src/rmind/scripts/train.py
+++ b/src/rmind/scripts/train.py
@@ -4,12 +4,12 @@ from subprocess import check_output  # noqa: S404
 import hydra
 import pytorch_lightning as pl
 import torch
+import wandb
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 from pytorch_lightning.utilities import rank_zero_only
 from structlog import get_logger
 
-import wandb
 from rmind.utils.precision import auto_precision
 
 logger = get_logger(__name__)

--- a/tests/test_joint_policy.py
+++ b/tests/test_joint_policy.py
@@ -283,3 +283,44 @@ def test_metric_offset_sampled_recon(
     assert recon.ndim == 0
     assert not recon.requires_grad
     assert cast("dict[str, Tensor]", metrics["loss"])["offset"].requires_grad
+
+
+@pytest.mark.parametrize("device", [torch.device("cpu")])
+def test_offset_scale_off_is_identity(device: torch.device) -> None:
+    """offset_scale=None (default) leaves the gathered offset untouched."""
+    torch.manual_seed(7)
+    objective = _make_objective(device, sample_codes=False, teacher_force_offset=True)
+    assert objective.offset_scale is None
+
+    offsets = torch.randn(
+        BATCH_SIZE, NUM_QUANTIZERS, CODEBOOK_SIZE, ACTION_DIM, device=device
+    )
+    codes = torch.randint(0, CODEBOOK_SIZE, (BATCH_SIZE, NUM_QUANTIZERS), device=device)
+    torch.testing.assert_close(
+        objective._offset(offsets, codes),  # noqa: SLF001
+        objective._gather_offset(offsets, codes),  # noqa: SLF001
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize("device", [torch.device("cpu")])
+def test_offset_scale_bounds_and_preserves_small(device: torch.device) -> None:
+    """scale*tanh(x/scale): |out| < scale always; ~identity for |x| << scale."""
+    torch.manual_seed(7)
+    scale = 0.05
+    objective = _make_objective(device, sample_codes=False, teacher_force_offset=True)
+    objective.offset_scale = scale
+
+    codes = torch.randint(0, CODEBOOK_SIZE, (BATCH_SIZE, NUM_QUANTIZERS), device=device)
+
+    large = torch.randn(
+        BATCH_SIZE, NUM_QUANTIZERS, CODEBOOK_SIZE, ACTION_DIM, device=device
+    )
+    bounded = objective._offset(large, codes)  # noqa: SLF001
+    assert bounded.abs().max() <= scale  # fp32 tanh saturates to exactly 1
+
+    small = torch.full_like(large, 1e-4 / NUM_QUANTIZERS)
+    contained = objective._offset(small, codes)  # noqa: SLF001
+    raw = objective._gather_offset(small, codes)  # noqa: SLF001
+    torch.testing.assert_close(contained, raw, rtol=1e-3, atol=1e-7)

--- a/tests/test_joint_policy.py
+++ b/tests/test_joint_policy.py
@@ -1,0 +1,285 @@
+"""Unit tests for `JointPolicyObjective` (VQ-BeT joint code + offset head).
+
+Covers the offset teacher-forcing fix: `_gather_offset` correctness, behavioral
+regression of the refactored `_predict` against the verbatim pre-refactor
+implementation, gradient routing of the teacher-forced offset loss, and
+equivalence of `teacher_force_offset=False` with the old (sampled-code) loss.
+"""
+
+from typing import TYPE_CHECKING, Any, cast
+
+import pytest
+import torch
+from einops import rearrange
+from torch import Tensor
+from torch.nn import L1Loss, Linear, Sequential
+from torchvision.ops import MLP
+
+from rmind.components.base import Modality
+from rmind.components.containers import ModuleDict
+from rmind.components.loss import FocalLoss
+from rmind.components.nn import Identity
+from rmind.components.norm import Scaler
+from rmind.components.objectives.joint_policy import JointPolicyObjective
+from rmind.components.vq import ResidualVQ
+from rmind.models.action_tokenizer import ActionTokenizer
+
+if TYPE_CHECKING:
+    from rmind.components.episode import Episode
+
+BATCH_SIZE = 2
+EPISODE_LENGTH = 2  # timesteps in the stub episode; compute_metrics uses [:, -1]
+ACTION_HORIZON = 3  # action-chunk timesteps
+ACTION_FIELDS = 4  # gas_pedal, brake_pedal, steering_angle, turn_signal
+ACTION_DIM = ACTION_HORIZON * ACTION_FIELDS
+LATENT_DIM = 8
+NUM_QUANTIZERS = 2
+CODEBOOK_SIZE = 4
+FEATURE_DIM = 16
+CHUNK: tuple[str, ...] = ("input", "joint_actions")
+
+
+def _make_tokenizer(device: torch.device) -> ActionTokenizer:
+    """Tiny ActionTokenizer mirroring config/model/yaak/action_tokenizer/raw.yaml."""
+    return ActionTokenizer(
+        input_transform=Sequential(
+            Identity(),
+            ModuleDict(
+                modules={
+                    Modality.CONTINUOUS: Identity(),
+                    Modality.DISCRETE: {
+                        # turn_signal {0, 1, 2} -> {0.0, 0.5, 1.0}
+                        "turn_signal": Scaler(in_range=(0.0, 2.0), out_range=(0.0, 1.0))
+                    },
+                }
+            ),
+        ),
+        encoder=Linear(ACTION_DIM, LATENT_DIM),
+        quantizer=ResidualVQ(
+            dim=LATENT_DIM,
+            codebook_size=CODEBOOK_SIZE,
+            num_quantizers=NUM_QUANTIZERS,
+            kmeans_init=False,
+        ),
+        decoder=Linear(LATENT_DIM, ACTION_DIM),
+        targets={
+            Modality.CONTINUOUS: {
+                "gas_pedal": ("continuous", "gas_pedal"),
+                "brake_pedal": ("continuous", "brake_pedal"),
+                "steering_angle": ("continuous", "steering_angle"),
+            },
+            Modality.DISCRETE: {"turn_signal": ("discrete", "turn_signal")},
+        },
+    ).to(device)
+
+
+def _make_objective(
+    device: torch.device, *, sample_codes: bool, teacher_force_offset: bool
+) -> JointPolicyObjective:
+    return (
+        JointPolicyObjective(
+            tokenizer=_make_tokenizer(device),
+            code_head=MLP(FEATURE_DIM, [16, NUM_QUANTIZERS * CODEBOOK_SIZE]),
+            offset_head=MLP(
+                FEATURE_DIM, [16, NUM_QUANTIZERS * CODEBOOK_SIZE * ACTION_DIM]
+            ),
+            losses=ModuleDict(modules={"code": FocalLoss(), "offset": L1Loss()}),
+            chunk=CHUNK,
+            sample_codes=sample_codes,
+            teacher_force_offset=teacher_force_offset,
+        )
+        .to(device)
+        .eval()
+    )
+
+
+class _EpisodeStub:
+    """Minimal Episode stand-in: compute_metrics only calls episode.get(chunk).
+
+    `_features` is monkeypatched on the objective instance, so the stub never
+    has to provide embeddings; the loss-path math below is the real
+    `compute_metrics`.
+    """
+
+    def __init__(self, chunk: Tensor) -> None:
+        self._chunk = chunk
+
+    def get(self, path: tuple[str, ...]) -> Tensor:
+        assert path == CHUNK
+        return self._chunk
+
+
+def _stubbed_inputs(
+    objective: JointPolicyObjective,
+    device: torch.device,
+    *,
+    requires_grad: bool = False,
+) -> tuple["Episode", Tensor, Tensor]:
+    """Random chunk episode + leaf features wired into the objective."""
+    features = torch.randn(
+        BATCH_SIZE, FEATURE_DIM, device=device, requires_grad=requires_grad
+    )
+    # monkeypatch _features on the instance: the stub episode has no embeddings
+    objective._features = (  # noqa: SLF001 # ty:ignore[invalid-assignment]
+        lambda episode, embedding: features  # noqa: ARG005
+    )
+    episode = _EpisodeStub(
+        torch.rand(
+            BATCH_SIZE, EPISODE_LENGTH, ACTION_HORIZON, ACTION_FIELDS, device=device
+        )
+    )
+    return cast("Episode", episode), features, torch.empty(0, device=device)
+
+
+def _predict_reference(
+    objective: JointPolicyObjective, features: Tensor
+) -> tuple[Tensor, Tensor, Tensor]:
+    """Verbatim pre-refactor `_predict` (origin/feat/action-tokenizer)."""
+    quantizer = cast("ActionTokenizer", objective.tokenizer).quantizer
+    g, c = quantizer.num_quantizers, quantizer.codebook_size
+
+    code_logits = rearrange(objective.code_head(features), "b (g c) -> b g c", g=g, c=c)
+    if objective.sample_codes:
+        codes = rearrange(
+            torch.multinomial(code_logits.softmax(dim=-1).reshape(-1, c), 1),
+            "(b g) 1 -> b g",
+            g=g,
+        )
+    else:
+        codes = code_logits.argmax(dim=-1)
+
+    offsets = rearrange(
+        objective.offset_head(features), "b (g c a) -> b g c a", g=g, c=c
+    )
+    index = codes[..., None, None].expand(-1, -1, 1, offsets.shape[-1])
+    offset = offsets.gather(2, index).squeeze(2).sum(dim=1)  # (b, action_dim)
+
+    return code_logits, codes, offset
+
+
+def _offset_loss_reference(
+    objective: JointPolicyObjective, episode: Any, embedding: Tensor
+) -> Tensor:
+    """Pre-refactor `compute_metrics` offset-loss value (sampled-code recon).
+
+    Mirrors the op order of the current `compute_metrics` up to the multinomial
+    call so RNG consumption is identical under a shared seed; the focal losses
+    are RNG-free and therefore omitted.
+    """
+    features = objective._features(episode, embedding)  # noqa: SLF001
+    tokenizer = cast("ActionTokenizer", objective.tokenizer)
+
+    with torch.no_grad():
+        chunk = episode.get(objective.chunk)[:, -1]
+        _ = tokenizer(chunk)  # target_codes: computed for op-order parity
+        target = tokenizer._normalize(chunk.flatten(-2, -1))  # noqa: SLF001
+
+    _, codes, offset = _predict_reference(objective, features)
+    predicted_chunk = tokenizer.invert(codes) + offset
+    return objective.losses["offset"](predicted_chunk, target)
+
+
+def test_gather_offset() -> None:
+    b, g, c, a = 2, 2, 4, 3
+    offsets = torch.arange(b * g * c * a, dtype=torch.float32).reshape(b, g, c, a)
+    codes = torch.tensor([[1, 3], [0, 2]])
+
+    # offsets[b, g, c, a] == ((b*2 + g)*4 + c)*3 + a, hence:
+    # b=0: offsets[0,0,1] + offsets[0,1,3] = [3,4,5] + [21,22,23] = [24,26,28]
+    # b=1: offsets[1,0,0] + offsets[1,1,2] = [24,25,26] + [42,43,44] = [66,68,70]
+    expected = torch.tensor([[24.0, 26.0, 28.0], [66.0, 68.0, 70.0]])
+
+    gathered = JointPolicyObjective._gather_offset(offsets, codes)  # noqa: SLF001
+
+    assert gathered.shape == (b, a)
+    torch.testing.assert_close(gathered, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize("sample_codes", [True, False], ids=["sampled", "argmax"])
+def test_predict_regression_old_impl(
+    device: torch.device,
+    sample_codes: bool,  # noqa: FBT001
+) -> None:
+    objective = _make_objective(
+        device, sample_codes=sample_codes, teacher_force_offset=True
+    )
+    features = torch.randn(BATCH_SIZE, FEATURE_DIM, device=device)
+
+    torch.manual_seed(1234)
+    code_logits_new, codes_new, offset_new = objective._predict(features)  # noqa: SLF001
+
+    torch.manual_seed(1234)
+    code_logits_old, codes_old, offset_old = _predict_reference(objective, features)
+
+    torch.testing.assert_close(code_logits_new, code_logits_old, rtol=0, atol=0)
+    torch.testing.assert_close(codes_new, codes_old, rtol=0, atol=0)
+    torch.testing.assert_close(offset_new, offset_old, rtol=0, atol=0)
+
+
+def test_gradients_teacher_forced(device: torch.device) -> None:
+    objective = _make_objective(device, sample_codes=False, teacher_force_offset=True)
+    episode, features, embedding = _stubbed_inputs(
+        objective, device, requires_grad=True
+    )
+
+    metrics = objective.compute_metrics(episode=episode, embedding=embedding)
+    losses = cast("dict[str, Tensor]", metrics["loss"])
+
+    # offset loss: gradients flow to the offset head only
+    losses["offset"].backward(retain_graph=True)
+
+    offset_grads = [p.grad for p in objective.offset_head.parameters()]
+    assert not any(g is None for g in offset_grads)
+    assert sum(g.abs().sum().item() for g in offset_grads if g is not None) > 0
+    assert all(p.grad is None for p in objective.code_head.parameters())
+    assert all(p.grad is None for p in objective.tokenizer.parameters())
+    assert not any(p.requires_grad for p in objective.tokenizer.parameters())
+    assert features.grad is not None
+
+    # focal losses: gradients flow to the code head only
+    objective.zero_grad()
+    features.grad = None
+
+    focal = torch.stack([losses[f"code_{q}"] for q in range(NUM_QUANTIZERS)]).sum()
+    focal.backward()
+
+    code_grads = [p.grad for p in objective.code_head.parameters()]
+    assert not any(g is None for g in code_grads)
+    assert sum(g.abs().sum().item() for g in code_grads if g is not None) > 0
+    assert all(p.grad is None for p in objective.offset_head.parameters())
+    assert all(p.grad is None for p in objective.tokenizer.parameters())
+
+
+def test_teacher_force_false_matches_old_loss(device: torch.device) -> None:
+    objective = _make_objective(device, sample_codes=True, teacher_force_offset=False)
+    episode, _, embedding = _stubbed_inputs(objective, device)
+
+    torch.manual_seed(1234)
+    metrics = objective.compute_metrics(episode=episode, embedding=embedding)
+
+    torch.manual_seed(1234)
+    expected = _offset_loss_reference(objective, episode, embedding)
+
+    offset_loss = cast("dict[str, Tensor]", metrics["loss"])["offset"]
+    torch.testing.assert_close(offset_loss, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "teacher_force_offset", [True, False], ids=["teacher_forced", "sampled"]
+)
+def test_metric_offset_sampled_recon(
+    device: torch.device,
+    teacher_force_offset: bool,  # noqa: FBT001
+) -> None:
+    objective = _make_objective(
+        device, sample_codes=True, teacher_force_offset=teacher_force_offset
+    )
+    episode, _, embedding = _stubbed_inputs(objective, device)
+
+    metrics = objective.compute_metrics(episode=episode, embedding=embedding)
+
+    recon = cast("dict[str, Tensor]", metrics["metric"])["offset_sampled_recon"]
+    assert isinstance(recon, Tensor)
+    assert recon.ndim == 0
+    assert not recon.requires_grad
+    assert cast("dict[str, Tensor]", metrics["loss"])["offset"].requires_grad


### PR DESCRIPTION
## Problem

`JointPolicyObjective` supervises the offset head at codes **sampled from the policy's own logits** (`sample_codes=True` during training). A sampled code is independent of the action it is graded against, so every code's offset entry trains on the full conditional action distribution, and under L1 its optimum is the per-dimension conditional **median** — for every code. The offset table converges to a negative copy of the codebook (measured: regression slope −0.97, corr −0.99 against the decodes) and cancels the code selection entirely (cancellation ratio R ≈ 0.02–0.05 on `model-2gqxhjod:v9`, i.e. offsets erase 95–99% of cross-code output variance).

Consequences at argmax export: coordinate-wise medians of multimodal action distributions press **gas and brake simultaneously** in ambiguous states (5.1% of val frames vs 0% in GT on the same frames), and minority behaviors are emitted **never, not rarely** (majority-mode lock-in — e.g. launching from rest). Data cleaning cannot fix this; the mechanism reproduces identically on conflict-filtered tokenizers.

## Fix

Teacher-force the offset loss: gather the offset at `target_codes` (already computed for the focal loss), so each code's entry only sees residuals of actions that actually quantized to it. Inference paths are unchanged — the offset table is still indexed by predicted codes at serving.

- `teacher_force_offset: bool = True` keeps the pre-fix behavior reachable (`=false`) so the A/B is a config flip, wired through `policy_finetune.yaml` + the finetune experiment config
- the pre-fix loss value is still logged as a gradient-free metric (`metric/offset_sampled_recon`) for train-curve comparability
- optional `offset_scale` soft bound (`scale·tanh(x/scale)`, **default off**): makes codebook-scale cancellation unrepresentable — defense in depth, kept out of the A/B
- `_predict` split into `_heads`/`_sample_codes`/`_gather_offset` (behavior-preserving; bit-exact regression test vs the old implementation, seeded multinomial included)
- diagnostics suite under `src/rmind/scripts/`: cancellation probe (1a+1b), pedal-conflict probe (1c, incl. activation rates + multi-threshold), residual-unimodality probe (1d), offset-head-only retrain, codebook conflict surface

## Evidence (condensed)

| check | bugged | teacher-forced |
|---|---|---|
| cancellation R (val, argmax) | 0.02–0.05 | **0.94–0.99** |
| offset table vs codebook | slope −0.97 (negative copy) | −0.11, offsets 6× smaller |
| conflict frames (strict thr) | 16.7% (A/B ep-0) | **5.9%** (≈ decode-noise floor) |
| code focal losses | — | identical to 3 decimals |

Offset-head-only retrain of the bugged checkpoint repairs it in place (R 0.02 → 0.79–0.87) while a sampled-code control stays collapsed. Full 10-epoch A/B in flight on tokenizer `model-y74asdtd:v9`: baseline [rpiav4ay](https://wandb.ai/yaak/rmind/runs/rpiav4ay) vs fix [zcglgth4](https://wandb.ai/yaak/rmind/runs/zcglgth4) (identical seed/data/config, only the flag differs).

**Deep dive:** [running report (Notion)](https://app.notion.com/p/399d658ccf87819d9960ef7664b36179) · [interactive explainer — live simulator + real codebook maps](https://claude.ai/code/artifact/b71e1fe7-097e-44a0-9e21-2b8db51f20cb) · [full evidence page — toy A/B + checkpoint probes](https://claude.ai/code/artifact/17d70670-8c1e-49d2-b9e4-ae759a969651)

## Tests

`tests/test_joint_policy.py` — 15 passed: gather correctness (hand-computed), bit-exact `_predict` regression vs the pre-refactor implementation, gradient routing (offset loss → `offset_head` only; focal → `code_head` only; tokenizer frozen), `teacher_force_offset=false` parity with the old loss, metric detachment, `offset_scale` bound/identity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)