### PR TITLE
feat: Patch Policy variant (arXiv:2607.18236) with VQ-BeT chunk head

### DIFF
--- a/config/_templates/dataset/yaak/action_train.yaml
+++ b/config/_templates/dataset/yaak/action_train.yaml
@@ -662,7 +662,7 @@
 _target_: rbyte.Dataset.from_config
 _recursive_: false
 _convert_: all
-# action-only: no video stream → no frame decode
+#! action-only: no video stream → no frame decode
 streams: {}
 
 samples:

--- a/config/_templates/dataset/yaak/action_val.yaml
+++ b/config/_templates/dataset/yaak/action_val.yaml
@@ -12,7 +12,7 @@
 _target_: rbyte.Dataset.from_config
 _recursive_: false
 _convert_: all
-# action-only: no video stream → no frame decode
+#! action-only: no video stream → no frame decode
 streams: {}
 
 samples:

--- a/config/_templates/logger/yaak/rerun/prediction_pretrain.yaml
+++ b/config/_templates/logger/yaak/rerun/prediction_pretrain.yaml
@@ -1,5 +1,5 @@
 #@yaml/text-templated-strings
-#
+#!
 #@ cameras = [
 #@     'cam_front_left'
 #@ ]

--- a/config/datamodule/yaak/train.yaml
+++ b/config/datamodule/yaak/train.yaml
@@ -6,7 +6,7 @@ defaults:
 
 _target_: rmind.datamodules.GenericDataModule
 train:
-  _target_: rbyte.dataloader.TorchDataNodeDataLoader
+  _target_: rmind.components.dataloader.DistributedTorchDataNodeDataLoader
   batch_size: 64
   shuffle: true
   drop_last: true
@@ -18,7 +18,7 @@ train:
   method: thread
 
 val:
-  _target_: rbyte.dataloader.TorchDataNodeDataLoader
+  _target_: rmind.components.dataloader.DistributedTorchDataNodeDataLoader
   batch_size: 32
   shuffle: true
   collate_fn:

--- a/config/experiment/yaak/patch_policy/dinov2.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+
+defaults:
+  - yaak/patch_policy/dinov3
+  - _self_
+
+# DINOv2 ViT-S/14 at 224x224 keeps the same 16x16 = 256 patch grid and 384 dim
+# as DINOv3 ViT-S/16 at 256x256, so only the encoder + input size change.
+image_encoder_name: vit_small_patch14_dinov2.lvd142m
+image_resize: [224, 224]
+
+wandb:
+  tags: [patch_policy, dinov2]

--- a/config/experiment/yaak/patch_policy/dinov2.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2.yaml
@@ -1,7 +1,7 @@
 # @package _global_
 
 defaults:
-  - yaak/patch_policy/dinov3
+  - /experiment/yaak/patch_policy/dinov3
   - _self_
 
 # DINOv2 ViT-S/14 at 224x224 keeps the same 16x16 = 256 patch grid and 384 dim

--- a/config/experiment/yaak/patch_policy/dinov2_cont.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_cont.yaml
@@ -1,0 +1,18 @@
+# @package _global_
+
+defaults:
+  - /experiment/yaak/patch_policy/dinov2
+  - override /model: yaak/patch_policy/continuation
+  - _self_
+
+# Continuation of the dinov2 arm (dashing-dream-514 / wxyp0bzq) after its
+# 10-epoch cosine run: another 10 epochs at CONSTANT lr 3e-5, no warmup,
+# fresh optimizer state (the first run had not converged).
+continuation_artifact: ???
+lr: 3e-5
+
+# NOTE: pass seed=1338 on the CLI for a fresh data order -- setting it here is
+# ineffective (train.yaml's _self_ overrides experiment values for `seed`).
+
+wandb:
+  tags: [patch_policy, dinov2, continuation, from-dashing-dream-514, from-wxyp0bzq]

--- a/config/experiment/yaak/patch_policy/dinov2_dinowm.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dinowm.yaml
@@ -1,0 +1,23 @@
+# @package _global_
+
+defaults:
+  - /experiment/yaak/patch_policy/dinov2
+  - _self_
+
+# DINO-WM-faithful features (https://github.com/gaoyuezhou/dino_wm): the FINAL
+# block's patch tokens after DINOv2's final LayerNorm (x_norm_patchtokens),
+# instead of the rmind convention of pre-norm layer-10 intermediates.
+# NOTE: _args_ lists merge by replacement, so the Sequential is re-stated fully.
+model:
+  image_encoder:
+    _target_: torch.nn.Sequential
+    _args_:
+      - _target_: rmind.components.timm_backbone.TimmBackbone
+        model_name: ${image_encoder_name}
+        img_size: ${image_resize}
+        norm_patch_tokens: true
+      - _target_: einops.layers.torch.Rearrange
+        pattern: "... c h w -> ... (h w) c"
+
+wandb:
+  tags: [patch_policy, dinov2_dinowm]

--- a/config/experiment/yaak/patch_policy/dinov2_dinowm_big.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dinowm_big.yaml
@@ -1,0 +1,16 @@
+# @package _global_
+
+defaults:
+  - /experiment/yaak/patch_policy/dinov2_dinowm
+  - _self_
+
+# Capacity-scaling arm on the closed-loop winner (dinov2_dinowm): trunk
+# 12L/768d/12H (~85M trainable vs 31.5M at 8L/512d). Sized to the serving
+# budget: stellar-hill's 8L/512d ran ~100ms in fp16 against a 300ms budget;
+# this is ~3.4x trunk FLOPs.
+policy_embedding_dim: 768
+num_layers: 12
+num_heads: 12
+
+wandb:
+  tags: [patch_policy, dinov2_dinowm_big]

--- a/config/experiment/yaak/patch_policy/dinov2_dinowm_cont.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dinowm_cont.yaml
@@ -1,0 +1,19 @@
+# @package _global_
+
+defaults:
+  - /experiment/yaak/patch_policy/dinov2_dinowm
+  - override /model: yaak/patch_policy/continuation
+  - _self_
+
+# Continuation of the dinov2_dinowm arm (solar-universe-517 / ifuusvwq) after
+# its 10-epoch cosine run: another 10 epochs at CONSTANT lr 3e-5, no warmup,
+# fresh optimizer state. NOTE: the parent run's epoch-9 checkpoint was lost to
+# a full disk (ENOSPC) -- v8 (epoch 8) is the newest surviving checkpoint.
+continuation_artifact: ???
+lr: 3e-5
+
+# NOTE: pass seed=1338 on the CLI for a fresh data order -- setting it here is
+# ineffective (train.yaml's _self_ overrides experiment values for `seed`).
+
+wandb:
+  tags: [patch_policy, dinov2_dinowm, continuation, from-solar-universe-517, from-ifuusvwq]

--- a/config/experiment/yaak/patch_policy/dinov2_dual.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dual.yaml
@@ -1,0 +1,24 @@
+# @package _global_
+
+defaults:
+  - /experiment/yaak/patch_policy/dinov2
+  - _self_
+
+# Dual-feature arm: layer-10 + final-norm ⊕ final-layer + final-norm,
+# channel-concatenated per patch token (2 x 384 = 768-d patches). If the two
+# depths encode complementary features, the policy benefits from both.
+model:
+  image_encoder:
+    _target_: torch.nn.Sequential
+    _args_:
+      - _target_: rmind.components.timm_backbone.TimmBackbone
+        model_name: ${image_encoder_name}
+        img_size: ${image_resize}
+        norm_indices: [10, 11]
+      - _target_: einops.layers.torch.Rearrange
+        pattern: "... c h w -> ... (h w) c"
+
+image_embedding_dim: 768
+
+wandb:
+  tags: [patch_policy, dinov2_dual]

--- a/config/experiment/yaak/patch_policy/dinov2_l10norm.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_l10norm.yaml
@@ -1,0 +1,23 @@
+# @package _global_
+
+defaults:
+  - /experiment/yaak/patch_policy/dinov2
+  - _self_
+
+# Norm-vs-layer disentangling arm: SAME layer-10 features as the dinov2 arm,
+# but with DINOv2's final LayerNorm applied (forward_intermediates norm=true).
+# If this matches dinov2_dinowm in closed loop, the norm was the decisive
+# factor; if it matches plain dinov2, it was the layer.
+model:
+  image_encoder:
+    _target_: torch.nn.Sequential
+    _args_:
+      - _target_: rmind.components.timm_backbone.TimmBackbone
+        model_name: ${image_encoder_name}
+        img_size: ${image_resize}
+        norm_indices: [10]
+      - _target_: einops.layers.torch.Rearrange
+        pattern: "... c h w -> ... (h w) c"
+
+wandb:
+  tags: [patch_policy, dinov2_l10norm]

--- a/config/experiment/yaak/patch_policy/dinov2_smalltrunk.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_smalltrunk.yaml
@@ -1,0 +1,15 @@
+# @package _global_
+
+defaults:
+  - /experiment/yaak/patch_policy/dinov2
+  - _self_
+
+# anti-overfitting arm: the paper's own small trunk (Table 9, LIBERO -- their
+# most multi-task benchmark): 6 layers / 6 heads / 120 dim, vs 8/8/512 elsewhere.
+# Everything else (encoder, data, batch, LR schedule) identical to the dinov2 arm.
+policy_embedding_dim: 120
+num_layers: 6
+num_heads: 6
+
+wandb:
+  tags: [patch_policy, dinov2_smalltrunk]

--- a/config/experiment/yaak/patch_policy/dinov2_smalltrunk.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_smalltrunk.yaml
@@ -5,11 +5,14 @@ defaults:
   - _self_
 
 # anti-overfitting arm: the paper's own small trunk (Table 9, LIBERO -- their
-# most multi-task benchmark): 6 layers / 6 heads / 120 dim, vs 8/8/512 elsewhere.
+# most multi-task benchmark): 6 layers / 120 dim, vs 8/8/512 elsewhere.
 # Everything else (encoder, data, batch, LR schedule) identical to the dinov2 arm.
+# NOTE: 5 heads instead of the paper's 6 -- head_dim must be a multiple of 8
+# (120/6=20 forces SDPA onto the math kernel, which materializes the full
+# (B, H, 1542, 1542) attention matrix and OOMs; 120/5=24 keeps fused kernels).
 policy_embedding_dim: 120
 num_layers: 6
-num_heads: 6
+num_heads: 5
 
 wandb:
   tags: [patch_policy, dinov2_smalltrunk]

--- a/config/experiment/yaak/patch_policy/dinov3.yaml
+++ b/config/experiment/yaak/patch_policy/dinov3.yaml
@@ -59,5 +59,9 @@ speed_bins: 512
 # supervise the offset head at ground-truth codes (the #258 fix)
 teacher_force_offset: true
 
+# scale-balanced feature fusion (default OFF to preserve comparability with
+# the arms trained before it existed; enable per-arm or via CLI fusion_norm=true)
+fusion_norm: false
+
 wandb:
   tags: [patch_policy, dinov3]

--- a/config/experiment/yaak/patch_policy/dinov3.yaml
+++ b/config/experiment/yaak/patch_policy/dinov3.yaml
@@ -1,0 +1,46 @@
+# @package _global_
+
+defaults:
+  - /model: yaak/patch_policy/raw
+  - /datamodule: yaak/train
+  - /trainer: default
+  - /trainer/callbacks: patch_policy
+  - /paths: yaak/default
+  - /wandb: yaak/rmind
+  - _self_
+
+episode_length: 6
+action_horizon: 6
+episode_step: 10
+episode_stride: 10
+
+# clip_horizon is the dataset build horizon (max over PT/FT) so the built dataset
+# is shared with the control_transformer configs.
+clip_horizon: 6
+clip_length: "${eval:'${episode_length} + ${clip_horizon} - 1'}"
+clip_period: "${eval:'${clip_length} * ${episode_step}'}i"
+
+# frozen encoders
+image_encoder_name: vit_small_patch16_dinov3.lvd1689m
+image_resize: [256, 256] # 256 / patch 16 -> 16x16 = 256 patch tokens
+image_embedding_dim: 384
+num_patches: 256
+
+waypoints_tokenizer_artifact: yaak/waypoints-tokenizer/model-gzxgumtf:v9
+waypoint_latent_dim: 384
+
+action_tokenizer_artifact: yaak/rmind/model-y74asdtd:v9
+
+# policy trunk (https://arxiv.org/pdf/2607.18236 Table 9, Push-T)
+policy_embedding_dim: 512
+num_layers: 8
+num_heads: 8
+lr: 5e-5
+
+speed_bins: 512
+
+# supervise the offset head at ground-truth codes (the #258 fix)
+teacher_force_offset: true
+
+wandb:
+  tags: [patch_policy, dinov3]

--- a/config/experiment/yaak/patch_policy/dinov3.yaml
+++ b/config/experiment/yaak/patch_policy/dinov3.yaml
@@ -35,7 +35,17 @@ action_tokenizer_artifact: yaak/rmind/model-y74asdtd:v9
 policy_embedding_dim: 512
 num_layers: 8
 num_heads: 8
-lr: 5e-5
+
+# batch 128 with linearly-scaled LR (baseline: 5e-5 @ 64). The clip11 train set
+# is ~1.97M samples (FT baseline zcglgth4: 308,038 steps @ batch 64 for 10
+# epochs) -> ~15.4k steps/epoch @ 128; cosine hits zero at the end of epoch 9.
+lr: 1e-4
+lr_warmup_steps: 12500
+lr_total_steps: 154000
+
+datamodule:
+  train:
+    batch_size: 128
 
 speed_bins: 512
 

--- a/config/experiment/yaak/patch_policy/dinov3.yaml
+++ b/config/experiment/yaak/patch_policy/dinov3.yaml
@@ -38,10 +38,17 @@ num_heads: 8
 
 # batch 128 with linearly-scaled LR (baseline: 5e-5 @ 64). The clip11 train set
 # is ~1.97M samples (FT baseline zcglgth4: 308,038 steps @ batch 64 for 10
-# epochs) -> ~15.4k steps/epoch @ 128; cosine hits zero at the end of epoch 9.
+# epochs) -> ~15.4k steps/epoch @ 128; cosine hits zero at the end of epoch 14.
+# NOTE: closed-loop sweeps showed collisions + route deviation keep improving
+# late in training, hence the 15-epoch default. Re-derive both step counts when
+# changing max_epochs or batch size (see get_cosine_schedule_with_warmup's
+# oscillation past num_training_steps).
 lr: 1e-4
-lr_warmup_steps: 12500
-lr_total_steps: 154000
+lr_warmup_steps: 18500
+lr_total_steps: 231000
+
+trainer:
+  max_epochs: 15
 
 datamodule:
   train:

--- a/config/experiment/yaak/patch_policy/dinov3_cont.yaml
+++ b/config/experiment/yaak/patch_policy/dinov3_cont.yaml
@@ -1,0 +1,18 @@
+# @package _global_
+
+defaults:
+  - /experiment/yaak/patch_policy/dinov3
+  - override /model: yaak/patch_policy/continuation
+  - _self_
+
+# Continuation of the dinov3 arm (stellar-hill-515 / 8crjqzii) after its
+# 10-epoch cosine run: another 10 epochs at CONSTANT lr 3e-5, no warmup,
+# fresh optimizer state (the first run had not converged).
+continuation_artifact: ???
+lr: 3e-5
+
+# NOTE: pass seed=1338 on the CLI for a fresh data order -- setting it here is
+# ineffective (train.yaml's _self_ overrides experiment values for `seed`).
+
+wandb:
+  tags: [patch_policy, dinov3, continuation, from-stellar-hill-515, from-8crjqzii]

--- a/config/experiment/yaak/patch_policy/dinov3_dinowm.yaml
+++ b/config/experiment/yaak/patch_policy/dinov3_dinowm.yaml
@@ -1,0 +1,22 @@
+# @package _global_
+
+defaults:
+  - /experiment/yaak/patch_policy/dinov3
+  - _self_
+
+# DINO-WM-style features (final layer + final norm) on DINOv3: tests whether
+# the dinov2_dinowm arm's closed-loop win transfers across encoder families
+# (and whether it resurrects the wandering DINOv3 arms).
+model:
+  image_encoder:
+    _target_: torch.nn.Sequential
+    _args_:
+      - _target_: rmind.components.timm_backbone.TimmBackbone
+        model_name: ${image_encoder_name}
+        img_size: ${image_resize}
+        norm_patch_tokens: true
+      - _target_: einops.layers.torch.Rearrange
+        pattern: "... c h w -> ... (h w) c"
+
+wandb:
+  tags: [patch_policy, dinov3_dinowm]

--- a/config/experiment/yaak/patch_policy/dinov3_fusion.yaml
+++ b/config/experiment/yaak/patch_policy/dinov3_fusion.yaml
@@ -1,0 +1,16 @@
+# @package _global_
+
+# H3 clean test: dinov3 layer-10 RAW features (the ~90x patch/goal imbalance
+# worst case) + fusion_norm — patch LN + learnable gains, goal gain init
+# 1/RMS(z_q). If this alone recovers most of stellar-hill's rdev gap, the
+# dinowm win was conditioning (scale), not feature content. Ladder-comparable:
+# stock batch-128 @ 1e-4 recipe, same as stellar-hill (8crjqzii).
+
+defaults:
+  - /experiment/yaak/patch_policy/dinov3
+  - _self_
+
+fusion_norm: true
+
+wandb:
+  tags: [patch_policy, dinov3, fusion_norm]

--- a/config/experiment/yaak/patch_policy/dinov3_vitb.yaml
+++ b/config/experiment/yaak/patch_policy/dinov3_vitb.yaml
@@ -1,0 +1,13 @@
+# @package _global_
+
+defaults:
+  - yaak/patch_policy/dinov3
+  - _self_
+
+# next encoder size up: DINOv3 ViT-B/16 (768-d patches; same 16x16 grid @256²,
+# also 12 layers, so out_indices [10] stays proportionally identical)
+image_encoder_name: vit_base_patch16_dinov3.lvd1689m
+image_embedding_dim: 768
+
+wandb:
+  tags: [patch_policy, dinov3_vitb]

--- a/config/experiment/yaak/patch_policy/dinov3_vitb.yaml
+++ b/config/experiment/yaak/patch_policy/dinov3_vitb.yaml
@@ -1,7 +1,7 @@
 # @package _global_
 
 defaults:
-  - yaak/patch_policy/dinov3
+  - /experiment/yaak/patch_policy/dinov3
   - _self_
 
 # next encoder size up: DINOv3 ViT-B/16 (768-d patches; same 16x16 grid @256²,

--- a/config/export/yaak/patch_policy/finetuned.yaml
+++ b/config/export/yaak/patch_policy/finetuned.yaml
@@ -1,0 +1,49 @@
+# @package _global_
+---
+# ONNX export for a PatchPolicy checkpoint. Deployment interface (mirrors the
+# control_transformer export conventions): 6 observation frames of
+# already-cropped/resized [0,1] float RGB in (1, 6, 3, H, W) -- H=W=256 for
+# dinov3 arms, 224 for dinov2 arms (set `image_hw`) -- plus speed (km/h) and
+# ego-frame /100 waypoints. No action series needed. Output: policy.joint_actions
+# (1, 6, 4) normalized action chunk from the newest frame, argmax decoding.
+#
+#   just export-onnx export=yaak/patch_policy/finetuned \
+#       model.artifact=yaak/rmind/model-<run>:vN image_hw=256
+
+model:
+  _target_: rmind.models.patch_policy.PatchPolicy.load_for_export
+  artifact: ???
+
+image_hw: 256
+
+input:
+  data:
+    cam_front_left:
+      _target_: torch.testing.make_tensor
+      _args_: [1, 6, 3, "${image_hw}", "${image_hw}"]
+      dtype:
+        _target_: hydra.utils.get_object
+        path: torch.float
+      device: cpu
+      low: 0
+      high: 1
+
+    meta/VehicleMotion/speed:
+      _target_: torch.testing.make_tensor
+      _args_: [1, 6, 1]
+      dtype:
+        _target_: hydra.utils.get_object
+        path: torch.float32
+      device: cpu
+      low: 0
+      high: 130
+
+    waypoints/xy_normalized:
+      _target_: torch.testing.make_tensor
+      _args_: [1, 6, 10, 2]
+      dtype:
+        _target_: hydra.utils.get_object
+        path: torch.float32
+      device: cpu
+      low: -1.0
+      high: 1.0

--- a/config/export/yaak/patch_policy/head.yaml
+++ b/config/export/yaak/patch_policy/head.yaml
@@ -1,0 +1,38 @@
+# @package _global_
+---
+# Head-only ONNX export for on-the-fly decoding (see PatchPolicyHead docstring).
+# Input dict: trunk readout features (b, d) + caller-chosen codes
+# (b, num_quantizers). Outputs: code_logits (b, g, c), the full offset table
+# (b, g, c, action_dim), and chunk (b, horizon, fields) = decode(codes) +
+# offset@codes. Code selection (argmax / sampling / temperature / entropy
+# gating) is the caller's, outside the graph.
+#
+#   just export-onnx export=yaak/patch_policy/head model.artifact=yaak/rmind/model-<run>:vN
+
+model:
+  _target_: rmind.models.patch_policy.PatchPolicy.load_head_for_export
+  artifact: ???
+
+feature_dim: 512
+num_quantizers: 4
+
+input:
+  features:
+    _target_: torch.testing.make_tensor
+    _args_: [1, "${feature_dim}"]
+    dtype:
+      _target_: hydra.utils.get_object
+      path: torch.float32
+    device: cpu
+    low: -1.0
+    high: 1.0
+
+  codes:
+    _target_: torch.testing.make_tensor
+    _args_: [1, "${num_quantizers}"]
+    dtype:
+      _target_: hydra.utils.get_object
+      path: torch.int64
+    device: cpu
+    low: 0
+    high: 16

--- a/config/model/yaak/patch_policy/continuation.yaml
+++ b/config/model/yaak/patch_policy/continuation.yaml
@@ -1,0 +1,22 @@
+_target_: rmind.models.patch_policy.PatchPolicy.load_for_continuation
+_recursive_: false
+_convert_: all
+
+# Warm start from a finished run's checkpoint: weights + hparams from the
+# artifact; ONLY the optimization config is replaced (fresh optimizer state,
+# constant LR -- no scheduler, no warmup).
+artifact: ${continuation_artifact}
+
+optimizer:
+  _target_: rmind.components.optimizers.SelectiveAdamW
+  _recursive_: true
+  lr: ${lr}
+  betas: [0.9, 0.95]
+  weight_decay: 0.1
+  weight_decay_module_blacklist:
+    - _target_: hydra.utils.get_class
+      path: torch.nn.Embedding
+    - _target_: hydra.utils.get_class
+      path: torch.nn.LayerNorm
+
+lr_scheduler: null

--- a/config/model/yaak/patch_policy/raw.yaml
+++ b/config/model/yaak/patch_policy/raw.yaml
@@ -1,0 +1,157 @@
+_target_: rmind.models.patch_policy.PatchPolicy
+_recursive_: false
+_convert_: all
+
+input_transform:
+  _target_: torch.nn.Sequential
+  _convert_: all
+  _args_:
+    - _target_: rmind.components.nn.Remapper
+      paths:
+        image:
+          cam_front_left: [data, cam_front_left]
+
+        continuous:
+          speed: [data, meta/VehicleMotion/speed]
+          gas_pedal: [data, meta/VehicleMotion/gas_pedal_normalized]
+          brake_pedal: [data, meta/VehicleMotion/brake_pedal_normalized]
+          steering_angle: [data, meta/VehicleMotion/steering_angle_normalized]
+
+        context:
+          waypoints: [data, waypoints/xy_normalized]
+
+        discrete:
+          turn_signal: [data, meta/VehicleState/turn_signal]
+
+    - _target_: rmind.components.nn.ChunkFields
+      episode_length: ${episode_length}
+      action_horizon: ${action_horizon}
+      unfold_paths:
+        - [continuous, gas_pedal]
+        - [continuous, brake_pedal]
+        - [continuous, steering_angle]
+        - [discrete, turn_signal]
+
+    - _target_: rmind.components.containers.ModuleDict
+      modules:
+        image:
+          _target_: torch.nn.Sequential
+          _args_:
+            - _target_: einops.layers.torch.Rearrange
+              pattern: "... h w c -> ... c h w"
+            - _target_: torchvision.transforms.v2.CenterCrop
+              size: [320, 576]
+            - _target_: torchvision.transforms.v2.Resize
+              size: ${image_resize}
+            - _target_: torchvision.transforms.v2.ToDtype
+              scale: true
+              dtype:
+                _target_: hydra.utils.get_object
+                path: torch.float32
+            - _target_: torchvision.transforms.v2.Normalize
+              mean: [0.485, 0.456, 0.406]
+              std: [0.229, 0.224, 0.225]
+
+        continuous:
+          _target_: rmind.components.nn.AtLeast3D
+
+        discrete:
+          _target_: rmind.components.nn.AtLeast3D
+
+        context:
+          _target_: torch.nn.Identity
+
+    - _target_: rmind.components.nn.StackFields
+      out_key: joint_actions
+      paths:
+        gas_pedal: [continuous, gas_pedal]
+        brake_pedal: [continuous, brake_pedal]
+        steering_angle: [continuous, steering_angle]
+        turn_signal: [discrete, turn_signal]
+
+image_encoder:
+  _target_: torch.nn.Sequential
+  _args_:
+    - _target_: rmind.components.timm_backbone.TimmBackbone
+      model_name: ${image_encoder_name}
+      out_indices: [10]
+      img_size: ${image_resize}
+    - _target_: einops.layers.torch.Rearrange
+      pattern: "... c h w -> ... (h w) c"
+
+goal_encoder:
+  _target_: rmind.models.waypoints_tokenizer.WaypointsTokenizer.load_from_wandb_artifact
+  artifact: ${waypoints_tokenizer_artifact}
+  weights_only: false
+
+# T x P x (D + G) -> policy width (https://arxiv.org/pdf/2607.18236 section 2.1)
+patch_projection:
+  _target_: rmind.components.nn.Linear
+  in_features: "${eval:'${image_embedding_dim} + ${waypoint_latent_dim}'}"
+  out_features: ${policy_embedding_dim}
+
+speed_tokenizer:
+  _target_: rmind.components.norm.UniformBinner
+  range: [0.0, 130.0]
+  bins: ${speed_bins}
+
+speed_embedding:
+  _target_: rmind.components.nn.Embedding
+  num_embeddings: ${speed_bins}
+  embedding_dim: ${policy_embedding_dim}
+
+encoder:
+  _target_: rmind.models.patch_policy.BlockCausalTransformer
+  dim_model: ${policy_embedding_dim}
+  num_layers: ${num_layers}
+  num_heads: ${num_heads}
+  # episode_length frames x (num_patches + 1 speed token)
+  max_sequence_length: "${eval:'${episode_length} * (${num_patches} + 1)'}"
+
+tokenizer:
+  _target_: rmind.models.action_tokenizer.ActionTokenizer.load_from_wandb_artifact
+  artifact: ${action_tokenizer_artifact}
+  weights_only: false
+
+norm:
+  _target_: torch.nn.LayerNorm
+  normalized_shape: ${policy_embedding_dim}
+
+code_head:
+  _target_: torchvision.ops.MLP
+  in_channels: ${policy_embedding_dim}
+  hidden_channels: [1024, 1024, 64] # 4 quantizers x 16 codes
+
+offset_head:
+  _target_: torchvision.ops.MLP
+  in_channels: ${policy_embedding_dim}
+  hidden_channels: [1024, 1024, 1536] # 4 quantizers x 16 codes x 24 action dims
+
+losses:
+  _target_: rmind.components.containers.ModuleDict
+  modules:
+    code:
+      _target_: rmind.components.loss.FocalLoss
+    offset:
+      _target_: torch.nn.L1Loss
+
+teacher_force_offset: ${teacher_force_offset}
+
+optimizer:
+  _target_: rmind.components.optimizers.SelectiveAdamW
+  _recursive_: true
+  lr: ${lr}
+  betas: [0.9, 0.95]
+  weight_decay: 0.1
+  weight_decay_module_blacklist:
+    - _target_: hydra.utils.get_class
+      path: torch.nn.Embedding
+    - _target_: hydra.utils.get_class
+      path: torch.nn.LayerNorm
+
+lr_scheduler:
+  interval: step
+  scheduler:
+    _target_: rmind.components.lr_schedulers.get_cosine_schedule_with_warmup
+    num_warmup_steps: 25000
+    num_training_steps: 250000

--- a/config/model/yaak/patch_policy/raw.yaml
+++ b/config/model/yaak/patch_policy/raw.yaml
@@ -149,11 +149,13 @@ optimizer:
     - _target_: hydra.utils.get_class
       path: torch.nn.LayerNorm
 
-# sized to the actual run budget: ~1.2k optimizer steps/epoch (76.7k clip11
-# samples @ batch 64) x 10 epochs -- one-epoch warmup, cosine to ~zero by the end
+# sized to the actual run budget: ~30.8k optimizer steps/epoch (measured on the
+# 10-epoch FT baseline zcglgth4: global_step 308,038 @ batch 64) -- warmup as in
+# the FT baseline, cosine reaching zero at the end of epoch 9. NOTE: the schedule
+# oscillates if trained past num_training_steps (the cosine comes back up).
 lr_scheduler:
   interval: step
   scheduler:
     _target_: rmind.components.lr_schedulers.get_cosine_schedule_with_warmup
-    num_warmup_steps: 1200
-    num_training_steps: 12000
+    num_warmup_steps: 25000
+    num_training_steps: 308000

--- a/config/model/yaak/patch_policy/raw.yaml
+++ b/config/model/yaak/patch_policy/raw.yaml
@@ -137,6 +137,10 @@ losses:
 
 teacher_force_offset: ${teacher_force_offset}
 
+# scale-balanced fusion: LN + learnable gain on patches, RVQ-calibrated
+# learnable gain on the goal latent (see PatchPolicy docstring)
+fusion_norm: ${fusion_norm}
+
 optimizer:
   _target_: rmind.components.optimizers.SelectiveAdamW
   _recursive_: true

--- a/config/model/yaak/patch_policy/raw.yaml
+++ b/config/model/yaak/patch_policy/raw.yaml
@@ -149,9 +149,11 @@ optimizer:
     - _target_: hydra.utils.get_class
       path: torch.nn.LayerNorm
 
+# sized to the actual run budget: ~1.2k optimizer steps/epoch (76.7k clip11
+# samples @ batch 64) x 10 epochs -- one-epoch warmup, cosine to ~zero by the end
 lr_scheduler:
   interval: step
   scheduler:
     _target_: rmind.components.lr_schedulers.get_cosine_schedule_with_warmup
-    num_warmup_steps: 25000
-    num_training_steps: 250000
+    num_warmup_steps: 1200
+    num_training_steps: 12000

--- a/config/model/yaak/patch_policy/raw.yaml
+++ b/config/model/yaak/patch_policy/raw.yaml
@@ -149,13 +149,11 @@ optimizer:
     - _target_: hydra.utils.get_class
       path: torch.nn.LayerNorm
 
-# sized to the actual run budget: ~30.8k optimizer steps/epoch (measured on the
-# 10-epoch FT baseline zcglgth4: global_step 308,038 @ batch 64) -- warmup as in
-# the FT baseline, cosine reaching zero at the end of epoch 9. NOTE: the schedule
-# oscillates if trained past num_training_steps (the cosine comes back up).
+# NOTE: the schedule oscillates if trained past num_training_steps (the cosine
+# comes back up) -- size lr_total_steps to the actual planned optimizer steps.
 lr_scheduler:
   interval: step
   scheduler:
     _target_: rmind.components.lr_schedulers.get_cosine_schedule_with_warmup
-    num_warmup_steps: 25000
-    num_training_steps: 308000
+    num_warmup_steps: ${lr_warmup_steps}
+    num_training_steps: ${lr_total_steps}

--- a/config/paths/yaak/verda.yaml
+++ b/config/paths/yaak/verda.yaml
@@ -1,0 +1,7 @@
+---
+# Verda cloud (FIN-01): the yaak dataset lives on the shared NFS volume
+# `verda-nas` (mount: nfs.fin-01.datacrunch.io:/verda-nas-33cba3e6, ro,nolock).
+# Layout mirrors /nasa/drives/yaak/data (drive dirs at the root).
+data: /mnt/verda-nas
+rbyte:
+  cache: .rbyte_cache

--- a/config/train.yaml
+++ b/config/train.yaml
@@ -6,3 +6,6 @@ defaults:
 
 seed: 1337
 matmul_precision: "high"
+
+# optional checkpoint to resume from (passed to trainer.fit)
+ckpt_path: null

--- a/config/trainer/callbacks/patch_policy.yaml
+++ b/config/trainer/callbacks/patch_policy.yaml
@@ -1,3 +1,4 @@
+- _target_: rmind.components.dataloader.DistributedSamplerEpochSetter
 - _target_: pytorch_lightning.callbacks.ModelSummary
   max_depth: 3
 - _target_: pytorch_lightning.callbacks.ModelCheckpoint

--- a/config/trainer/callbacks/patch_policy.yaml
+++ b/config/trainer/callbacks/patch_policy.yaml
@@ -1,0 +1,60 @@
+- _target_: pytorch_lightning.callbacks.ModelSummary
+  max_depth: 3
+- _target_: pytorch_lightning.callbacks.ModelCheckpoint
+  every_n_epochs: 1
+  save_on_train_epoch_end: True
+- _target_: pytorch_lightning.callbacks.LearningRateMonitor
+  logging_interval: step
+- _target_: rmind.callbacks.PredictMetricsCallback
+  prediction_config:
+    objectives:
+      - score_l1
+      - score_signed_error
+  cluster_fn:
+    _target_: rmind.utils.RuleBasedCluster
+    fields:
+      gas:
+        key: meta/VehicleMotion/gas_pedal_normalized
+        reduce: last
+      brake:
+        key: meta/VehicleMotion/brake_pedal_normalized
+        reduce: last
+      steer:
+        key: meta/VehicleMotion/steering_angle_normalized
+        reduce: last
+      dp_g:
+        key: meta/VehicleMotion/gas_pedal_normalized
+        reduce: last_diff
+      speed:
+        key: meta/VehicleMotion/speed
+        reduce: last
+    rules:
+      - name: highway
+        when: {speed: {ge: 70}}
+      - name: braking_turn
+        when: {brake: {ge: 0.02}, steer: {abs_ge: 0.05}}
+      - name: braking
+        when: {brake: {ge: 0.02}, steer: {abs_lt: 0.05}}
+      - name: cruise_turn
+        when: {gas: {ge: 0.05}, brake: {lt: 0.02}, steer: {abs_ge: 0.05}}
+      - name: acceleration
+        when: {gas: {ge: 0.05}, brake: {lt: 0.02}, dp_g: {ge: 0.01}}
+      - name: gas_release
+        when: {gas: {ge: 0.05}, brake: {lt: 0.02}, dp_g: {lt: -0.01}}
+      - name: cruise
+        when: {gas: {ge: 0.05}, brake: {lt: 0.02}, steer: {abs_lt: 0.05}, dp_g: {abs_lt: 0.01}}
+    default: idle_coast
+  cluster_metrics:
+    acceleration:
+      - policy/score_l1/value/continuous/gas_pedal
+      - policy/score_signed_error/value/continuous/gas_pedal
+    cruise_turn:
+      - policy/score_l1/value/continuous/steering_angle
+    braking_turn:
+      - policy/score_l1/value/continuous/brake_pedal
+      - policy/score_l1/value/continuous/steering_angle
+    braking:
+      - policy/score_l1/value/continuous/brake_pedal
+    highway:
+      - policy/score_l1/value/continuous/gas_pedal
+      - policy/score_signed_error/value/continuous/gas_pedal

--- a/config/trainer/multi_gpu.yaml
+++ b/config/trainer/multi_gpu.yaml
@@ -1,8 +1,18 @@
+# Multi-GPU DDP training: select with `trainer=multi_gpu`.
+#
+# Effective batch = devices x datamodule.train.batch_size — halve the
+# per-rank batch_size when moving a single-GPU recipe here to keep the
+# optimization trajectory comparable (e.g. 2 x 32 == bs64).
+#
+# Requires the DDP-sharded dataloader (rmind.components.dataloader, see
+# yaak-ai/rbyte#106): without DistributedSampler sharding every rank draws
+# identical batches and 2 GPUs train no faster than one.
+#
+# find_unused_parameters: frozen-path modules (e.g. DINOv3 backbone under
+# pretrain-style freezing) leave grad-less parameters each step, which
+# vanilla DDP treats as an error.
 defaults:
   - default
-  - _self_
-devices: auto
-sync_batchnorm: True
-strategy:
-  _target_: pytorch_lightning.strategies.DDPStrategy
-  static_graph: True
+
+devices: 2
+strategy: ddp_find_unused_parameters_true

--- a/docs/patch_policy_architecture.svg
+++ b/docs/patch_policy_architecture.svg
@@ -1,0 +1,196 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 1560" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#555"/>
+    </marker>
+  </defs>
+
+  <rect width="1180" height="1560" fill="#fcfcfd"/>
+  <text x="590" y="38" text-anchor="middle" font-size="24" font-weight="bold" fill="#1a1a2e">Patch Policy (arXiv:2607.18236) — rmind variant with VQ-BeT chunk head</text>
+
+  <!-- legend -->
+  <rect x="820" y="56" width="14" height="14" rx="3" fill="#dbeafe" stroke="#3b82f6"/>
+  <text x="840" y="68" font-size="13" fill="#333">frozen ("PT", not trained)</text>
+  <rect x="1000" y="56" width="14" height="14" rx="3" fill="#ffedd5" stroke="#f97316"/>
+  <text x="1020" y="68" font-size="13" fill="#333">trained ("FT")</text>
+
+  <!-- ===================== BAND 1: per-frame encoding ===================== -->
+  <text x="30" y="95" font-size="16" font-weight="bold" fill="#1a1a2e">1 · Per-frame packing  Z_t   (each of T = 6 history frames, every 10th video frame)</text>
+
+  <!-- camera column -->
+  <rect x="40" y="115" width="230" height="52" rx="8" fill="#f1f5f9" stroke="#94a3b8"/>
+  <text x="155" y="137" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">camera frame t</text>
+  <text x="155" y="155" text-anchor="middle" font-size="12" fill="#555">cam_front_left · 576×324</text>
+
+  <line x1="155" y1="167" x2="155" y2="192" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="40" y="194" width="230" height="46" rx="8" fill="#f1f5f9" stroke="#94a3b8"/>
+  <text x="155" y="213" text-anchor="middle" font-size="12" fill="#333">CenterCrop 320×576 → Resize</text>
+  <text x="155" y="230" text-anchor="middle" font-size="12" fill="#333">256² (v3) / 224² (v2) + norm</text>
+
+  <line x1="155" y1="240" x2="155" y2="265" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="40" y="267" width="230" height="64" rx="8" fill="#dbeafe" stroke="#3b82f6"/>
+  <text x="155" y="288" text-anchor="middle" font-size="14" font-weight="bold" fill="#1e3a8a">❄ DINO ViT-S (layer 10)</text>
+  <text x="155" y="306" text-anchor="middle" font-size="12" fill="#1e3a8a">dinov3 /16 @256²  |  dinov2 /14 @224²</text>
+  <text x="155" y="322" text-anchor="middle" font-size="12" fill="#1e3a8a">→ 16×16 grid, both arms</text>
+
+  <line x1="155" y1="331" x2="155" y2="356" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- patch tokens graphic -->
+  <g>
+    <rect x="60" y="358" width="190" height="58" rx="8" fill="#fff" stroke="#64748b"/>
+    <g fill="#93c5fd" stroke="#3b82f6" stroke-width="0.6">
+      <rect x="72" y="368" width="9" height="9"/><rect x="83" y="368" width="9" height="9"/><rect x="94" y="368" width="9" height="9"/><rect x="105" y="368" width="9" height="9"/>
+      <rect x="72" y="379" width="9" height="9"/><rect x="83" y="379" width="9" height="9"/><rect x="94" y="379" width="9" height="9"/><rect x="105" y="379" width="9" height="9"/>
+      <rect x="72" y="390" width="9" height="9"/><rect x="83" y="390" width="9" height="9"/><rect x="94" y="390" width="9" height="9"/><rect x="105" y="390" width="9" height="9"/>
+      <rect x="72" y="401" width="9" height="9"/><rect x="83" y="401" width="9" height="9"/><rect x="94" y="401" width="9" height="9"/><rect x="105" y="401" width="9" height="9"/>
+    </g>
+    <text x="125" y="384" font-size="13" font-weight="bold" fill="#333">P = 256 patch</text>
+    <text x="125" y="401" font-size="13" fill="#333">tokens × 384</text>
+  </g>
+
+  <!-- waypoints column -->
+  <rect x="330" y="115" width="230" height="52" rx="8" fill="#f1f5f9" stroke="#94a3b8"/>
+  <text x="445" y="137" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">waypoints t (goal)</text>
+  <text x="445" y="155" text-anchor="middle" font-size="12" fill="#555">10 × (x,y) · ego frame · /100</text>
+
+  <line x1="445" y1="167" x2="445" y2="265" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="330" y="267" width="230" height="64" rx="8" fill="#dbeafe" stroke="#3b82f6"/>
+  <text x="445" y="288" text-anchor="middle" font-size="14" font-weight="bold" fill="#1e3a8a">❄ Waypoints RVQ tokenizer</text>
+  <text x="445" y="306" text-anchor="middle" font-size="12" fill="#1e3a8a">MLP enc → RVQ (4 × 32 codes)</text>
+  <text x="445" y="322" text-anchor="middle" font-size="12" fill="#1e3a8a">gzxgumtf:v9 · z_q post-quant</text>
+
+  <line x1="445" y1="331" x2="445" y2="356" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="365" y="358" width="160" height="40" rx="8" fill="#fff" stroke="#64748b"/>
+  <text x="445" y="383" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">g_t ∈ ℝ³⁸⁴</text>
+
+  <!-- speed column -->
+  <rect x="620" y="115" width="200" height="52" rx="8" fill="#f1f5f9" stroke="#94a3b8"/>
+  <text x="720" y="137" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">speed t</text>
+  <text x="720" y="155" text-anchor="middle" font-size="12" fill="#555">0–130 km/h</text>
+
+  <line x1="720" y1="167" x2="720" y2="265" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="620" y="267" width="200" height="64" rx="8" fill="#ffedd5" stroke="#f97316"/>
+  <text x="720" y="291" text-anchor="middle" font-size="13" font-weight="bold" fill="#7c2d12">UniformBinner (512 bins)</text>
+  <text x="720" y="311" text-anchor="middle" font-size="13" fill="#7c2d12">+ Embedding → 512</text>
+
+  <line x1="720" y1="331" x2="720" y2="356" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="645" y="358" width="150" height="40" rx="8" fill="#fff" stroke="#64748b"/>
+  <text x="720" y="383" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">speed token (512)</text>
+
+  <!-- concat + projection -->
+  <line x1="155" y1="416" x2="155" y2="452" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="445" y1="398" x2="445" y2="430" stroke="#555" stroke-width="1.5"/>
+  <line x1="445" y1="430" x2="300" y2="430" stroke="#555" stroke-width="1.5"/>
+  <line x1="300" y1="430" x2="300" y2="465" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="460" y="424" font-size="12" fill="#555">broadcast g_t to all 256 patch tokens</text>
+
+  <rect x="40" y="454" width="450" height="60" rx="8" fill="#ffedd5" stroke="#f97316"/>
+  <text x="265" y="478" text-anchor="middle" font-size="14" font-weight="bold" fill="#7c2d12">T × P × (D + G):  [patch (384) ⊕ g_t (384)] = 768</text>
+  <text x="265" y="500" text-anchor="middle" font-size="13" fill="#7c2d12">Linear 768 → 512   (single projection, paper §2.1)</text>
+
+  <!-- frame block -->
+  <line x1="265" y1="514" x2="265" y2="540" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="720" y1="398" x2="720" y2="527" stroke="#555" stroke-width="1.5"/>
+  <line x1="720" y1="527" x2="560" y2="555" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <g>
+    <rect x="40" y="542" width="520" height="52" rx="8" fill="#fff" stroke="#334155" stroke-width="1.5"/>
+    <rect x="52" y="552" width="70" height="32" rx="5" fill="#fed7aa" stroke="#f97316"/>
+    <text x="87" y="572" text-anchor="middle" font-size="12" fill="#7c2d12">speed</text>
+    <rect x="128" y="552" width="380" height="32" rx="5" fill="#bfdbfe" stroke="#3b82f6"/>
+    <text x="318" y="572" text-anchor="middle" font-size="12" fill="#1e3a8a">patch₁ … patch₂₅₆   (goal-conditioned, 512-d)</text>
+    <text x="530" y="573" font-size="13" fill="#333">= K</text>
+  </g>
+  <text x="40" y="614" font-size="13" fill="#555">frame block: K = 257 tokens · speed first, so the block <tspan font-weight="bold">ends on a patch token = readout position</tspan></text>
+
+  <!-- ===================== BAND 2: sequence + transformer ===================== -->
+  <text x="30" y="668" font-size="16" font-weight="bold" fill="#1a1a2e">2 · Flattened sequence + block-causal transformer</text>
+
+  <!-- sequence of 6 frame blocks -->
+  <g>
+    <rect x="40" y="688" width="700" height="56" rx="8" fill="#fff" stroke="#334155" stroke-width="1.5"/>
+    <rect x="52"  y="698" width="106" height="36" rx="5" fill="#e2e8f0" stroke="#64748b"/><text x="105" y="721" text-anchor="middle" font-size="12" fill="#333">frame t−5</text>
+    <rect x="164" y="698" width="106" height="36" rx="5" fill="#e2e8f0" stroke="#64748b"/><text x="217" y="721" text-anchor="middle" font-size="12" fill="#333">t−4</text>
+    <rect x="276" y="698" width="106" height="36" rx="5" fill="#e2e8f0" stroke="#64748b"/><text x="329" y="721" text-anchor="middle" font-size="12" fill="#333">t−3</text>
+    <rect x="388" y="698" width="106" height="36" rx="5" fill="#e2e8f0" stroke="#64748b"/><text x="441" y="721" text-anchor="middle" font-size="12" fill="#333">t−2</text>
+    <rect x="500" y="698" width="106" height="36" rx="5" fill="#e2e8f0" stroke="#64748b"/><text x="553" y="721" text-anchor="middle" font-size="12" fill="#333">t−1</text>
+    <rect x="612" y="698" width="116" height="36" rx="5" fill="#cbd5e1" stroke="#334155"/><text x="670" y="721" text-anchor="middle" font-size="12" font-weight="bold" fill="#111">t (newest)</text>
+  </g>
+  <text x="40" y="766" font-size="13" fill="#555">6 × 257 = <tspan font-weight="bold">1542 tokens</tspan>  +  learned 1D positional embedding (index in flattened sequence)</text>
+
+  <line x1="390" y1="776" x2="390" y2="800" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- transformer -->
+  <rect x="120" y="802" width="540" height="130" rx="10" fill="#ffedd5" stroke="#f97316" stroke-width="1.5"/>
+  <text x="390" y="828" text-anchor="middle" font-size="15" font-weight="bold" fill="#7c2d12">Transformer trunk — 8 layers · 8 heads · 512 dim</text>
+  <text x="390" y="852" text-anchor="middle" font-size="13" fill="#7c2d12">pre-LN GPT block: LN → MHA (block-causal mask) → +res → LN → MLP 4× GELU → +res</text>
+  <text x="390" y="874" text-anchor="middle" font-size="13" fill="#7c2d12">gradient checkpointing per layer · final LayerNorm</text>
+  <text x="390" y="912" text-anchor="middle" font-size="13" font-weight="bold" fill="#7c2d12">31.5M trainable / 51.5M total (paper: 29.5M / 51.6M)</text>
+
+  <!-- block-causal mask graphic -->
+  <g transform="translate(790, 780)">
+    <text x="120" y="0" text-anchor="middle" font-size="14" font-weight="bold" fill="#1a1a2e">block-causal mask</text>
+    <g stroke="#94a3b8" stroke-width="0.5">
+      <rect x="30"  y="12"  width="30" height="30" fill="#475569"/><rect x="60" y="12" width="30" height="30" fill="#f1f5f9"/><rect x="90" y="12" width="30" height="30" fill="#f1f5f9"/><rect x="120" y="12" width="30" height="30" fill="#f1f5f9"/><rect x="150" y="12" width="30" height="30" fill="#f1f5f9"/><rect x="180" y="12" width="30" height="30" fill="#f1f5f9"/>
+      <rect x="30"  y="42"  width="30" height="30" fill="#475569"/><rect x="60" y="42" width="30" height="30" fill="#475569"/><rect x="90" y="42" width="30" height="30" fill="#f1f5f9"/><rect x="120" y="42" width="30" height="30" fill="#f1f5f9"/><rect x="150" y="42" width="30" height="30" fill="#f1f5f9"/><rect x="180" y="42" width="30" height="30" fill="#f1f5f9"/>
+      <rect x="30"  y="72"  width="30" height="30" fill="#475569"/><rect x="60" y="72" width="30" height="30" fill="#475569"/><rect x="90" y="72" width="30" height="30" fill="#475569"/><rect x="120" y="72" width="30" height="30" fill="#f1f5f9"/><rect x="150" y="72" width="30" height="30" fill="#f1f5f9"/><rect x="180" y="72" width="30" height="30" fill="#f1f5f9"/>
+      <rect x="30"  y="102" width="30" height="30" fill="#475569"/><rect x="60" y="102" width="30" height="30" fill="#475569"/><rect x="90" y="102" width="30" height="30" fill="#475569"/><rect x="120" y="102" width="30" height="30" fill="#475569"/><rect x="150" y="102" width="30" height="30" fill="#f1f5f9"/><rect x="180" y="102" width="30" height="30" fill="#f1f5f9"/>
+      <rect x="30"  y="132" width="30" height="30" fill="#475569"/><rect x="60" y="132" width="30" height="30" fill="#475569"/><rect x="90" y="132" width="30" height="30" fill="#475569"/><rect x="120" y="132" width="30" height="30" fill="#475569"/><rect x="150" y="132" width="30" height="30" fill="#475569"/><rect x="180" y="132" width="30" height="30" fill="#f1f5f9"/>
+      <rect x="30"  y="162" width="30" height="30" fill="#475569"/><rect x="60" y="162" width="30" height="30" fill="#475569"/><rect x="90" y="162" width="30" height="30" fill="#475569"/><rect x="120" y="162" width="30" height="30" fill="#475569"/><rect x="150" y="162" width="30" height="30" fill="#475569"/><rect x="180" y="162" width="30" height="30" fill="#475569"/>
+    </g>
+    <text x="120" y="212" text-anchor="middle" font-size="12" fill="#555">bidirectional within a frame,</text>
+    <text x="120" y="228" text-anchor="middle" font-size="12" fill="#555">causal across frames (dark = attends)</text>
+    <text x="18" y="110" text-anchor="middle" font-size="11" fill="#777" transform="rotate(-90 18 110)">query frame →</text>
+  </g>
+
+  <!-- ===================== BAND 3: head ===================== -->
+  <text x="30" y="990" font-size="16" font-weight="bold" fill="#1a1a2e">3 · VQ-BeT joint chunk head (bug-fixed, PR #258) — at every frame's last patch token</text>
+
+  <line x1="390" y1="932" x2="390" y2="1008" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="240" y="1010" width="300" height="44" rx="8" fill="#fff" stroke="#334155"/>
+  <text x="390" y="1030" text-anchor="middle" font-size="13" font-weight="bold" fill="#333">readout: last patch token per frame</text>
+  <text x="390" y="1047" text-anchor="middle" font-size="12" fill="#555">(B, 6, 512) → LayerNorm</text>
+
+  <line x1="320" y1="1054" x2="230" y2="1090" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="460" y1="1054" x2="550" y2="1090" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- code head -->
+  <rect x="60" y="1092" width="340" height="88" rx="8" fill="#ffedd5" stroke="#f97316"/>
+  <text x="230" y="1114" text-anchor="middle" font-size="14" font-weight="bold" fill="#7c2d12">code head  MLP 512→1024→1024→64</text>
+  <text x="230" y="1136" text-anchor="middle" font-size="13" fill="#7c2d12">logits (4 quantizers × 16 codes)</text>
+  <text x="230" y="1158" text-anchor="middle" font-size="13" fill="#7c2d12">focal loss vs target codes</text>
+
+  <!-- offset head -->
+  <rect x="440" y="1092" width="360" height="88" rx="8" fill="#ffedd5" stroke="#f97316"/>
+  <text x="620" y="1114" text-anchor="middle" font-size="14" font-weight="bold" fill="#7c2d12">offset head  MLP 512→1024→1024→1536</text>
+  <text x="620" y="1136" text-anchor="middle" font-size="13" fill="#7c2d12">offset table (4 × 16 × 24), gather at codes, Σ quantizers</text>
+  <text x="620" y="1158" text-anchor="middle" font-size="13" font-weight="bold" fill="#7c2d12">L1 · teacher-forced at target codes (#258 fix)</text>
+
+  <!-- action tokenizer -->
+  <rect x="860" y="1030" width="280" height="96" rx="8" fill="#dbeafe" stroke="#3b82f6"/>
+  <text x="1000" y="1054" text-anchor="middle" font-size="14" font-weight="bold" fill="#1e3a8a">❄ Action chunk tokenizer</text>
+  <text x="1000" y="1076" text-anchor="middle" font-size="12" fill="#1e3a8a">RVQ 4 × 16 codes · y74asdtd:v9</text>
+  <text x="1000" y="1094" text-anchor="middle" font-size="12" fill="#1e3a8a">chunk (6 steps × 4 fields = 24-d)</text>
+  <text x="1000" y="1112" text-anchor="middle" font-size="12" fill="#1e3a8a">targets: codes + normalized chunk</text>
+
+  <line x1="1000" y1="1126" x2="1000" y2="1215" stroke="#3b82f6" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#arr)"/>
+  <text x="1010" y="1170" font-size="12" fill="#3b82f6">decode: invert(codes)</text>
+
+  <!-- combine -->
+  <line x1="230" y1="1180" x2="380" y2="1218" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="620" y1="1180" x2="560" y2="1218" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <rect x="240" y="1220" width="700" height="52" rx="8" fill="#fff" stroke="#334155" stroke-width="1.5"/>
+  <text x="590" y="1242" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">action chunk  =  decode(codes)  +  offset</text>
+  <text x="590" y="1262" text-anchor="middle" font-size="13" fill="#555">(B, 6 steps, 4) — gas · brake · steering · turn signal   (current + 5 future actions)</text>
+
+  <!-- loss / inference note -->
+  <rect x="240" y="1296" width="700" height="70" rx="8" fill="#f8fafc" stroke="#94a3b8" stroke-dasharray="6 4"/>
+  <text x="590" y="1322" text-anchor="middle" font-size="13" fill="#333"><tspan font-weight="bold">training:</tspan> loss at all 6 frames' readouts (each frame predicts its own chunk, paper §2.2)</text>
+  <text x="590" y="1344" text-anchor="middle" font-size="13" fill="#333"><tspan font-weight="bold">inference:</tspan> decode only the newest frame's chunk (sampled codes)</text>
+
+  <!-- footer: training setup -->
+  <line x1="40" y1="1400" x2="1140" y2="1400" stroke="#e2e8f0"/>
+  <text x="40" y="1430" font-size="13" fill="#555"><tspan font-weight="bold" fill="#333">Data:</tspan> clip_length 11 = 6 obs frames + 5 future actions · ~1.97M train samples · single camera</text>
+  <text x="40" y="1454" font-size="13" fill="#555"><tspan font-weight="bold" fill="#333">Training:</tspan> batch 128 · AdamW lr 1e-4 (no wd on Emb/LN/pos_embed) · cosine 12.5k warmup / 154k steps (= 10 epochs) · bf16</text>
+  <text x="40" y="1478" font-size="13" fill="#555"><tspan font-weight="bold" fill="#333">Ablation:</tspan> DINOv3 ViT-S/16 @256² (run 8crjqzii) vs DINOv2 ViT-S/14 @224² (run wxyp0bzq) — identical 16×16×384 patch grid</text>
+  <text x="40" y="1502" font-size="13" fill="#555"><tspan font-weight="bold" fill="#333">Deviations from paper:</tspan> vector goal g_t is per-frame (ego-relative waypoints) · +1 speed token per frame (paper is vision-only)</text>
+</svg>

--- a/src/rmind/components/dataloader.py
+++ b/src/rmind/components/dataloader.py
@@ -1,0 +1,205 @@
+"""DDP-aware drop-in for ``rbyte.dataloader.TorchDataNodeDataLoader``.
+
+rbyte's loader hard-codes ``RandomSampler`` and is not a ``torch.utils.data
+.DataLoader``, so Lightning cannot inject a ``DistributedSampler``. Under
+``trainer.devices>1`` every rank would draw an identical batch sequence
+(Lightning seeds all ranks alike) and the all-reduced gradient degenerates to
+the single-rank one — 2x the compute for an unchanged effective batch.
+
+This loader swaps in a ``DistributedSampler`` (disjoint per-rank shards, so
+world_size x per-rank batch = the effective batch) whenever
+``torch.distributed`` is initialized, and falls back to rbyte's exact
+behavior otherwise. ``DistributedSamplerEpochSetter`` forwards the epoch to
+the sampler for per-epoch reshuffling (Lightning only does this for plain
+DataLoaders).
+
+Only ``method: thread`` workers are supported under DDP: ``method: process``
+forks after CUDA initialization and deadlocks (fork + CUDA + locked
+shared-memory TensorDict).
+"""
+
+from collections.abc import Callable, Iterable, Sized
+from typing import Any, Literal, override
+
+import pytorch_lightning as pl
+import torch.distributed
+import torchdata.nodes as tn
+from pydantic import InstanceOf, PositiveInt, validate_call
+from rbyte.dataloader import BatchIndexableDataset, MapAndCollate
+from structlog import get_logger
+from torch import Generator
+from torch.utils.data import (
+    BatchSampler,
+    DistributedSampler,
+    RandomSampler,
+    SequentialSampler,
+    default_collate,
+)
+from torchdata.nodes.loader import LoaderIterator
+
+logger = get_logger(__name__)
+
+
+class DistributedTorchDataNodeDataLoader[T](Iterable[T], Sized):
+    """rbyte TorchDataNodeDataLoader with DDP-sharded sampling."""
+
+    @validate_call
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        dataset: InstanceOf[BatchIndexableDataset],
+        batch_size: int = 1,
+        shuffle: bool | None = None,
+        num_workers: PositiveInt = 1,
+        collate_fn: Callable[..., Any] | None = None,
+        pin_memory: bool = False,
+        pin_memory_device: str = "",
+        drop_last: bool = False,
+        in_order: bool = True,
+        method: Literal["thread", "process"] = "thread",
+        multiprocessing_context: Literal["spawn", "forkserver", "fork"] | None = None,
+        generator: InstanceOf[Generator] | None = None,
+        prefetch_factor: int = 2,
+        max_concurrent: int | None = None,
+        snapshot_frequency: int = 1,
+        prebatch: int | None = None,
+        seed: int = 0,
+    ) -> None:
+        self._dataset = dataset
+        self._batch_size = batch_size
+        self._shuffle = shuffle
+        self._drop_last = drop_last
+        self._generator = generator
+        self._seed = seed
+        self._method: Literal["thread", "process"] = method
+        self._num_workers = num_workers
+        self._in_order = in_order
+        self._multiprocessing_context = multiprocessing_context
+        self._max_concurrent = max_concurrent
+        self._snapshot_frequency = snapshot_frequency
+        self._prebatch = prebatch
+        self._collate_fn = collate_fn
+        self._pin_memory = pin_memory
+        self._pin_memory_device = pin_memory_device
+        self._prefetch_factor = prefetch_factor
+
+        self._distributed_sampler: DistributedSampler[Any] | None = None
+        self._sampler: BatchSampler | None = None
+        self._loader: tn.Loader[T] | None = None
+        self._built_distributed: bool | None = None
+
+    @staticmethod
+    def _distributed_now() -> bool:
+        return torch.distributed.is_available() and torch.distributed.is_initialized()
+
+    def _ensure_built(self) -> None:
+        # Rebuild if the process group appeared after a pre-DDP len()/iter()
+        # call — an unsharded graph under DDP silently degenerates the
+        # effective batch to a single rank's.
+        if self._loader is not None and (
+            self._built_distributed is False and self._distributed_now()
+        ):
+            logger.warning("rebuilding dataloader: process group appeared after build")
+            self._loader = None
+        if self._loader is None:
+            self._build()
+
+    def _build(self) -> None:
+        """Build the sampler + node graph on first use.
+
+        Deferred past __init__ because hydra instantiates the loader before
+        ``trainer.fit`` initializes the DDP process group; the sharding
+        decision must be taken at iteration time.
+
+        Raises:
+            ValueError: if ``method='process'`` is configured under DDP.
+        """
+        distributed = self._distributed_now()
+        self._built_distributed = distributed
+        if distributed:
+            if self._method != "thread":
+                msg = (
+                    "method='process' deadlocks under DDP (fork after CUDA init); "
+                    "use method='thread'"
+                )
+                raise ValueError(msg)
+            self._distributed_sampler = DistributedSampler(
+                self._dataset,  # ty:ignore[invalid-argument-type]  # type: ignore[arg-type]
+                shuffle=bool(self._shuffle),
+                drop_last=self._drop_last,
+                seed=self._seed,
+            )
+            sampler = self._distributed_sampler
+            logger.info(
+                "distributed sampler",
+                rank=self._distributed_sampler.rank,
+                world_size=self._distributed_sampler.num_replicas,
+                shard_len=self._distributed_sampler.num_samples,
+            )
+        else:
+            sampler = (  # type: ignore[assignment]
+                RandomSampler(self._dataset, generator=self._generator)  # type: ignore[arg-type]
+                if self._shuffle
+                else SequentialSampler(self._dataset)  # type: ignore[arg-type]
+            )
+
+        self._sampler = BatchSampler(
+            sampler,  # ty:ignore[invalid-argument-type]
+            batch_size=self._batch_size,
+            drop_last=self._drop_last,
+        )
+
+        node = tn.SamplerWrapper(self._sampler)
+        node = tn.ParallelMapper(
+            source=node,
+            map_fn=MapAndCollate(self._dataset, self._collate_fn or default_collate),
+            method=self._method,
+            num_workers=self._num_workers,
+            in_order=self._in_order,
+            multiprocessing_context=self._multiprocessing_context,
+            max_concurrent=self._max_concurrent,
+            snapshot_frequency=self._snapshot_frequency,
+            prebatch=self._prebatch,
+        )
+
+        if self._pin_memory:
+            node = tn.PinMemory(node, pin_memory_device=self._pin_memory_device)
+
+        node = tn.Prefetcher(
+            node, prefetch_factor=self._num_workers * self._prefetch_factor
+        )
+
+        self._loader = tn.Loader(node)
+
+    def set_epoch(self, epoch: int) -> None:
+        if self._distributed_sampler is not None:
+            self._distributed_sampler.set_epoch(epoch)
+
+    @override
+    def __iter__(self) -> LoaderIterator[T]:
+        self._ensure_built()
+        assert self._loader is not None  # noqa: S101
+        return iter(self._loader)
+
+    @override
+    def __len__(self) -> int:
+        self._ensure_built()
+        assert self._sampler is not None  # noqa: S101
+        return len(self._sampler)
+
+    @property
+    def dataset(self) -> BatchIndexableDataset:
+        return self._dataset
+
+
+class DistributedSamplerEpochSetter(pl.Callback):
+    """Forward the epoch to DDP-sharded loaders for per-epoch reshuffling."""
+
+    @override
+    def on_train_epoch_start(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        loader = trainer.train_dataloader
+        set_epoch = getattr(loader, "set_epoch", None)
+        if callable(set_epoch):
+            set_epoch(trainer.current_epoch)

--- a/src/rmind/components/optimizers/selective_adamw.py
+++ b/src/rmind/components/optimizers/selective_adamw.py
@@ -27,8 +27,15 @@ class SelectiveAdamW(AdamW):
         submodules = dict(module.named_modules())
         params = dict(module.named_parameters())
         for param_name in params:
-            submodule_name, param_type = param_name.rsplit(sep=".", maxsplit=1)
+            # top-level parameters (e.g. PatchPolicy's fusion gains) have no
+            # module prefix; their "submodule" is the root module itself
+            submodule_name, _, param_type = param_name.rpartition(".")
             match param_type:
+                # fusion_norm scale gains: scalar calibration parameters,
+                # no weight decay (decay would pull the goal gain toward 0
+                # and re-open the patch/goal scale gap it exists to close)
+                case "fusion_patch_gain" | "fusion_goal_gain":
+                    weight_decay_param_blacklist.add(param_name)
                 case "weight":
                     if isinstance(
                         submodules[submodule_name], weight_decay_module_blacklist

--- a/src/rmind/components/optimizers/selective_adamw.py
+++ b/src/rmind/components/optimizers/selective_adamw.py
@@ -55,14 +55,17 @@ class SelectiveAdamW(AdamW):
 
         weight_decay_param_whitelist = params.keys() - weight_decay_param_blacklist
 
+        # sorted: set iteration order is salted per process, and torch's
+        # Optimizer.load_state_dict maps saved state onto params POSITIONALLY --
+        # unsorted groups corrupt Adam moments on any cross-process resume
         param_groups = [
             {
                 "weight_decay": 0.0,
-                "params": [params[k] for k in weight_decay_param_blacklist],
+                "params": [params[k] for k in sorted(weight_decay_param_blacklist)],
             },
             {
                 "weight_decay": weight_decay,
-                "params": [params[k] for k in weight_decay_param_whitelist],
+                "params": [params[k] for k in sorted(weight_decay_param_whitelist)],
             },
         ]
 

--- a/src/rmind/components/optimizers/selective_adamw.py
+++ b/src/rmind/components/optimizers/selective_adamw.py
@@ -39,6 +39,11 @@ class SelectiveAdamW(AdamW):
                     weight_decay_param_blacklist.add(param_name)
 
                 # https://github.com/pytorch/pytorch/blob/v2.7.0/torch/nn/modules/activation.py#L1091
+                # `pos_embed`/`gamma` (timm ViT positional embedding / LayerScale,
+                # e.g. DINOv2): keep weight decay off, matching Embedding/LayerNorm
+                case "pos_embed" | "gamma":
+                    weight_decay_param_blacklist.add(param_name)
+
                 case (
                     "in_proj_weight" | "cls_token" | "reg_token" | "gamma_1" | "gamma_2"
                 ):

--- a/src/rmind/components/timm_backbone.py
+++ b/src/rmind/components/timm_backbone.py
@@ -1,4 +1,4 @@
-from math import prod
+from math import isqrt, prod
 from typing import override
 
 from timm import create_model
@@ -6,26 +6,53 @@ from torch import Tensor, nn
 
 
 class TimmBackbone(nn.Module):
+    """Frozen-friendly timm feature extractor with two output modes.
+
+    - `norm_patch_tokens=False` (default): timm `features_only` intermediates at
+      `out_indices` (pre final-norm), the historical rmind convention.
+    - `norm_patch_tokens=True`: the FINAL block's patch tokens after the model's
+      final LayerNorm -- DINOv2's `x_norm_patchtokens`, as consumed by DINO-WM
+      (https://github.com/gaoyuezhou/dino_wm); prefix (cls/register) tokens are
+      dropped. `out_indices` is ignored in this mode.
+
+    Both modes return `(..., C, H, W)`.
+    """
+
     def __init__(
         self,
         model_name: str = "vit_small_patch16_dinov3.lvd1689m",
         *,
         out_indices: list[int] | None = None,
         img_size: list[int] | None = None,
+        norm_patch_tokens: bool = False,
     ) -> None:
         super().__init__()
-        self.model: nn.Module = create_model(
-            model_name,
-            pretrained=True,
-            features_only=True,
-            out_indices=out_indices,
-            img_size=img_size,
+        self.norm_patch_tokens = norm_patch_tokens
+        self.model: nn.Module = (
+            create_model(model_name, pretrained=True, num_classes=0, img_size=img_size)
+            if norm_patch_tokens
+            else create_model(
+                model_name,
+                pretrained=True,
+                features_only=True,
+                out_indices=out_indices,
+                img_size=img_size,
+            )
         )
 
     @override
     def forward(self, input: Tensor) -> Tensor:
         *b, c, h, w = input.shape
         x = input.view(prod(b), c, h, w)
-        x = self.model(x)[-1]
+
+        if self.norm_patch_tokens:
+            # (B, prefix + P, D), final norm applied by timm's forward_features
+            tokens = self.model.forward_features(x)
+            tokens = tokens[:, self.model.num_prefix_tokens :]
+            grid = isqrt(tokens.shape[1])
+            x = tokens.transpose(1, 2).reshape(-1, tokens.shape[-1], grid, grid)
+        else:
+            x = self.model(x)[-1]
+
         *_, c, h, w = x.shape
         return x.view(*b, c, h, w)

--- a/src/rmind/components/timm_backbone.py
+++ b/src/rmind/components/timm_backbone.py
@@ -1,21 +1,26 @@
 from math import isqrt, prod
 from typing import override
 
+import torch
 from timm import create_model
 from torch import Tensor, nn
 
 
 class TimmBackbone(nn.Module):
-    """Frozen-friendly timm feature extractor with two output modes.
+    """Frozen-friendly timm feature extractor with three output modes.
 
-    - `norm_patch_tokens=False` (default): timm `features_only` intermediates at
-      `out_indices` (pre final-norm), the historical rmind convention.
+    - default (`out_indices`): timm `features_only` intermediates, PRE final-norm
+      -- the historical rmind convention.
     - `norm_patch_tokens=True`: the FINAL block's patch tokens after the model's
       final LayerNorm -- DINOv2's `x_norm_patchtokens`, as consumed by DINO-WM
       (https://github.com/gaoyuezhou/dino_wm); prefix (cls/register) tokens are
-      dropped. `out_indices` is ignored in this mode.
+      dropped. `out_indices` is ignored.
+    - `norm_indices=[i, ...]`: block-`i` intermediates WITH the final LayerNorm
+      applied (timm `forward_intermediates(norm=True)`), channel-concatenated
+      when more than one index is given -- e.g. `[10]` for "layer 10 + norm",
+      `[10, 11]` for "layer 10 + norm ⊕ final layer + norm" (C doubles).
 
-    Both modes return `(..., C, H, W)`.
+    All modes return `(..., C, H, W)`.
     """
 
     def __init__(
@@ -25,12 +30,17 @@ class TimmBackbone(nn.Module):
         out_indices: list[int] | None = None,
         img_size: list[int] | None = None,
         norm_patch_tokens: bool = False,
+        norm_indices: list[int] | None = None,
     ) -> None:
         super().__init__()
+        if norm_patch_tokens and norm_indices is not None:
+            msg = "norm_patch_tokens and norm_indices are mutually exclusive"
+            raise ValueError(msg)
         self.norm_patch_tokens = norm_patch_tokens
+        self.norm_indices = norm_indices
         self.model: nn.Module = (
             create_model(model_name, pretrained=True, num_classes=0, img_size=img_size)
-            if norm_patch_tokens
+            if norm_patch_tokens or norm_indices is not None
             else create_model(
                 model_name,
                 pretrained=True,
@@ -45,7 +55,16 @@ class TimmBackbone(nn.Module):
         *b, c, h, w = input.shape
         x = input.view(prod(b), c, h, w)
 
-        if self.norm_patch_tokens:
+        if self.norm_indices is not None:
+            feats = self.model.forward_intermediates(
+                x,
+                indices=self.norm_indices,
+                norm=True,
+                output_fmt="NCHW",
+                intermediates_only=True,
+            )
+            x = torch.cat(feats, dim=1)
+        elif self.norm_patch_tokens:
             # (B, prefix + P, D), final norm applied by timm's forward_features
             tokens = self.model.forward_features(x)
             tokens = tokens[:, self.model.num_prefix_tokens :]

--- a/src/rmind/components/vq.py
+++ b/src/rmind/components/vq.py
@@ -1,9 +1,12 @@
-from typing import final
+from typing import TYPE_CHECKING, cast, final
 
 import torch
 from torch import Tensor
 from torch.nn import Module
 from vector_quantize_pytorch import ResidualVQ as RVQ  # noqa: N817
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 @final
@@ -35,6 +38,26 @@ class ResidualVQ(Module):
             threshold_ema_dead_code=threshold_ema_dead_code,
             kmeans_init=kmeans_init,
         )
+
+        # The library codebook lazily runs kmeans-init on the first forward,
+        # guarded by a data-dependent `if self.initted` (a tensor buffer) that
+        # `torch.export` can't trace. That init is only needed while training
+        # from scratch -- an eval/inference model always loads an
+        # already-initialized codebook -- so gate it on the Python `training`
+        # flag, which export specializes as a constant. (Ported from
+        # feat/wpts-rvq.)
+        for layer in self.vq.layers:
+            self._guard_kmeans_init(cast("Module", layer._codebook))  # noqa: SLF001
+
+    @staticmethod
+    def _guard_kmeans_init(codebook: Module) -> None:
+        init_embed_ = cast("Callable[..., object]", codebook.init_embed_)
+
+        def guarded(*args: object, **kwargs: object) -> None:
+            if codebook.training:
+                init_embed_(*args, **kwargs)
+
+        codebook.init_embed_ = guarded  # ty:ignore[unresolved-attribute]
 
     @property
     def codebook_sizes(self) -> tuple[int, ...]:

--- a/src/rmind/config.py
+++ b/src/rmind/config.py
@@ -63,3 +63,13 @@ class HydraConfig[T](BaseModel):
                 return f"{module}.{qualname}"
 
         return ImportString._serialize(target)  # noqa: SLF001
+
+
+def init_hydra_param[T](
+    hparams: dict[str, Any], name: str, value: "HydraConfig[T] | T"
+) -> T:
+    if isinstance(value, HydraConfig):
+        hparams[name] = value.model_dump()
+        return value.instantiate()
+
+    return value

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -446,9 +446,36 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
 
         losses["offset"] = self.losses["offset"](predicted_chunk, target)
 
-        # gradient-free LAST-FRAME metrics: the training losses above average over
-        # all T readouts (contexts of 1..T frames), whereas JointPolicyObjective
-        # only ever scores the newest frame -- these make the two comparable
+        metrics = self._readout_metrics(
+            code_logits=code_logits,
+            offsets=offsets,
+            target_codes=target_codes,
+            target=target,
+            predicted_chunk=predicted_chunk,
+            sampled_chunk=sampled_chunk,
+            sampled_recon=sampled_recon,
+        )
+
+        return TensorDict({"policy": {"loss": losses, "metric": metrics}})
+
+    def _readout_metrics(  # noqa: PLR0913
+        self,
+        *,
+        code_logits: Tensor,
+        offsets: Tensor,
+        target_codes: Tensor,
+        target: Tensor,
+        predicted_chunk: Tensor,
+        sampled_chunk: Tensor,
+        sampled_recon: Tensor,
+    ) -> dict[str, Tensor]:
+        """Gradient-free diagnostics at the deployed readout.
+
+        The training losses average over all T readouts (contexts of 1..T
+        frames), whereas `JointPolicyObjective` only ever scores the newest
+        frame -- these make the two comparable.
+        """
+        tokenizer = self.tokenizer
         with torch.no_grad():
             metrics: dict[str, Tensor] = {"offset_sampled_recon": sampled_recon}
             for q in range(tokenizer.quantizer.num_quantizers):
@@ -489,7 +516,7 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
                 metrics[f"code_acc_{q}_last"] = correct[:, q].float().mean()
             metrics["code_acc_joint_last"] = correct.all(dim=-1).float().mean()
 
-        return TensorDict({"policy": {"loss": losses, "metric": metrics}})
+        return metrics
 
     def _step(self, batch: Any, prefix: str) -> STEP_OUTPUT:
         metrics = self._compute_metrics(batch)

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -462,6 +462,33 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
                 sampled_chunk[:, -1].detach(), target[:, -1]
             )
 
+            # ARGMAX decode -- exactly what inference emits when `sample_codes=false`,
+            # i.e. what the exported engine actually serves. This is a DEPLOYMENT-aligned
+            # number and it does not track the code losses above. Measured on
+            # dashing-dream-514 (wxyp0bzq) v0 -> v9: val code_0 rose 0.811 -> 2.885
+            # (+256%) while this metric IMPROVED 13% (0.0456 -> 0.0395) and p_gt improved
+            # 20% -- the rising NLL is tail miscalibration, not capability loss. Across
+            # arms it is worse than uninformative: dinov2_smalltrunk has the BEST val
+            # code_0 (0.890) and the WORST argmax recon (0.0462), and it underperformed
+            # in rsim. Select checkpoints on this, not on val/loss/code_*.
+            argmax_codes = code_logits.argmax(dim=-1)
+            argmax_chunk = tokenizer.invert(argmax_codes) + self._offset(
+                offsets, argmax_codes
+            )
+            metrics["offset_argmax_recon"] = self.losses["offset"](argmax_chunk, target)
+            metrics["offset_argmax_recon_last"] = self.losses["offset"](
+                argmax_chunk[:, -1], target[:, -1]
+            )
+
+            # code accuracy at the deployed readout. Without it the code losses cannot
+            # separate "argmax still right, tails miscalibrated" from "argmax now wrong",
+            # which is the distinction that decides whether a rising val code loss
+            # matters. Chance is 1/num_codes marginally, (1/num_codes)**g jointly.
+            correct = argmax_codes[:, -1] == target_codes[:, -1]  # (b, g)
+            for q in range(tokenizer.quantizer.num_quantizers):
+                metrics[f"code_acc_{q}_last"] = correct[:, q].float().mean()
+            metrics["code_acc_joint_last"] = correct.all(dim=-1).float().mean()
+
         return TensorDict({"policy": {"loss": losses, "metric": metrics}})
 
     def _step(self, batch: Any, prefix: str) -> STEP_OUTPUT:

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -167,6 +167,7 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
         sample_codes: bool = True,
         teacher_force_offset: bool = True,
         offset_scale: float | None = None,
+        fusion_norm: bool = False,
         optimizer: HydraConfig[Optimizer] | None = None,
         lr_scheduler: LRSchedulerHydraConfig | None = None,
         prediction_config: Annotated[
@@ -229,7 +230,40 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
             "sample_codes": sample_codes,
             "teacher_force_offset": teacher_force_offset,
             "offset_scale": offset_scale,
+            "fusion_norm": fusion_norm,
         }
+
+        # scale-balanced feature fusion: LayerNorm + learnable gain on the patch
+        # side (encoder-agnostic scale; DINO token-norm spread is negligible so
+        # nothing informative is lost), and a learnable gain on the goal side
+        # initialized so RMS(gain * z_q) ~= RMS(LN(patches)) ~= 1 -- calibrated
+        # from the frozen RVQ codebooks (seeded, data-free, identical across
+        # DDP ranks). Per-sample code-norm information passes through untouched.
+        if fusion_norm:
+            goal_dim = self.goal_encoder.quantizer.dim
+            patch_dim = self.patch_projection.in_features - goal_dim
+            self.fusion_patch_norm: Module | None = nn.LayerNorm(patch_dim)
+            self.fusion_patch_gain: nn.Parameter | None = nn.Parameter(
+                torch.tensor(1.0)
+            )
+            with torch.no_grad():
+                quantizer = self.goal_encoder.quantizer
+                generator = torch.Generator().manual_seed(0)
+                codes = torch.stack(
+                    [
+                        torch.randint(
+                            0, quantizer.codebook_size, (1024,), generator=generator
+                        )
+                        for _ in range(quantizer.num_quantizers)
+                    ],
+                    dim=-1,
+                )
+                rms = quantizer.lookup(codes).pow(2).mean().sqrt()
+            self.fusion_goal_gain: nn.Parameter | None = nn.Parameter(1.0 / rms)
+        else:
+            self.fusion_patch_norm = None
+            self.fusion_patch_gain = None
+            self.fusion_goal_gain = None
 
         if optimizer is not None:
             hparams["optimizer"] = optimizer.model_dump()
@@ -280,6 +314,12 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
         with torch.no_grad():
             patches = self.image_encoder(images)  # (b, t, p, d_img)
             goal = self.goal_encoder.encode(waypoints)  # (b, t, g)
+
+        if self.fusion_patch_norm is not None:
+            # NOTE: no in-place ops -- these tensors come from a no_grad block
+            # and the gains must receive gradients
+            patches = self.fusion_patch_norm(patches) * self.fusion_patch_gain
+            goal = torch.mul(goal, self.fusion_goal_gain)
 
         _, _, num_patches, _ = patches.shape
         patches = torch.cat(

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -237,9 +237,17 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
         # scale-balanced feature fusion: LayerNorm + learnable gain on the patch
         # side (encoder-agnostic scale; DINO token-norm spread is negligible so
         # nothing informative is lost), and a learnable gain on the goal side
-        # initialized so RMS(gain * z_q) ~= RMS(LN(patches)) ~= 1 -- calibrated
-        # from the frozen RVQ codebooks (seeded, data-free, identical across
-        # DDP ranks). Per-sample code-norm information passes through untouched.
+        # initialized to 1/RMS so that RMS(gain * z_q) ~= RMS(LN(patches)) ~= 1 --
+        # calibrated from the frozen RVQ codebooks (seeded, data-free, identical
+        # across DDP ranks). Per-sample code-norm information passes through
+        # untouched.
+        #
+        # CAVEAT on the estimate: the codes below are drawn INDEPENDENTLY and
+        # UNIFORMLY per quantizer, whereas a real z_q is a residual-VQ tuple
+        # (level q+1 corrects level q's residual) with strongly non-uniform code
+        # usage. Measured on gzxgumtf:v9 the estimate is 1.86x too large
+        # (0.143 vs 0.077 on real data), which lands the goal stream ~2x quieter
+        # than intended. Prefer passing a measured value where it is known.
         if fusion_norm:
             goal_dim = self.goal_encoder.quantizer.dim
             patch_dim = self.patch_projection.in_features - goal_dim
@@ -272,6 +280,12 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
                     .sqrt()
                     .cpu()
                 )
+            if not bool(rms.isfinite()) or not float(rms) > 0.0:
+                msg = (
+                    f"fusion_norm goal-gain calibration produced RMS={float(rms)}; "
+                    "the goal codebooks are probably uninitialized (1/RMS is not finite)"
+                )
+                raise ValueError(msg)
             self.fusion_goal_gain: nn.Parameter | None = nn.Parameter(1.0 / rms)
         else:
             self.fusion_patch_norm = None
@@ -750,7 +764,9 @@ class PatchPolicyHead(pl.LightningModule):
     def __init__(
         self,
         *,
-        norm: InstanceOf[Module],
+        # optional, mirroring PatchPolicy.norm -- head-only export of an arm
+        # trained with `norm: null` must not fail validation
+        norm: InstanceOf[Module] | None,
         code_head: InstanceOf[Module],
         offset_head: InstanceOf[Module],
         tokenizer: InstanceOf[Module],
@@ -767,7 +783,8 @@ class PatchPolicyHead(pl.LightningModule):
         quantizer = self.tokenizer.quantizer
         g, c = quantizer.num_quantizers, quantizer.codebook_size
 
-        features = self.norm(features)
+        if self.norm is not None:
+            features = self.norm(features)
         code_logits = rearrange(
             self.code_head(features), "... (g c) -> ... g c", g=g, c=c
         )

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -476,6 +476,36 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
         return model.eval()
 
     @classmethod
+    def load_for_continuation(
+        cls, artifact: str, *, optimizer: Any, lr_scheduler: Any | None = None
+    ) -> "PatchPolicy":
+        """Warm-start continuation training from a finished run's checkpoint.
+
+        Loads weights AND saved hparams from the artifact, then replaces only
+        the optimization config: fresh optimizer state (Adam moments reset) and
+        the given LR/schedule. `lr_scheduler=None` -> constant LR, no warmup.
+        The replacement is written back into `hparams` so checkpoints saved by
+        the continuation run reload with the continuation settings.
+        """
+        if not isinstance(optimizer, HydraConfig):
+            optimizer = HydraConfig[Optimizer].model_validate(optimizer)
+        if lr_scheduler is not None and not isinstance(
+            lr_scheduler, LRSchedulerHydraConfig
+        ):
+            lr_scheduler = LRSchedulerHydraConfig.model_validate(lr_scheduler)
+
+        model = cls.load_from_wandb_artifact(
+            artifact, filename="model.ckpt", map_location="cpu", weights_only=False
+        )
+        model.optimizer = optimizer
+        model.lr_scheduler = lr_scheduler
+        model.hparams["optimizer"] = optimizer.model_dump()
+        model.hparams["lr_scheduler"] = (
+            lr_scheduler.model_dump() if lr_scheduler is not None else None
+        )
+        return model
+
+    @classmethod
     def load_head_for_export(cls, artifact: str) -> "PatchPolicyHead":
         """Head-only export for on-the-fly decoding (see `PatchPolicyHead`)."""
         model = cls.load_from_wandb_artifact(

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -475,6 +475,19 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
         )
         return model.eval()
 
+    @classmethod
+    def load_head_for_export(cls, artifact: str) -> "PatchPolicyHead":
+        """Head-only export for on-the-fly decoding (see `PatchPolicyHead`)."""
+        model = cls.load_from_wandb_artifact(
+            artifact, filename="model.ckpt", map_location="cpu", weights_only=False
+        ).eval()
+        return PatchPolicyHead(
+            norm=model.norm,
+            code_head=model.code_head,
+            offset_head=model.offset_head,
+            tokenizer=model.tokenizer,
+        ).eval()
+
     @staticmethod
     def _structure(chunk: Tensor) -> TensorDict:
         """Split a normalized `(b, horizon, action_features)` chunk into named fields."""
@@ -565,3 +578,64 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
             return {"optimizer": optimizer, "lr_scheduler": lr_scheduler}
 
         return {"optimizer": optimizer}
+
+
+@final
+class PatchPolicyHead(pl.LightningModule):
+    """The VQ-BeT head alone, for split deployment with on-the-fly decoding.
+
+    Consumes the trunk's readout token (the `BlockCausalTransformer` output at a
+    frame's last patch token, BEFORE `PatchPolicy.norm` -- the LayerNorm is part
+    of this module) plus caller-chosen codes, and emits everything a custom
+    decode strategy needs:
+
+    - ``code_logits`` `(b, g, c)`: pick codes however you like (argmax,
+      temperature sampling, entropy gating, ...) -- code selection is
+      deliberately OUTSIDE the graph;
+    - ``offsets`` `(b, g, c, action_dim)`: the full state-conditioned offset
+      table, for offset inspection or custom gathering;
+    - ``chunk`` `(b, horizon, action_features)`: `decode(codes) + offset@codes`
+      for the codes passed IN. Two-pass usage: run once (any codes) to read
+      logits, choose codes, run again to decode -- the head is a few MLPs, so a
+      second pass costs microseconds.
+    """
+
+    @validate_call
+    def __init__(
+        self,
+        *,
+        norm: InstanceOf[Module],
+        code_head: InstanceOf[Module],
+        offset_head: InstanceOf[Module],
+        tokenizer: InstanceOf[Module],
+    ) -> None:
+        super().__init__()
+        self.norm = norm
+        self.code_head = code_head
+        self.offset_head = offset_head
+        self.tokenizer = tokenizer.requires_grad_(False).eval()  # noqa: FBT003
+
+    @override
+    def forward(self, inputs: Mapping[str, Tensor]) -> TensorDict:
+        features, codes = inputs["features"], inputs["codes"]
+        quantizer = self.tokenizer.quantizer
+        g, c = quantizer.num_quantizers, quantizer.codebook_size
+
+        features = self.norm(features)
+        code_logits = rearrange(
+            self.code_head(features), "... (g c) -> ... g c", g=g, c=c
+        )
+        offsets = rearrange(
+            self.offset_head(features), "... (g c a) -> ... g c a", g=g, c=c
+        )
+
+        offset = PatchPolicy._gather_offset(offsets, codes)  # noqa: SLF001
+        chunk = (self.tokenizer.invert(codes) + offset).unflatten(
+            -1,
+            (-1, self.tokenizer._action_features),  # noqa: SLF001
+        )
+        return TensorDict({
+            "code_logits": code_logits,
+            "offsets": offsets,
+            "chunk": chunk,
+        })

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -1,4 +1,5 @@
 from collections.abc import Mapping
+from itertools import chain
 from typing import Annotated, Any, final, override
 
 import pytorch_lightning as pl
@@ -258,7 +259,18 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
                     ],
                     dim=-1,
                 )
-                rms = quantizer.lookup(codes).pow(2).mean().sqrt()
+                # the CPU generator fixes the seed sequence; lookup must run on
+                # whatever device the loaded codebooks landed on
+                quantizer_device = next(
+                    chain(quantizer.parameters(), quantizer.buffers())
+                ).device
+                rms = (
+                    quantizer.lookup(codes.to(quantizer_device))
+                    .pow(2)
+                    .mean()
+                    .sqrt()
+                    .cpu()
+                )
             self.fusion_goal_gain: nn.Parameter | None = nn.Parameter(1.0 / rms)
         else:
             self.fusion_patch_norm = None

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -1,0 +1,519 @@
+from collections.abc import Mapping
+from typing import Annotated, Any, final, override
+
+import pytorch_lightning as pl
+import torch
+from einops import rearrange
+from pydantic import Field, InstanceOf, validate_call
+from pytorch_lightning.utilities.types import STEP_OUTPUT, OptimizerLRScheduler
+from tensordict import TensorDict
+from torch import Tensor, nn
+from torch.nn import Module
+from torch.nn import functional as F
+from torch.optim import Optimizer
+from torch.utils._pytree import MappingKey  # noqa: PLC2701
+
+from rmind.components import optimizers
+from rmind.components.containers import ModuleDict
+from rmind.components.objectives.base import ObjectivePredictionKey, Prediction
+from rmind.components.transformer.utils import run_layer_stack
+from rmind.config import HydraConfig, init_hydra_param
+from rmind.models.action_tokenizer import LRSchedulerHydraConfig
+from rmind.models.control_transformer import PredictionConfig
+from rmind.utils._wandb import LoadableFromArtifact
+from rmind.utils.pytree import key_get_default
+
+type Path = tuple[str, ...]
+
+
+def block_causal_mask(
+    num_frames: int, tokens_per_frame: int, *, device: torch.device | None = None
+) -> Tensor:
+    """Bool mask (True = blocked) over the flattened `num_frames * tokens_per_frame`
+    sequence: full bidirectional attention within a frame, causal across frames
+    (https://arxiv.org/pdf/2607.18236).
+    """
+    frames = (
+        torch.arange(num_frames * tokens_per_frame, device=device) // tokens_per_frame
+    )
+    return frames[None, :] > frames[:, None]
+
+
+@final
+class TransformerBlock(nn.Module):
+    """Pre-LN GPT block (minGPT-style, as used by the VQ-BeT policy trunk)."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        dim_model: int,
+        num_heads: int,
+        attn_dropout: float = 0.1,
+        resid_dropout: float = 0.1,
+        mlp_dropout: float = 0.1,
+        hidden_layer_multiplier: int = 4,
+    ) -> None:
+        super().__init__()
+
+        self.attn_norm = nn.LayerNorm(dim_model)
+        self.attn = nn.MultiheadAttention(
+            embed_dim=dim_model,
+            num_heads=num_heads,
+            dropout=attn_dropout,
+            batch_first=True,
+        )
+        self.resid_drop = nn.Dropout(resid_dropout)
+        self.mlp_norm = nn.LayerNorm(dim_model)
+        self.mlp = nn.Sequential(
+            nn.Linear(dim_model, hidden_layer_multiplier * dim_model),
+            nn.GELU(),
+            nn.Linear(hidden_layer_multiplier * dim_model, dim_model),
+            nn.Dropout(mlp_dropout),
+        )
+
+    @override
+    def forward(self, x: Tensor, mask: Tensor) -> Tensor:
+        attn_out, _ = self.attn(
+            *(self.attn_norm(x),) * 3, attn_mask=mask, need_weights=False
+        )
+        # NOTE: no in-place ops on the residual stream (autograd + checkpointing)
+        h = x + self.resid_drop(attn_out)
+        return h + self.mlp(self.mlp_norm(h))
+
+
+@final
+class BlockCausalTransformer(nn.Module):
+    """Flattened-sequence encoder over `num_frames * tokens_per_frame` tokens with a
+    learned 1D positional embedding and a block-causal attention mask
+    (https://arxiv.org/pdf/2607.18236).
+    """
+
+    @validate_call
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        dim_model: int,
+        num_layers: int,
+        num_heads: int,
+        max_sequence_length: int,
+        attn_dropout: float = 0.1,
+        resid_dropout: float = 0.1,
+        mlp_dropout: float = 0.1,
+        hidden_layer_multiplier: int = 4,
+    ) -> None:
+        super().__init__()
+
+        self.position_embedding = nn.Embedding(max_sequence_length, dim_model)
+        nn.init.trunc_normal_(
+            self.position_embedding.weight, mean=0.0, std=0.02, a=-0.04, b=0.04
+        )
+        self.layers = nn.ModuleList([
+            TransformerBlock(
+                dim_model=dim_model,
+                num_heads=num_heads,
+                attn_dropout=attn_dropout,
+                resid_dropout=resid_dropout,
+                mlp_dropout=mlp_dropout,
+                hidden_layer_multiplier=hidden_layer_multiplier,
+            )
+            for _ in range(num_layers)
+        ])
+        self.norm = nn.LayerNorm(dim_model)
+
+    @override
+    def forward(self, src: Tensor, *, num_frames: int) -> Tensor:
+        _, seq_len, _ = src.shape
+        x = src + self.position_embedding(torch.arange(seq_len, device=src.device))
+        mask = block_causal_mask(num_frames, seq_len // num_frames, device=src.device)
+        x = run_layer_stack(self.layers, x, mask, training=self.training)
+        return self.norm(x)
+
+
+class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
+    """Patch Policy (https://arxiv.org/pdf/2607.18236) with a VQ-BeT action head.
+
+    Per frame: frozen ViT patch features `(P, D)` get the frozen waypoints-tokenizer
+    latent `g_t` (that frame's goal vector) concatenated to every patch token --
+    the paper's `T x P x (D + G)` scheme -- then projected to the policy width. An
+    embedded speed token is prepended, the `T x (P + 1)` sequence is flattened,
+    given a learned 1D positional embedding, and run through a block-causal
+    transformer (bidirectional intra-frame, causal inter-frame). Each frame's LAST
+    patch token predicts that frame's action chunk with the VQ-BeT joint head from
+    `JointPolicyObjective` (frozen residual-VQ chunk tokenizer; focal code loss +
+    teacher-forced L1 offset).
+    """
+
+    @validate_call
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        input_transform: HydraConfig[Module] | InstanceOf[Module],
+        image_encoder: HydraConfig[Module] | InstanceOf[Module],
+        goal_encoder: HydraConfig[Module] | InstanceOf[Module],
+        patch_projection: HydraConfig[Module] | InstanceOf[Module],
+        speed_tokenizer: HydraConfig[Module] | InstanceOf[Module],
+        speed_embedding: HydraConfig[Module] | InstanceOf[Module],
+        encoder: HydraConfig[BlockCausalTransformer]
+        | InstanceOf[BlockCausalTransformer],
+        tokenizer: HydraConfig[Module] | InstanceOf[Module],
+        code_head: HydraConfig[Module] | InstanceOf[Module],
+        offset_head: HydraConfig[Module] | InstanceOf[Module],
+        losses: HydraConfig[ModuleDict] | InstanceOf[ModuleDict],
+        norm: HydraConfig[Module] | InstanceOf[Module] | None = None,
+        image: Path = ("image", "cam_front_left"),
+        speed: Path = ("continuous", "speed"),
+        waypoints: Path = ("context", "waypoints"),
+        chunk: Path = ("joint_actions",),
+        sample_codes: bool = True,
+        teacher_force_offset: bool = True,
+        offset_scale: float | None = None,
+        optimizer: HydraConfig[Optimizer] | None = None,
+        lr_scheduler: LRSchedulerHydraConfig | None = None,
+        prediction_config: Annotated[
+            PredictionConfig, Field(default_factory=PredictionConfig)
+        ],
+    ) -> None:
+        super().__init__()
+
+        hparams: dict[str, Any] = {}
+
+        self.input_transform = init_hydra_param(
+            hparams, "input_transform", input_transform
+        )
+        # frozen feature extractors: never train, never leave eval mode (see train())
+        self.image_encoder = (
+            init_hydra_param(hparams, "image_encoder", image_encoder)
+            .requires_grad_(False)  # noqa: FBT003
+            .eval()
+        )
+        self.goal_encoder = (
+            init_hydra_param(hparams, "goal_encoder", goal_encoder)
+            .requires_grad_(False)  # noqa: FBT003
+            .eval()
+        )
+        self.tokenizer = (
+            init_hydra_param(hparams, "tokenizer", tokenizer)
+            .requires_grad_(False)  # noqa: FBT003
+            .eval()
+        )
+
+        self.patch_projection = init_hydra_param(
+            hparams, "patch_projection", patch_projection
+        )
+        self.speed_tokenizer = init_hydra_param(
+            hparams, "speed_tokenizer", speed_tokenizer
+        )
+        self.speed_embedding = init_hydra_param(
+            hparams, "speed_embedding", speed_embedding
+        )
+        self.encoder: BlockCausalTransformer = init_hydra_param(
+            hparams, "encoder", encoder
+        )
+        self.code_head = init_hydra_param(hparams, "code_head", code_head)
+        self.offset_head = init_hydra_param(hparams, "offset_head", offset_head)
+        self.losses: ModuleDict = init_hydra_param(hparams, "losses", losses)
+        self.norm: Module | None = init_hydra_param(hparams, "norm", norm)
+
+        self.image: Path = image
+        self.speed: Path = speed
+        self.waypoints: Path = waypoints
+        self.chunk: Path = chunk
+        self.sample_codes = sample_codes
+        self.teacher_force_offset = teacher_force_offset
+        self.offset_scale = offset_scale
+        hparams |= {
+            "image": image,
+            "speed": speed,
+            "waypoints": waypoints,
+            "chunk": chunk,
+            "sample_codes": sample_codes,
+            "teacher_force_offset": teacher_force_offset,
+            "offset_scale": offset_scale,
+        }
+
+        if optimizer is not None:
+            hparams["optimizer"] = optimizer.model_dump()
+        self.optimizer: HydraConfig[Optimizer] | None = optimizer
+
+        if lr_scheduler is not None:
+            hparams["lr_scheduler"] = lr_scheduler.model_dump()
+        self.lr_scheduler: LRSchedulerHydraConfig | None = lr_scheduler
+
+        self.prediction_config = prediction_config
+
+        self.save_hyperparameters(hparams)
+
+    @override
+    def train(self, mode: bool = True) -> "PatchPolicy":
+        super().train(mode)
+        self.image_encoder.eval()
+        self.goal_encoder.eval()
+        self.tokenizer.eval()
+        return self
+
+    @staticmethod
+    def _get(inputs: Mapping[str, Any], path: Path) -> Tensor:
+        value = key_get_default(inputs, tuple(map(MappingKey, path)), None)
+        if value is None:
+            msg = f"input {path!r} missing from transformed batch"
+            raise KeyError(msg)
+        return value
+
+    def _features(self, batch: Any) -> tuple[Tensor, Tensor]:
+        """Per-frame readout features `(b, t, d)` and the action chunks `(b, t, h, a)`."""
+        inputs = self.input_transform(batch)
+
+        images = self._get(inputs, self.image)  # (b, t, c, h, w)
+        speed = self._get(inputs, self.speed)  # (b, t, 1)
+        waypoints = self._get(inputs, self.waypoints)  # (b, t, n, 2)
+        chunk = self._get(inputs, self.chunk)  # (b, t, horizon, fields)
+
+        with torch.no_grad():
+            patches = self.image_encoder(images)  # (b, t, p, d_img)
+            goal = self.goal_encoder.encode(waypoints)  # (b, t, g)
+
+        _, _, num_patches, _ = patches.shape
+        patches = torch.cat(
+            [patches, goal.unsqueeze(-2).expand(-1, -1, num_patches, -1)], dim=-1
+        )  # T x P x (D + G), https://arxiv.org/pdf/2607.18236 section 2.1
+        patches = self.patch_projection(patches)  # (b, t, p, d)
+
+        speed_token = self.speed_embedding(self.speed_tokenizer(speed))  # (b, t, 1, d)
+
+        # speed first so the frame block ends on a patch token (the readout position)
+        tokens = torch.cat([speed_token, patches], dim=-2)  # (b, t, p + 1, d)
+        _, num_frames, _, _ = tokens.shape
+
+        embedding = self.encoder(
+            rearrange(tokens, "b t k d -> b (t k) d"), num_frames=num_frames
+        )
+        features = rearrange(embedding, "b (t k) d -> b t k d", t=num_frames)[
+            :, :, -1
+        ]  # last patch token per frame
+
+        if self.norm is not None:
+            features = self.norm(features)
+
+        return features, chunk
+
+    # VQ-BeT joint head -- mirrors `JointPolicyObjective` (incl. the teacher-forced
+    # offset fix) with a leading (b, t) batch instead of (b,).
+
+    def _heads(self, features: Tensor) -> tuple[Tensor, Tensor]:
+        """Code logits (*b, g, c) and the full offset table (*b, g, c, action_dim)."""
+        quantizer = self.tokenizer.quantizer
+        g, c = quantizer.num_quantizers, quantizer.codebook_size
+
+        code_logits = rearrange(
+            self.code_head(features), "... (g c) -> ... g c", g=g, c=c
+        )
+        offsets = rearrange(
+            self.offset_head(features), "... (g c a) -> ... g c a", g=g, c=c
+        )
+        return code_logits, offsets
+
+    @staticmethod
+    def _gather_offset(offsets: Tensor, codes: Tensor) -> Tensor:
+        """Select each quantizer's offset at `codes` and sum over quantizers."""
+        index = codes[..., None, None].expand(*codes.shape, 1, offsets.shape[-1])
+        # https://arxiv.org/pdf/2403.03181 Figure 2.
+        return offsets.gather(-2, index).squeeze(-2).sum(dim=-2)  # (*b, action_dim)
+
+    def _offset(self, offsets: Tensor, codes: Tensor) -> Tensor:
+        offset = self._gather_offset(offsets, codes)
+        if self.offset_scale is None:
+            return offset
+        return torch.tanh(offset / self.offset_scale) * self.offset_scale
+
+    def _sample_codes(self, code_logits: Tensor) -> Tensor:
+        *batch, g, c = code_logits.shape
+        if self.sample_codes:
+            return rearrange(
+                torch.multinomial(code_logits.softmax(dim=-1).reshape(-1, c), 1),
+                "(b g) 1 -> b g",
+                g=g,
+            ).reshape(*batch, g)
+        return code_logits.argmax(dim=-1)
+
+    def _predict_chunk(self, features: Tensor) -> Tensor:
+        """Decode `invert(codes) + offset` -> `(*b, horizon, action_features)`."""
+        code_logits, offsets = self._heads(features)
+        codes = self._sample_codes(code_logits)
+        offset = self._offset(offsets, codes)
+
+        return (self.tokenizer.invert(codes) + offset).unflatten(
+            -1,
+            (-1, self.tokenizer._action_features),  # noqa: SLF001
+        )
+
+    def _compute_metrics(self, batch: Any) -> TensorDict:
+        features, chunk = self._features(batch)  # (b, t, d), (b, t, h, a)
+        tokenizer = self.tokenizer
+
+        with torch.no_grad():
+            target_codes = tokenizer(chunk)  # (b, t, num_quantizers)
+            target = tokenizer._normalize(  # noqa: SLF001
+                chunk.flatten(-2, -1)
+            )  # (b, t, action_dim)
+
+        code_logits, offsets = self._heads(features)  # (b, t, g, c), (b, t, g, c, a)
+
+        losses: dict[str, Tensor] = {}
+
+        # per-quantizer classification against the ground-truth codes, supervised at
+        # every frame's readout token (https://arxiv.org/pdf/2607.18236 section 2.2)
+        for q in range(tokenizer.quantizer.num_quantizers):
+            losses[f"code_{q}"] = self.losses["code"](
+                rearrange(code_logits[..., q, :], "b t c -> (b t) c"),
+                rearrange(target_codes[..., q], "b t -> (b t)"),
+            )
+
+        # reconstruction as inference does it, logged for train-curve comparability
+        codes = self._sample_codes(code_logits)
+        sampled_chunk = tokenizer.invert(codes) + self._offset(offsets, codes)
+        sampled_recon = self.losses["offset"](sampled_chunk.detach(), target)
+
+        if self.teacher_force_offset:
+            # offset supervised at the GROUND-TRUTH codes (teacher forcing), so each
+            # code's offset entry only sees residuals of actions that quantized to it
+            predicted_chunk = tokenizer.invert(target_codes) + self._offset(
+                offsets, target_codes
+            )
+        else:
+            predicted_chunk = sampled_chunk
+
+        losses["offset"] = self.losses["offset"](predicted_chunk, target)
+
+        return TensorDict({
+            "policy": {
+                "loss": losses,
+                "metric": {"offset_sampled_recon": sampled_recon},
+            }
+        })
+
+    def _step(self, batch: Any, prefix: str) -> STEP_OUTPUT:
+        metrics = self._compute_metrics(batch)
+
+        losses = metrics.select(*((k, "loss") for k in metrics.keys()))  # noqa: SIM118
+        metrics["loss", "total"] = losses.sum(reduce=True)
+
+        self.log_dict(
+            {
+                "/".join([prefix, *k]): v
+                for k, v in metrics.detach().items(
+                    include_nested=True, leaves_only=True
+                )
+            },
+            sync_dist=True,
+        )
+
+        return {"loss": metrics["loss", "total"]}
+
+    @override
+    def training_step(self, batch: dict[str, Any], _batch_idx: int) -> STEP_OUTPUT:
+        return self._step(batch, "train")
+
+    @override
+    def validation_step(self, batch: dict[str, Any], _batch_idx: int) -> STEP_OUTPUT:
+        if self.trainer.sanity_checking:
+            return {
+                "loss": self._compute_metrics(batch)["policy", "loss"].sum(reduce=True)
+            }
+        return self._step(batch, "val")
+
+    @override
+    def forward(self, batch: Any) -> TensorDict:
+        features, _ = self._features(batch)
+        chunk = self._predict_chunk(features[:, -1])
+        return TensorDict({"policy": {"joint_actions": chunk}})
+
+    @staticmethod
+    def _structure(chunk: Tensor) -> TensorDict:
+        """Split a normalized `(b, horizon, action_features)` chunk into named fields."""
+        return TensorDict({
+            "continuous": TensorDict({
+                "gas_pedal": chunk[..., 0],
+                "brake_pedal": chunk[..., 1],
+                "steering_angle": chunk[..., 2],
+            }),
+            "discrete": TensorDict({
+                "turn_signal": torch.bucketize(
+                    chunk[..., 3] * 2, torch.tensor([0.5, 1.5], device=chunk.device)
+                )
+            }),
+        })
+
+    @override
+    def predict_step(self, batch: dict[str, Any]) -> TensorDict:
+        keys = frozenset(self.prediction_config.objectives)
+        predictions: dict[ObjectivePredictionKey, Prediction] = {}
+        tokenizer = self.tokenizer
+
+        features, chunk = self._features(batch)
+        features = features[:, -1]  # predict from the newest frame only
+
+        b, t = chunk.shape[:2]
+        time_index = torch.arange(t, device=features.device).expand(b, -1)[:, -1:]
+
+        ground_truth = tokenizer._normalize(  # noqa: SLF001
+            chunk[:, -1].flatten(-2, -1)
+        ).unflatten(-1, (-1, tokenizer._action_features))  # noqa: SLF001
+
+        if (key := ObjectivePredictionKey.GROUND_TRUTH) in keys:
+            gt = self._structure(ground_truth)
+            gt["discrete", "turn_signal"] = chunk[:, -1, :, 3].long()
+            predictions[key] = Prediction(value=gt, time_index=time_index)
+
+        needs_prediction = keys & {
+            ObjectivePredictionKey.PREDICTION_VALUE,
+            ObjectivePredictionKey.SCORE_L1,
+            ObjectivePredictionKey.SCORE_SIGNED_ERROR,
+        }
+        if needs_prediction:
+            predicted = self._predict_chunk(features)
+
+            if (key := ObjectivePredictionKey.PREDICTION_VALUE) in keys:
+                predictions[key] = Prediction(
+                    value=self._structure(predicted), time_index=time_index
+                )
+
+            if (key := ObjectivePredictionKey.SCORE_L1) in keys:
+                predictions[key] = Prediction(
+                    value=self._structure(predicted).apply(
+                        lambda p, g: F.l1_loss(p.float(), g.float(), reduction="none"),
+                        self._structure(ground_truth),
+                    ),
+                    time_index=time_index,
+                )
+
+            if (key := ObjectivePredictionKey.SCORE_SIGNED_ERROR) in keys:
+                predictions[key] = Prediction(
+                    value=self._structure(predicted).apply(
+                        lambda p, g: p.float() - g.float(),
+                        self._structure(ground_truth),
+                    ),
+                    time_index=time_index,
+                )
+
+        return TensorDict({"policy": predictions}).auto_batch_size_(2)
+
+    @override
+    def configure_optimizers(self) -> OptimizerLRScheduler:
+        if self.optimizer is None:
+            msg = "optimizer not specified"
+            raise ValueError(msg)
+
+        match self.optimizer.target:
+            case optimizers.SelectiveAdamW:
+                optimizer = self.optimizer.instantiate(module=self)
+            case _:
+                optimizer = self.optimizer.instantiate(params=self.parameters())
+
+        if self.lr_scheduler is not None:
+            scheduler = self.lr_scheduler.scheduler.instantiate(optimizer=optimizer)
+            lr_scheduler = {"scheduler": scheduler} | self.lr_scheduler.model_dump(
+                exclude={"scheduler"}
+            )
+            return {"optimizer": optimizer, "lr_scheduler": lr_scheduler}
+
+        return {"optimizer": optimizer}

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -265,7 +265,8 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
                     chain(quantizer.parameters(), quantizer.buffers())
                 ).device
                 rms = (
-                    quantizer.lookup(codes.to(quantizer_device))
+                    quantizer
+                    .lookup(codes.to(quantizer_device))
                     .pow(2)
                     .mean()
                     .sqrt()

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -252,21 +252,30 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
         return self
 
     @staticmethod
-    def _get(inputs: Mapping[str, Any], path: Path) -> Tensor:
+    def _get(
+        inputs: Mapping[str, Any], path: Path, *, required: bool = True
+    ) -> Tensor | None:
         value = key_get_default(inputs, tuple(map(MappingKey, path)), None)
-        if value is None:
+        if value is None and required:
             msg = f"input {path!r} missing from transformed batch"
             raise KeyError(msg)
         return value
 
-    def _features(self, batch: Any) -> tuple[Tensor, Tensor]:
-        """Per-frame readout features `(b, t, d)` and the action chunks `(b, t, h, a)`."""
+    def _features(
+        self, batch: Any, *, require_chunk: bool = True
+    ) -> tuple[Tensor, Tensor | None]:
+        """Per-frame readout features `(b, t, d)` and the action chunks `(b, t, h, a)`.
+
+        The chunk is only a TARGET (and never feeds the features), so callers on
+        the inference path (`forward`, ONNX export) pass `require_chunk=False`
+        and may omit the action series from the batch entirely.
+        """
         inputs = self.input_transform(batch)
 
         images = self._get(inputs, self.image)  # (b, t, c, h, w)
         speed = self._get(inputs, self.speed)  # (b, t, 1)
         waypoints = self._get(inputs, self.waypoints)  # (b, t, n, 2)
-        chunk = self._get(inputs, self.chunk)  # (b, t, horizon, fields)
+        chunk = self._get(inputs, self.chunk, required=require_chunk)
 
         with torch.no_grad():
             patches = self.image_encoder(images)  # (b, t, p, d_img)
@@ -434,9 +443,37 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
 
     @override
     def forward(self, batch: Any) -> TensorDict:
-        features, _ = self._features(batch)
+        features, _ = self._features(batch, require_chunk=False)
         chunk = self._predict_chunk(features[:, -1])
         return TensorDict({"policy": {"joint_actions": chunk}})
+
+    @classmethod
+    def load_for_export(cls, artifact: str, **kwargs: Any) -> "PatchPolicy":
+        """Load a checkpoint configured for deployment export (ONNX).
+
+        Mirrors the control-transformer export conventions
+        (config/export/yaak/control_transformer/finetuned.yaml):
+        - argmax code decoding (`sample_codes=False`) for determinism;
+        - the in-model image pipeline (Rearrange/CenterCrop/Resize/ToDtype)
+          is replaced by ImageNet `Normalize` only -- deployment supplies
+          already-cropped/resized `[0, 1]` float frames in `(b, t, c, h, w)`.
+
+        The exported graph needs no action series in the batch (`forward`
+        passes `require_chunk=False`).
+        """
+        from torchvision.transforms.v2 import Normalize  # noqa: PLC0415
+
+        model = cls.load_from_wandb_artifact(
+            artifact, filename="model.ckpt", map_location="cpu", weights_only=False
+        )
+        for key, value in kwargs.items():
+            setattr(model, key, value)
+        model.sample_codes = False
+        # index 2 of the input_transform Sequential is the per-modality ModuleDict
+        model.input_transform[2]["image"] = Normalize(
+            mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+        )
+        return model.eval()
 
     @staticmethod
     def _structure(chunk: Tensor) -> TensorDict:

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -384,12 +384,23 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
 
         losses["offset"] = self.losses["offset"](predicted_chunk, target)
 
-        return TensorDict({
-            "policy": {
-                "loss": losses,
-                "metric": {"offset_sampled_recon": sampled_recon},
-            }
-        })
+        # gradient-free LAST-FRAME metrics: the training losses above average over
+        # all T readouts (contexts of 1..T frames), whereas JointPolicyObjective
+        # only ever scores the newest frame -- these make the two comparable
+        with torch.no_grad():
+            metrics: dict[str, Tensor] = {"offset_sampled_recon": sampled_recon}
+            for q in range(tokenizer.quantizer.num_quantizers):
+                metrics[f"code_{q}_last"] = self.losses["code"](
+                    code_logits[:, -1, q, :], target_codes[:, -1, q]
+                )
+            metrics["offset_last"] = self.losses["offset"](
+                predicted_chunk[:, -1], target[:, -1]
+            )
+            metrics["offset_sampled_recon_last"] = self.losses["offset"](
+                sampled_chunk[:, -1].detach(), target[:, -1]
+            )
+
+        return TensorDict({"policy": {"loss": losses, "metric": metrics}})
 
     def _step(self, batch: Any, prefix: str) -> STEP_OUTPUT:
         metrics = self._compute_metrics(batch)

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -477,7 +477,12 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
 
     @classmethod
     def load_for_continuation(
-        cls, artifact: str, *, optimizer: Any, lr_scheduler: Any | None = None
+        cls,
+        artifact: str,
+        *,
+        optimizer: Any,
+        lr_scheduler: Any | None = None,
+        **_ignored: Any,
     ) -> "PatchPolicy":
         """Warm-start continuation training from a finished run's checkpoint.
 
@@ -486,6 +491,10 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
         the given LR/schedule. `lr_scheduler=None` -> constant LR, no warmup.
         The replacement is written back into `hparams` so checkpoints saved by
         the continuation run reload with the continuation settings.
+
+        `**_ignored` swallows architecture keys that parent experiments inline
+        under `model.*` (e.g. dinov2_dinowm's `image_encoder`): on continuation
+        the architecture comes from the CHECKPOINT hparams, not the config.
         """
         if not isinstance(optimizer, HydraConfig):
             optimizer = HydraConfig[Optimizer].model_validate(optimizer)

--- a/src/rmind/models/waypoints_tokenizer.py
+++ b/src/rmind/models/waypoints_tokenizer.py
@@ -1,0 +1,212 @@
+from functools import reduce
+from typing import Any, Self, final, override
+
+import pytorch_lightning as pl
+from lightning_fabric.utilities.types import _MAP_LOCATION_TYPE, _PATH
+from pydantic import ConfigDict, InstanceOf, validate_call
+from pytorch_lightning.utilities.model_helpers import (
+    _restricted_classmethod,  # noqa: PLC2701
+)
+from pytorch_lightning.utilities.types import STEP_OUTPUT, OptimizerLRScheduler
+from torch import Tensor
+from torch.nn import Module
+from torch.nn import functional as F
+from torch.optim import Optimizer
+
+from rmind.components import optimizers
+from rmind.components.vq import ResidualVQ
+from rmind.config import HydraConfig, init_hydra_param
+from rmind.models.action_tokenizer import LRSchedulerHydraConfig
+from rmind.utils._wandb import LoadableFromArtifact
+
+type Path = tuple[str, ...]
+
+
+class WaypointsTokenizer(pl.LightningModule, LoadableFromArtifact):
+    """Residual-VQ autoencoder over a whole per-frame waypoint path.
+
+    Ported from the `feat/wpts-rvq` branch; `_step` is adapted to this repo's
+    `ResidualVQ.forward` contract (codes, z_q, {"codebook", "commit"}).
+    """
+
+    @validate_call
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        input_transform: HydraConfig[Module] | InstanceOf[Module],
+        encoder: HydraConfig[Module] | InstanceOf[Module],
+        quantizer: HydraConfig[ResidualVQ] | InstanceOf[ResidualVQ],
+        decoder: HydraConfig[Module] | InstanceOf[Module],
+        waypoints: Path,
+        num_waypoints: int = 10,
+        waypoint_dim: int = 2,
+        commitment_weight: float = 1.0,
+        vq_weight: float = 5.0,
+        optimizer: HydraConfig[Optimizer] | None = None,
+        lr_scheduler: LRSchedulerHydraConfig | None = None,
+        **_legacy_hparams: Any,
+    ) -> None:
+        # HOTFIX: `**_legacy_hparams` swallows (and ignores) `__init__` kwargs saved
+        # by older tokenizer checkpoints but absent from this model -- e.g.
+        # `normalize` (a normalization submodule). Their leftover state_dict
+        # entries are dropped by `strict=False` on load.
+        super().__init__()
+
+        hparams: dict[str, Any] = {}
+
+        self.input_transform = init_hydra_param(
+            hparams, "input_transform", input_transform
+        )
+        self.encoder = init_hydra_param(hparams, "encoder", encoder)
+        self.quantizer: ResidualVQ = init_hydra_param(hparams, "quantizer", quantizer)
+        self.decoder = init_hydra_param(hparams, "decoder", decoder)
+
+        self.waypoints: Path = waypoints
+        self.num_waypoints = num_waypoints
+        self.waypoint_dim = waypoint_dim
+        self.commitment_weight = commitment_weight
+        self.vq_weight = vq_weight
+        hparams |= {
+            "waypoints": waypoints,
+            "num_waypoints": num_waypoints,
+            "waypoint_dim": waypoint_dim,
+            "commitment_weight": commitment_weight,
+            "vq_weight": vq_weight,
+        }
+
+        if optimizer is not None:
+            hparams["optimizer"] = optimizer.model_dump()
+        self.optimizer: HydraConfig[Optimizer] | None = optimizer
+
+        if lr_scheduler is not None:
+            hparams["lr_scheduler"] = lr_scheduler.model_dump()
+        self.lr_scheduler: LRSchedulerHydraConfig | None = lr_scheduler
+
+        self.save_hyperparameters(hparams)
+
+    @override
+    @_restricted_classmethod
+    @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+    def load_from_checkpoint(
+        cls,  # noqa: N805
+        checkpoint_path: _PATH,
+        *,
+        map_location: _MAP_LOCATION_TYPE = None,
+        strict: bool | None = False,
+        weights_only: bool | None = False,
+        **kwargs: Any,
+    ) -> Self:  # ty:ignore[invalid-method-override]
+        # `weights_only` defaults to False because the checkpoint's saved hparams
+        # contain non-tensor objects.
+        # HOTFIX: `strict` defaults to False so artifacts whose state_dict carries
+        # extra keys absent from this model (e.g. a `normalization` submodule added
+        # in a newer tokenizer) still load instead of raising on unexpected keys.
+        return super().load_from_checkpoint(
+            checkpoint_path,
+            map_location=map_location,
+            strict=strict,
+            weights_only=weights_only,
+            **kwargs,
+        )
+
+    @property
+    def _input_dim(self) -> int:
+        return self.num_waypoints * self.waypoint_dim
+
+    def encode(self, waypoints: Tensor) -> Tensor:
+        """Quantized latent `z_q` for a waypoint path `(*batch, N, 2)` -> `(*batch, dim)`."""
+        *batch, _num_waypoints, _waypoint_dim = waypoints.shape
+        w = waypoints.reshape(-1, self._input_dim)
+        _codes, z_q, _ = self.quantizer(self.encoder(w))
+        return z_q.reshape(*batch, z_q.shape[-1])
+
+    def _gather_waypoints(self, batch: Any) -> Tensor:
+        inputs = self.input_transform(batch)
+        waypoints = reduce(lambda acc, key: acc[key], self.waypoints, inputs)
+        return waypoints.reshape(-1, self._input_dim)
+
+    def _step(self, batch: Any) -> tuple[Tensor, dict[str, Tensor]]:
+        w = self._gather_waypoints(batch)
+
+        z = self.encoder(w)
+        codes, z_q, vq = self.quantizer(z)
+        w_hat = self.decoder(z + (z_q - z).detach())  # straight-through
+
+        recon = F.l1_loss(w_hat, w)
+        total = recon + self.vq_weight * (
+            vq["codebook"] + self.commitment_weight * vq["commit"]
+        )
+
+        metrics = {
+            "recon": recon,
+            "codebook": vq["codebook"],
+            "commit": vq["commit"],
+            "total": total,
+        }
+        perplexity = self.quantizer.perplexity(codes)
+        for q in range(self.quantizer.num_quantizers):
+            metrics[f"perplexity/q{q}"] = perplexity[q]
+
+        return total, metrics
+
+    @override
+    def training_step(self, batch: Any, _batch_idx: int) -> STEP_OUTPUT:
+        total, metrics = self._step(batch)
+        self.log_dict({f"train/{k}": v for k, v in metrics.items()}, sync_dist=True)
+        return {"loss": total}
+
+    @override
+    def validation_step(self, batch: Any, _batch_idx: int) -> STEP_OUTPUT:
+        total, metrics = self._step(batch)
+        if not self.trainer.sanity_checking:
+            self.log_dict({f"val/{k}": v for k, v in metrics.items()}, sync_dist=True)
+        return {"loss": total}
+
+    @override
+    def configure_optimizers(self) -> OptimizerLRScheduler:
+        if self.optimizer is None:
+            msg = "optimizer not specified"
+            raise ValueError(msg)
+
+        match self.optimizer.target:
+            case optimizers.SelectiveAdamW:
+                optimizer = self.optimizer.instantiate(module=self)
+            case _:
+                optimizer = self.optimizer.instantiate(params=self.parameters())
+
+        if self.lr_scheduler is not None:
+            scheduler = self.lr_scheduler.scheduler.instantiate(optimizer=optimizer)
+            lr_scheduler = {"scheduler": scheduler} | self.lr_scheduler.model_dump(
+                exclude={"scheduler"}
+            )
+            return {"optimizer": optimizer, "lr_scheduler": lr_scheduler}
+
+        return {"optimizer": optimizer}
+
+
+@final
+class WaypointsLatentTokenizer(Module):
+    """Encode a per-frame waypoint path into ONE residual-VQ latent token.
+
+    Wraps a pretrained `WaypointsTokenizer`. `forward` maps waypoints
+    `(*batch, num_waypoints, waypoint_dim)` -> `(*batch, 1, dim)`: the quantized
+    latent `z_q` (the sum of the per-level codebook vectors) with a singleton
+    token axis, so a policy sees a single waypoint token per timestep instead of
+    one token per waypoint.
+
+    Freezing the wrapped tokenizer (so its residual-VQ codebook EMA never updates
+    during downstream training) is the job of the `ModuleFreezer` callback, not
+    this module -- see `config/trainer/callbacks`.
+    """
+
+    def __init__(self, *, tokenizer: WaypointsTokenizer, **_legacy_kwargs: Any) -> None:
+        # HOTFIX: `**_legacy_kwargs` swallows kwargs saved by older checkpoints but
+        # no longer used here -- e.g. `freeze`, now handled by the `ModuleFreezer`
+        # callback (see the class docstring) rather than this module.
+        super().__init__()
+        self.tokenizer = tokenizer
+
+    @override
+    def forward(self, waypoints: Tensor) -> Tensor:
+        z_q = self.tokenizer.encode(waypoints)  # (*batch, dim)
+        return z_q.unsqueeze(-2)  # (*batch, 1, dim) -- one latent token per frame

--- a/src/rmind/scripts/patch_policy_eval.py
+++ b/src/rmind/scripts/patch_policy_eval.py
@@ -129,8 +129,14 @@ def evaluate(  # noqa: C901, PLR0914
                 offsets, target_codes
             )
             # both decodings from the SAME logits: one multinomial draw (the
-            # inference path with sample_codes=true) and argmax (deterministic)
-            sampled_codes = model._sample_codes(code_logits)  # noqa: SLF001
+            # inference path with sample_codes=true) and argmax (deterministic).
+            # Drawn explicitly rather than via `model._sample_codes`, which
+            # returns ARGMAX when the loaded checkpoint carries
+            # `sample_codes=false` -- that would silently alias the two columns
+            # and erase the sampled-vs-argmax divergence this table exists for.
+            sampled_codes = torch.multinomial(
+                code_logits.float().softmax(dim=-1).flatten(0, -2), num_samples=1
+            ).view(code_logits.shape[:-1])
             sampled_chunk = tokenizer.invert(sampled_codes) + model._offset(  # noqa: SLF001
                 offsets, sampled_codes
             )
@@ -214,7 +220,13 @@ def _report(
     results: dict[str, Tensor], *, num_quantizers: int, checkpoint: str
 ) -> None:
     """Print the per-position, per-cluster and per-quantizer tables."""
-    positions = sorted({int(k[1]) for k in results if k.startswith("t")})
+    # k[1] would collapse t10.. onto t1.. -- fine at episode_length=6, wrong for
+    # the 32-frame causal arms
+    positions = sorted({
+        int(k.split("/", 1)[0][1:])
+        for k in results
+        if k.startswith("t") and k.split("/", 1)[0][1:].isdigit()
+    })
 
     def mean_over(prefixes: list[str], name: str) -> float:
         return torch.stack([results[f"{p}/{name}"] for p in prefixes]).mean().item()

--- a/src/rmind/scripts/patch_policy_eval.py
+++ b/src/rmind/scripts/patch_policy_eval.py
@@ -15,6 +15,7 @@ Usage (from a repo checkout with the val rbyte cache built):
 """
 
 import argparse
+from typing import TYPE_CHECKING
 
 import pytorch_lightning as pl
 import torch
@@ -25,6 +26,9 @@ from torch.utils._pytree import tree_map  # noqa: PLC2701
 
 from rmind.models.patch_policy import PatchPolicy
 
+if TYPE_CHECKING:
+    from rmind.utils import RuleBasedCluster
+
 
 def _to_device(batch: object, device: torch.device) -> object:
     return tree_map(
@@ -32,8 +36,71 @@ def _to_device(batch: object, device: torch.device) -> object:
     )
 
 
+def _default_cluster_fn() -> "RuleBasedCluster":
+    """The exact rule set from config/trainer/callbacks/patch_policy.yaml, so the
+    per-cluster numbers here are comparable with the training-time predict metrics
+    (which, however, were logged under SAMPLED decoding only)."""
+    from rmind.utils import RuleBasedCluster  # noqa: PLC0415
+
+    key = "meta/VehicleMotion/{}"
+    return RuleBasedCluster(
+        fields={
+            "gas": {"key": key.format("gas_pedal_normalized"), "reduce": "last"},
+            "brake": {"key": key.format("brake_pedal_normalized"), "reduce": "last"},
+            "steer": {"key": key.format("steering_angle_normalized"), "reduce": "last"},
+            "dp_g": {"key": key.format("gas_pedal_normalized"), "reduce": "last_diff"},
+            "speed": {"key": key.format("speed"), "reduce": "last"},
+        },
+        rules=[
+            {"name": "highway", "when": {"speed": {"ge": 70}}},
+            {
+                "name": "braking_turn",
+                "when": {"brake": {"ge": 0.02}, "steer": {"abs_ge": 0.05}},
+            },
+            {
+                "name": "braking",
+                "when": {"brake": {"ge": 0.02}, "steer": {"abs_lt": 0.05}},
+            },
+            {
+                "name": "cruise_turn",
+                "when": {
+                    "gas": {"ge": 0.05},
+                    "brake": {"lt": 0.02},
+                    "steer": {"abs_ge": 0.05},
+                },
+            },
+            {
+                "name": "acceleration",
+                "when": {
+                    "gas": {"ge": 0.05},
+                    "brake": {"lt": 0.02},
+                    "dp_g": {"ge": 0.01},
+                },
+            },
+            {
+                "name": "gas_release",
+                "when": {
+                    "gas": {"ge": 0.05},
+                    "brake": {"lt": 0.02},
+                    "dp_g": {"lt": -0.01},
+                },
+            },
+            {
+                "name": "cruise",
+                "when": {
+                    "gas": {"ge": 0.05},
+                    "brake": {"lt": 0.02},
+                    "steer": {"abs_lt": 0.05},
+                    "dp_g": {"abs_lt": 0.01},
+                },
+            },
+        ],
+        default="idle_coast",
+    )
+
+
 @torch.no_grad()
-def evaluate(  # noqa: PLR0914
+def evaluate(  # noqa: C901, PLR0914
     model: PatchPolicy,
     loader: object,
     *,
@@ -78,6 +145,8 @@ def evaluate(  # noqa: PLR0914
         p_gt = probs.gather(-1, target_codes[..., None]).squeeze(-1)  # (b, t, g)
         entropy = -(probs * probs.clamp_min(1e-10).log()).sum(dim=-1)  # (b, t, g)
         accuracy = (argmax_codes == target_codes).float()  # (b, t, g)
+        # joint: all quantizer levels correct simultaneously ("exact behavior token")
+        joint_accuracy = (argmax_codes == target_codes).all(dim=-1).float()  # (b, t)
 
         b, t = features.shape[:2]
         for pos in range(t):
@@ -89,6 +158,7 @@ def evaluate(  # noqa: PLR0914
                 values[f"t{pos}/acc_{q}"] = accuracy[:, pos, q].mean()
                 values[f"t{pos}/p_gt_{q}"] = p_gt[:, pos, q].mean()
                 values[f"t{pos}/entropy_{q}"] = entropy[:, pos, q].mean()
+            values[f"t{pos}/acc_joint"] = joint_accuracy[:, pos].mean()
             values[f"t{pos}/offset"] = (
                 (teacher_chunk[:, pos] - target[:, pos]).abs().mean()
             )
@@ -101,14 +171,46 @@ def evaluate(  # noqa: PLR0914
             for key, value in values.items():
                 sums[key] = sums.get(key, torch.zeros((), device=device)) + value * b
 
+        # per-cluster x per-decoding, last frame only (deployment position),
+        # per-field L1 mean over the action horizon. Skipped when the batch
+        # lacks the raw meta series the cluster rules need (synthetic batches).
+        try:
+            labels = _default_cluster_fn()(batch, None)
+        except (KeyError, TypeError):
+            labels = None
+        if labels is not None:
+            action_features = tokenizer._action_features  # noqa: SLF001
+            tgt = target[:, -1].unflatten(-1, (-1, action_features))
+            per_field = {
+                "sampled": (
+                    sampled_chunk[:, -1].unflatten(-1, (-1, action_features)) - tgt
+                )
+                .abs()
+                .mean(dim=1),  # (b, fields)
+                "argmax": (
+                    argmax_chunk[:, -1].unflatten(-1, (-1, action_features)) - tgt
+                )
+                .abs()
+                .mean(dim=1),
+            }
+            for j, label in enumerate(labels):
+                key = f"cluster_n/{label}"
+                sums[key] = sums.get(key, torch.zeros((), device=device)) + 1
+                for dec, l1 in per_field.items():
+                    for f, field in enumerate(("gas", "brake", "steer")):
+                        k = f"cluster/{label}/{dec}_{field}"
+                        sums[k] = sums.get(k, torch.zeros((), device=device)) + l1[j, f]
+
         count += b
 
-    return {k: v / count for k, v in sums.items()} | {
-        "num_samples": torch.tensor(count)
-    }
+    # cluster sums are normalized by their own cluster counts at report time
+    return {
+        k: (v if k.startswith(("cluster/", "cluster_n/")) else v / count)
+        for k, v in sums.items()
+    } | {"num_samples": torch.tensor(count)}
 
 
-def main() -> None:
+def main() -> None:  # noqa: PLR0914
     parser = argparse.ArgumentParser(description=__doc__)
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
@@ -177,7 +279,8 @@ def main() -> None:
     header = [
         "pos(context)",
         "code_focal",
-        "top1_acc",
+        "top1_acc",  # mean of per-quantizer marginal accuracies
+        "joint_acc",  # all 4 levels correct simultaneously
         "p_gt",
         "entropy",
         "offset",
@@ -192,6 +295,7 @@ def main() -> None:
             for v in [
                 q_mean(prefixes, "code"),
                 q_mean(prefixes, "acc"),
+                mean_over(prefixes, "acc_joint"),
                 q_mean(prefixes, "p_gt"),
                 q_mean(prefixes, "entropy"),
                 mean_over(prefixes, "offset"),
@@ -206,6 +310,29 @@ def main() -> None:
     row("all (wandb)", [f"t{p}" for p in positions])
     last = [f"t{positions[-1]}"]
     row("last (=bsln)", last)
+
+    cluster_labels = sorted(
+        (k.removeprefix("cluster_n/") for k in results if k.startswith("cluster_n/")),
+        key=lambda c: -results[f"cluster_n/{c}"].item(),
+    )
+    if cluster_labels:
+        print(  # noqa: T201
+            "\nper-cluster @ last frame (field L1 over horizon; both decodings):"
+        )
+        cols = ["cluster", "n"] + [
+            f"{dec[:4]}_{f}"
+            for dec in ("sampled", "argmax")
+            for f in ("gas", "brake", "steer")
+        ]
+        print(" | ".join(f"{h:>12s}" for h in cols))  # noqa: T201
+        for c in cluster_labels:
+            n = results[f"cluster_n/{c}"].item()
+            cells = [f"{c:>12s}", f"{int(n):12d}"] + [
+                f"{results[f'cluster/{c}/{dec}_{f}'].item() / n:12.4f}"
+                for dec in ("sampled", "argmax")
+                for f in ("gas", "brake", "steer")
+            ]
+            print(" | ".join(cells))  # noqa: T201
 
     print("\nper-quantizer @ last frame:")  # noqa: T201
     print(  # noqa: T201

--- a/src/rmind/scripts/patch_policy_eval.py
+++ b/src/rmind/scripts/patch_policy_eval.py
@@ -61,27 +61,44 @@ def evaluate(  # noqa: PLR0914
             teacher_chunk = tokenizer.invert(target_codes) + model._offset(  # noqa: SLF001
                 offsets, target_codes
             )
-            codes = model._sample_codes(code_logits)  # noqa: SLF001
-            sampled_chunk = tokenizer.invert(codes) + model._offset(offsets, codes)  # noqa: SLF001
+            # both decodings from the SAME logits: one multinomial draw (the
+            # inference path with sample_codes=true) and argmax (deterministic)
+            sampled_codes = model._sample_codes(code_logits)  # noqa: SLF001
+            sampled_chunk = tokenizer.invert(sampled_codes) + model._offset(  # noqa: SLF001
+                offsets, sampled_codes
+            )
+            argmax_codes = code_logits.argmax(dim=-1)
+            argmax_chunk = tokenizer.invert(argmax_codes) + model._offset(  # noqa: SLF001
+                offsets, argmax_codes
+            )
+
+        # per-quantizer code diagnostics: top-1 accuracy, probability mass on
+        # the GT code, and sampling entropy (nats; uniform over 16 = 2.77)
+        probs = code_logits.float().softmax(dim=-1)  # (b, t, g, c)
+        p_gt = probs.gather(-1, target_codes[..., None]).squeeze(-1)  # (b, t, g)
+        entropy = -(probs * probs.clamp_min(1e-10).log()).sum(dim=-1)  # (b, t, g)
+        accuracy = (argmax_codes == target_codes).float()  # (b, t, g)
 
         b, t = features.shape[:2]
         for pos in range(t):
+            values: dict[str, Tensor] = {}
             for q in range(num_quantizers):
-                key = f"t{pos}/code_{q}"
-                value = model.losses["code"](
+                values[f"t{pos}/code_{q}"] = model.losses["code"](
                     code_logits[:, pos, q, :].float(), target_codes[:, pos, q]
                 )
-                sums[key] = sums.get(key, torch.zeros((), device=device)) + value * b
-            for key, value in (
-                (
-                    f"t{pos}/offset",
-                    (teacher_chunk[:, pos] - target[:, pos]).abs().mean(),
-                ),
-                (
-                    f"t{pos}/sampled_recon",
-                    (sampled_chunk[:, pos] - target[:, pos]).abs().mean(),
-                ),
-            ):
+                values[f"t{pos}/acc_{q}"] = accuracy[:, pos, q].mean()
+                values[f"t{pos}/p_gt_{q}"] = p_gt[:, pos, q].mean()
+                values[f"t{pos}/entropy_{q}"] = entropy[:, pos, q].mean()
+            values[f"t{pos}/offset"] = (
+                (teacher_chunk[:, pos] - target[:, pos]).abs().mean()
+            )
+            values[f"t{pos}/sampled_recon"] = (
+                (sampled_chunk[:, pos] - target[:, pos]).abs().mean()
+            )
+            values[f"t{pos}/argmax_recon"] = (
+                (argmax_chunk[:, pos] - target[:, pos]).abs().mean()
+            )
+            for key, value in values.items():
                 sums[key] = sums.get(key, torch.zeros((), device=device)) + value * b
 
         count += b
@@ -144,32 +161,65 @@ def main() -> None:
 
     num_quantizers = model.tokenizer.quantizer.num_quantizers
     positions = sorted({int(k[1]) for k in results if k.startswith("t")})
-    header = (
-        ["pos(context)"]
-        + [f"code_{q}" for q in range(num_quantizers)]
-        + ["code_mean", "offset", "sampled_recon"]
-    )
+
+    def mean_over(prefixes: list[str], name: str) -> float:
+        return torch.stack([results[f"{p}/{name}"] for p in prefixes]).mean().item()
+
+    def q_mean(prefixes: list[str], stem: str) -> float:
+        return (
+            sum(mean_over(prefixes, f"{stem}_{q}") for q in range(num_quantizers))
+            / num_quantizers
+        )
+
     print(f"\ncheckpoint: {args.artifact or args.ckpt}")  # noqa: T201
     print(f"val samples: {int(results['num_samples'])}\n")  # noqa: T201
+
+    header = [
+        "pos(context)",
+        "code_focal",
+        "top1_acc",
+        "p_gt",
+        "entropy",
+        "offset",
+        "recon_sampled",
+        "recon_argmax",
+    ]
     print(" | ".join(f"{h:>13s}" for h in header))  # noqa: T201
 
-    def row(label: str, keys_prefix: list[str]) -> None:
-        codes = [
-            torch.stack([results[f"{p}/code_{q}"] for p in keys_prefix]).mean()
-            for q in range(num_quantizers)
-        ]
-        offset = torch.stack([results[f"{p}/offset"] for p in keys_prefix]).mean()
-        recon = torch.stack([results[f"{p}/sampled_recon"] for p in keys_prefix]).mean()
+    def row(label: str, prefixes: list[str]) -> None:
         cells = [f"{label:>13s}"] + [
-            f"{v.item():13.4f}"
-            for v in [*codes, torch.stack(codes).mean(), offset, recon]
+            f"{v:13.4f}"
+            for v in [
+                q_mean(prefixes, "code"),
+                q_mean(prefixes, "acc"),
+                q_mean(prefixes, "p_gt"),
+                q_mean(prefixes, "entropy"),
+                mean_over(prefixes, "offset"),
+                mean_over(prefixes, "sampled_recon"),
+                mean_over(prefixes, "argmax_recon"),
+            ]
         ]
         print(" | ".join(cells))  # noqa: T201
 
     for pos in positions:
         row(f"t={pos} ({pos + 1}f)", [f"t{pos}"])
     row("all (wandb)", [f"t{p}" for p in positions])
-    row("last (=bsln)", [f"t{positions[-1]}"])
+    last = [f"t{positions[-1]}"]
+    row("last (=bsln)", last)
+
+    print("\nper-quantizer @ last frame:")  # noqa: T201
+    print(  # noqa: T201
+        " | ".join(
+            f"{h:>13s}"
+            for h in ["quantizer", "code_focal", "top1_acc", "p_gt", "entropy"]
+        )
+    )
+    for q in range(num_quantizers):
+        cells = [f"{f'q{q}':>13s}"] + [
+            f"{mean_over(last, f'{stem}_{q}'):13.4f}"
+            for stem in ["code", "acc", "p_gt", "entropy"]
+        ]
+        print(" | ".join(cells))  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/src/rmind/scripts/patch_policy_eval.py
+++ b/src/rmind/scripts/patch_policy_eval.py
@@ -1,0 +1,176 @@
+"""Post-hoc per-frame-position evaluation of a PatchPolicy checkpoint.
+
+The training/val losses logged by `PatchPolicy` average over all T frame
+readouts, whose block-causal contexts span 1..T frames; `JointPolicyObjective`
+(the FT baseline) only ever scores the newest frame. This script evaluates a
+checkpoint on the val set and reports code/offset/sampled-recon losses PER
+FRAME POSITION, plus the all-frames mean (what wandb shows) and the last-frame
+value (comparable to the baseline).
+
+Usage (from a repo checkout with the val rbyte cache built):
+    uv run python -m rmind.scripts.patch_policy_eval \
+        --artifact yaak/rmind/model-<run_id>:latest \
+        --config-dir /abs/path/to/config \
+        [--experiment yaak/patch_policy/dinov3] [--batches 200] [--device cuda]
+"""
+
+import argparse
+
+import pytorch_lightning as pl
+import torch
+from hydra import compose, initialize_config_dir
+from hydra.utils import instantiate
+from torch import Tensor
+from torch.utils._pytree import tree_map  # noqa: PLC2701
+
+from rmind.models.patch_policy import PatchPolicy
+
+
+def _to_device(batch: object, device: torch.device) -> object:
+    return tree_map(
+        lambda x: x.to(device, non_blocking=True) if isinstance(x, Tensor) else x, batch
+    )
+
+
+@torch.no_grad()
+def evaluate(  # noqa: PLR0914
+    model: PatchPolicy,
+    loader: object,
+    *,
+    device: torch.device,
+    max_batches: int,
+    autocast: bool,
+) -> dict[str, Tensor]:
+    tokenizer = model.tokenizer
+    num_quantizers = tokenizer.quantizer.num_quantizers
+
+    sums: dict[str, Tensor] = {}
+    count = 0
+
+    for i, cpu_batch in enumerate(loader):
+        if i >= max_batches:
+            break
+
+        batch = _to_device(cpu_batch, device)
+        with torch.autocast(device.type, dtype=torch.bfloat16, enabled=autocast):
+            features, chunk = model._features(batch)  # noqa: SLF001
+            target_codes = tokenizer(chunk)  # (b, t, g)
+            target = tokenizer._normalize(chunk.flatten(-2, -1))  # noqa: SLF001
+            code_logits, offsets = model._heads(features)  # noqa: SLF001
+
+            teacher_chunk = tokenizer.invert(target_codes) + model._offset(  # noqa: SLF001
+                offsets, target_codes
+            )
+            codes = model._sample_codes(code_logits)  # noqa: SLF001
+            sampled_chunk = tokenizer.invert(codes) + model._offset(offsets, codes)  # noqa: SLF001
+
+        b, t = features.shape[:2]
+        for pos in range(t):
+            for q in range(num_quantizers):
+                key = f"t{pos}/code_{q}"
+                value = model.losses["code"](
+                    code_logits[:, pos, q, :].float(), target_codes[:, pos, q]
+                )
+                sums[key] = sums.get(key, torch.zeros((), device=device)) + value * b
+            for key, value in (
+                (
+                    f"t{pos}/offset",
+                    (teacher_chunk[:, pos] - target[:, pos]).abs().mean(),
+                ),
+                (
+                    f"t{pos}/sampled_recon",
+                    (sampled_chunk[:, pos] - target[:, pos]).abs().mean(),
+                ),
+            ):
+                sums[key] = sums.get(key, torch.zeros((), device=device)) + value * b
+
+        count += b
+
+    return {k: v / count for k, v in sums.items()} | {
+        "num_samples": torch.tensor(count)
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--artifact", help="wandb model artifact, e.g. yaak/rmind/model-<id>:latest"
+    )
+    group.add_argument("--ckpt", help="local checkpoint path")
+    parser.add_argument(
+        "--config-dir", required=True, help="absolute path to the hydra config dir"
+    )
+    parser.add_argument(
+        "--experiment",
+        default="yaak/patch_policy/dinov3",
+        help="experiment supplying the (shared) val datamodule",
+    )
+    parser.add_argument("--batches", type=int, default=200)
+    parser.add_argument("--device", default="cuda")
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=1337,
+        help="fixes the shuffled val subset across invocations",
+    )
+    args = parser.parse_args()
+
+    pl.seed_everything(args.seed, workers=True)
+    device = torch.device(args.device)
+
+    with initialize_config_dir(config_dir=args.config_dir, version_base=None):
+        cfg = compose(config_name="train", overrides=[f"experiment={args.experiment}"])
+    datamodule = instantiate(cfg.datamodule)
+
+    model = (
+        PatchPolicy.load_from_wandb_artifact(
+            args.artifact, weights_only=False, map_location="cpu"
+        )
+        if args.artifact
+        else PatchPolicy.load_from_checkpoint(
+            args.ckpt, weights_only=False, map_location="cpu"
+        )
+    )
+    model = model.to(device).eval()
+
+    results = evaluate(
+        model,
+        datamodule.val_dataloader(),
+        device=device,
+        max_batches=args.batches,
+        autocast=device.type == "cuda",
+    )
+
+    num_quantizers = model.tokenizer.quantizer.num_quantizers
+    positions = sorted({int(k[1]) for k in results if k.startswith("t")})
+    header = (
+        ["pos(context)"]
+        + [f"code_{q}" for q in range(num_quantizers)]
+        + ["code_mean", "offset", "sampled_recon"]
+    )
+    print(f"\ncheckpoint: {args.artifact or args.ckpt}")  # noqa: T201
+    print(f"val samples: {int(results['num_samples'])}\n")  # noqa: T201
+    print(" | ".join(f"{h:>13s}" for h in header))  # noqa: T201
+
+    def row(label: str, keys_prefix: list[str]) -> None:
+        codes = [
+            torch.stack([results[f"{p}/code_{q}"] for p in keys_prefix]).mean()
+            for q in range(num_quantizers)
+        ]
+        offset = torch.stack([results[f"{p}/offset"] for p in keys_prefix]).mean()
+        recon = torch.stack([results[f"{p}/sampled_recon"] for p in keys_prefix]).mean()
+        cells = [f"{label:>13s}"] + [
+            f"{v.item():13.4f}"
+            for v in [*codes, torch.stack(codes).mean(), offset, recon]
+        ]
+        print(" | ".join(cells))  # noqa: T201
+
+    for pos in positions:
+        row(f"t={pos} ({pos + 1}f)", [f"t{pos}"])
+    row("all (wandb)", [f"t{p}" for p in positions])
+    row("last (=bsln)", [f"t{positions[-1]}"])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rmind/scripts/patch_policy_eval.py
+++ b/src/rmind/scripts/patch_policy_eval.py
@@ -210,7 +210,103 @@ def evaluate(  # noqa: C901, PLR0914
     } | {"num_samples": torch.tensor(count)}
 
 
-def main() -> None:  # noqa: PLR0914
+def _report(
+    results: dict[str, Tensor], *, num_quantizers: int, checkpoint: str
+) -> None:
+    """Print the per-position, per-cluster and per-quantizer tables."""
+    positions = sorted({int(k[1]) for k in results if k.startswith("t")})
+
+    def mean_over(prefixes: list[str], name: str) -> float:
+        return torch.stack([results[f"{p}/{name}"] for p in prefixes]).mean().item()
+
+    def q_mean(prefixes: list[str], stem: str) -> float:
+        return (
+            sum(mean_over(prefixes, f"{stem}_{q}") for q in range(num_quantizers))
+            / num_quantizers
+        )
+
+    print(f"\ncheckpoint: {checkpoint}")  # noqa: T201
+    print(f"val samples: {int(results['num_samples'])}\n")  # noqa: T201
+
+    header = [
+        "pos(context)",
+        "code_focal",
+        "top1_acc",  # mean of per-quantizer marginal accuracies
+        "joint_acc",  # all 4 levels correct simultaneously
+        "p_gt",
+        "entropy",
+        "offset",
+        "recon_sampled",
+        "recon_argmax",
+    ]
+    print(" | ".join(f"{h:>13s}" for h in header))  # noqa: T201
+
+    def row(label: str, prefixes: list[str]) -> None:
+        cells = [f"{label:>13s}"] + [
+            f"{v:13.4f}"
+            for v in [
+                q_mean(prefixes, "code"),
+                q_mean(prefixes, "acc"),
+                mean_over(prefixes, "acc_joint"),
+                q_mean(prefixes, "p_gt"),
+                q_mean(prefixes, "entropy"),
+                mean_over(prefixes, "offset"),
+                mean_over(prefixes, "sampled_recon"),
+                mean_over(prefixes, "argmax_recon"),
+            ]
+        ]
+        print(" | ".join(cells))  # noqa: T201
+
+    for pos in positions:
+        row(f"t={pos} ({pos + 1}f)", [f"t{pos}"])
+    row("all (wandb)", [f"t{p}" for p in positions])
+    last = [f"t{positions[-1]}"]
+    row("last (=bsln)", last)
+
+    _report_clusters(results)
+
+    print("\nper-quantizer @ last frame:")  # noqa: T201
+    print(  # noqa: T201
+        " | ".join(
+            f"{h:>13s}"
+            for h in ["quantizer", "code_focal", "top1_acc", "p_gt", "entropy"]
+        )
+    )
+    for q in range(num_quantizers):
+        cells = [f"{f'q{q}':>13s}"] + [
+            f"{mean_over(last, f'{stem}_{q}'):13.4f}"
+            for stem in ["code", "acc", "p_gt", "entropy"]
+        ]
+        print(" | ".join(cells))  # noqa: T201
+
+
+def _report_clusters(results: dict[str, Tensor]) -> None:
+    """Per-cluster last-frame field L1, for both decodings."""
+    cluster_labels = sorted(
+        (k.removeprefix("cluster_n/") for k in results if k.startswith("cluster_n/")),
+        key=lambda c: -results[f"cluster_n/{c}"].item(),
+    )
+    if not cluster_labels:
+        return
+
+    print("\nper-cluster @ last frame (field L1 over horizon; both decodings):")  # noqa: T201
+    cols = ["cluster", "n"] + [
+        f"{dec[:4]}_{f}"
+        for dec in ("sampled", "argmax")
+        for f in ("gas", "brake", "steer")
+    ]
+    print(" | ".join(f"{h:>12s}" for h in cols))  # noqa: T201
+    for c in cluster_labels:
+        n = results[f"cluster_n/{c}"].item()
+        cells = [f"{c:>12s}", f"{int(n):12d}"] + [
+            f"{results[f'cluster/{c}/{dec}_{f}'].item() / n:12.4f}"
+            for dec in ("sampled", "argmax")
+            for f in ("gas", "brake", "steer")
+        ]
+        print(" | ".join(cells))  # noqa: T201
+
+
+def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument(
@@ -261,92 +357,11 @@ def main() -> None:  # noqa: PLR0914
         autocast=device.type == "cuda",
     )
 
-    num_quantizers = model.tokenizer.quantizer.num_quantizers
-    positions = sorted({int(k[1]) for k in results if k.startswith("t")})
-
-    def mean_over(prefixes: list[str], name: str) -> float:
-        return torch.stack([results[f"{p}/{name}"] for p in prefixes]).mean().item()
-
-    def q_mean(prefixes: list[str], stem: str) -> float:
-        return (
-            sum(mean_over(prefixes, f"{stem}_{q}") for q in range(num_quantizers))
-            / num_quantizers
-        )
-
-    print(f"\ncheckpoint: {args.artifact or args.ckpt}")  # noqa: T201
-    print(f"val samples: {int(results['num_samples'])}\n")  # noqa: T201
-
-    header = [
-        "pos(context)",
-        "code_focal",
-        "top1_acc",  # mean of per-quantizer marginal accuracies
-        "joint_acc",  # all 4 levels correct simultaneously
-        "p_gt",
-        "entropy",
-        "offset",
-        "recon_sampled",
-        "recon_argmax",
-    ]
-    print(" | ".join(f"{h:>13s}" for h in header))  # noqa: T201
-
-    def row(label: str, prefixes: list[str]) -> None:
-        cells = [f"{label:>13s}"] + [
-            f"{v:13.4f}"
-            for v in [
-                q_mean(prefixes, "code"),
-                q_mean(prefixes, "acc"),
-                mean_over(prefixes, "acc_joint"),
-                q_mean(prefixes, "p_gt"),
-                q_mean(prefixes, "entropy"),
-                mean_over(prefixes, "offset"),
-                mean_over(prefixes, "sampled_recon"),
-                mean_over(prefixes, "argmax_recon"),
-            ]
-        ]
-        print(" | ".join(cells))  # noqa: T201
-
-    for pos in positions:
-        row(f"t={pos} ({pos + 1}f)", [f"t{pos}"])
-    row("all (wandb)", [f"t{p}" for p in positions])
-    last = [f"t{positions[-1]}"]
-    row("last (=bsln)", last)
-
-    cluster_labels = sorted(
-        (k.removeprefix("cluster_n/") for k in results if k.startswith("cluster_n/")),
-        key=lambda c: -results[f"cluster_n/{c}"].item(),
+    _report(
+        results,
+        num_quantizers=model.tokenizer.quantizer.num_quantizers,
+        checkpoint=args.artifact or args.ckpt,
     )
-    if cluster_labels:
-        print(  # noqa: T201
-            "\nper-cluster @ last frame (field L1 over horizon; both decodings):"
-        )
-        cols = ["cluster", "n"] + [
-            f"{dec[:4]}_{f}"
-            for dec in ("sampled", "argmax")
-            for f in ("gas", "brake", "steer")
-        ]
-        print(" | ".join(f"{h:>12s}" for h in cols))  # noqa: T201
-        for c in cluster_labels:
-            n = results[f"cluster_n/{c}"].item()
-            cells = [f"{c:>12s}", f"{int(n):12d}"] + [
-                f"{results[f'cluster/{c}/{dec}_{f}'].item() / n:12.4f}"
-                for dec in ("sampled", "argmax")
-                for f in ("gas", "brake", "steer")
-            ]
-            print(" | ".join(cells))  # noqa: T201
-
-    print("\nper-quantizer @ last frame:")  # noqa: T201
-    print(  # noqa: T201
-        " | ".join(
-            f"{h:>13s}"
-            for h in ["quantizer", "code_focal", "top1_acc", "p_gt", "entropy"]
-        )
-    )
-    for q in range(num_quantizers):
-        cells = [f"{f'q{q}':>13s}"] + [
-            f"{mean_over(last, f'{stem}_{q}'):13.4f}"
-            for stem in ["code", "acc", "p_gt", "entropy"]
-        ]
-        print(" | ".join(cells))  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/src/rmind/scripts/train.py
+++ b/src/rmind/scripts/train.py
@@ -31,7 +31,9 @@ def _train(cfg: DictConfig) -> None:
 
     logger.debug("starting training")
 
-    return trainer.fit(model=model, datamodule=datamodule)
+    return trainer.fit(
+        model=model, datamodule=datamodule, ckpt_path=cfg.get("ckpt_path")
+    )
 
 
 @hydra.main(version_base=None)

--- a/tests/test_patch_policy.py
+++ b/tests/test_patch_policy.py
@@ -82,6 +82,10 @@ class _GoalEncoderStub(Module):
     def __init__(self) -> None:
         super().__init__()
         self.proj = Linear(2, GOAL_DIM)
+        # fusion_norm calibrates its goal gain from the quantizer codebooks
+        self.quantizer = ResidualVQ(
+            dim=GOAL_DIM, codebook_size=4, num_quantizers=2, kmeans_init=False
+        )
 
     def encode(self, waypoints: Tensor) -> Tensor:
         return self.proj(waypoints).mean(dim=-2)
@@ -91,8 +95,11 @@ class _GoalEncoderStub(Module):
         return self.encode(waypoints)
 
 
-def _make_model(*, teacher_force_offset: bool = True) -> PatchPolicy:
+def _make_model(
+    *, teacher_force_offset: bool = True, fusion_norm: bool = False
+) -> PatchPolicy:
     return PatchPolicy(
+        fusion_norm=fusion_norm,
         input_transform=Identity(),
         # tests feed pre-extracted patch features (b, t, p, d) directly
         image_encoder=Identity(),
@@ -331,3 +338,46 @@ def test_readout_is_causally_valid() -> None:
 
     torch.testing.assert_close(features[:, :-1], features_perturbed[:, :-1])
     assert not torch.allclose(features[:, -1], features_perturbed[:, -1])
+
+
+def test_fusion_norm_balances_sources() -> None:
+    model = _make_model(fusion_norm=True)
+    batch = _make_batch()
+
+    inputs = model.input_transform(batch)
+    patches = model.image_encoder(inputs["image"]["cam_front_left"])
+    goal = model.goal_encoder.encode(inputs["context"]["waypoints"])
+
+    normed = model.fusion_patch_norm(patches) * model.fusion_patch_gain
+    goal * model.fusion_goal_gain
+
+    patch_rms = normed.pow(2).mean().sqrt().item()
+    # the goal gain is calibrated from codebook combinations, the stub's encode
+    # is a different map -- assert ballpark scale match, not equality
+    codes = model.goal_encoder.quantizer.lookup(
+        torch.randint(0, 4, (256, 2), generator=torch.Generator().manual_seed(1))
+    )
+    zq_rms = (codes * model.fusion_goal_gain).pow(2).mean().sqrt().item()
+    tolerance = 0.2
+    assert abs(patch_rms - 1.0) < tolerance
+    assert abs(zq_rms - 1.0) < tolerance
+
+    assert model.fusion_patch_gain.requires_grad
+    assert model.fusion_goal_gain.requires_grad
+    loss = model._compute_metrics(batch)["policy", "loss"].sum(reduce=True)  # noqa: SLF001
+    loss.backward()
+    assert model.fusion_goal_gain.grad is not None
+
+    # flag off -> attributes absent
+    off = _make_model()
+    assert off.fusion_patch_norm is None
+
+
+def test_fusion_norm_calibration_deterministic() -> None:
+    """Same goal-encoder weights (the real-world case: loaded from a checkpoint)
+    must yield the identical calibrated gain on every construction/DDP rank."""
+    torch.manual_seed(7)
+    a = _make_model(fusion_norm=True)
+    torch.manual_seed(7)
+    b = _make_model(fusion_norm=True)
+    torch.testing.assert_close(a.fusion_goal_gain, b.fusion_goal_gain)

--- a/tests/test_patch_policy.py
+++ b/tests/test_patch_policy.py
@@ -1,0 +1,333 @@
+"""Unit tests for `PatchPolicy` (https://arxiv.org/pdf/2607.18236).
+
+Covers the block-causal attention mask, per-frame readout/loss shapes, the
+teacher-forced offset semantics inherited from `JointPolicyObjective` (#258),
+and equivalence of the batched `_gather_offset` with the joint-policy original.
+"""
+
+from typing import override
+
+import torch
+from torch import Tensor
+from torch.nn import Identity, L1Loss, Linear, Module, Sequential
+from torchvision.ops import MLP
+
+from rmind.components.base import Modality
+from rmind.components.containers import ModuleDict
+from rmind.components.loss import FocalLoss
+from rmind.components.nn import Embedding
+from rmind.components.norm import Scaler, UniformBinner
+from rmind.components.objectives.base import ObjectivePredictionKey
+from rmind.components.objectives.joint_policy import JointPolicyObjective
+from rmind.components.vq import ResidualVQ
+from rmind.models.action_tokenizer import ActionTokenizer
+from rmind.models.control_transformer import PredictionConfig
+from rmind.models.patch_policy import (
+    BlockCausalTransformer,
+    PatchPolicy,
+    block_causal_mask,
+)
+
+BATCH_SIZE = 2
+EPISODE_LENGTH = 3
+NUM_PATCHES = 4
+IMAGE_DIM = 8
+GOAL_DIM = 8
+POLICY_DIM = 16
+ACTION_HORIZON = 3
+ACTION_FIELDS = 4
+ACTION_DIM = ACTION_HORIZON * ACTION_FIELDS
+LATENT_DIM = 8
+NUM_QUANTIZERS = 2
+CODEBOOK_SIZE = 4
+SPEED_BINS = 8
+
+
+def _make_tokenizer() -> ActionTokenizer:
+    """Tiny ActionTokenizer mirroring config/model/yaak/action_tokenizer/raw.yaml."""
+    return ActionTokenizer(
+        input_transform=Sequential(
+            Identity(),
+            ModuleDict(
+                modules={
+                    Modality.CONTINUOUS: Identity(),
+                    Modality.DISCRETE: {
+                        "turn_signal": Scaler(in_range=(0.0, 2.0), out_range=(0.0, 1.0))
+                    },
+                }
+            ),
+        ),
+        encoder=Linear(ACTION_DIM, LATENT_DIM),
+        quantizer=ResidualVQ(
+            dim=LATENT_DIM,
+            codebook_size=CODEBOOK_SIZE,
+            num_quantizers=NUM_QUANTIZERS,
+            kmeans_init=False,
+        ),
+        decoder=Linear(LATENT_DIM, ACTION_DIM),
+        targets={
+            Modality.CONTINUOUS: {
+                "gas_pedal": ("continuous", "gas_pedal"),
+                "brake_pedal": ("continuous", "brake_pedal"),
+                "steering_angle": ("continuous", "steering_angle"),
+            },
+            Modality.DISCRETE: {"turn_signal": ("discrete", "turn_signal")},
+        },
+    )
+
+
+class _GoalEncoderStub(Module):
+    """Maps waypoints `(b, t, n, 2)` -> a deterministic latent `(b, t, GOAL_DIM)`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.proj = Linear(2, GOAL_DIM)
+
+    def encode(self, waypoints: Tensor) -> Tensor:
+        return self.proj(waypoints).mean(dim=-2)
+
+    @override
+    def forward(self, waypoints: Tensor) -> Tensor:
+        return self.encode(waypoints)
+
+
+def _make_model(*, teacher_force_offset: bool = True) -> PatchPolicy:
+    return PatchPolicy(
+        input_transform=Identity(),
+        # tests feed pre-extracted patch features (b, t, p, d) directly
+        image_encoder=Identity(),
+        goal_encoder=_GoalEncoderStub(),
+        patch_projection=Linear(IMAGE_DIM + GOAL_DIM, POLICY_DIM),
+        speed_tokenizer=UniformBinner(range=(0.0, 130.0), bins=SPEED_BINS),
+        speed_embedding=Embedding(SPEED_BINS, POLICY_DIM),
+        encoder=BlockCausalTransformer(
+            dim_model=POLICY_DIM,
+            num_layers=2,
+            num_heads=2,
+            max_sequence_length=EPISODE_LENGTH * (NUM_PATCHES + 1),
+        ),
+        tokenizer=_make_tokenizer(),
+        code_head=MLP(POLICY_DIM, [16, NUM_QUANTIZERS * CODEBOOK_SIZE]),
+        offset_head=MLP(POLICY_DIM, [16, NUM_QUANTIZERS * CODEBOOK_SIZE * ACTION_DIM]),
+        losses=ModuleDict(modules={"code": FocalLoss(), "offset": L1Loss()}),
+        norm=torch.nn.LayerNorm(POLICY_DIM),
+        sample_codes=False,
+        teacher_force_offset=teacher_force_offset,
+        prediction_config=PredictionConfig(
+            objectives={
+                ObjectivePredictionKey.GROUND_TRUTH,
+                ObjectivePredictionKey.PREDICTION_VALUE,
+                ObjectivePredictionKey.SCORE_L1,
+                ObjectivePredictionKey.SCORE_SIGNED_ERROR,
+            }
+        ),
+    ).eval()
+
+
+def _make_batch() -> dict:
+    generator = torch.Generator().manual_seed(0)
+    chunk = torch.rand(
+        (BATCH_SIZE, EPISODE_LENGTH, ACTION_HORIZON, ACTION_FIELDS), generator=generator
+    )
+    chunk[..., 3] = torch.randint(
+        0, 3, chunk[..., 3].shape, generator=generator
+    ).float()
+    return {
+        "image": {
+            "cam_front_left": torch.randn(
+                (BATCH_SIZE, EPISODE_LENGTH, NUM_PATCHES, IMAGE_DIM),
+                generator=generator,
+            )
+        },
+        "continuous": {
+            "speed": torch.rand((BATCH_SIZE, EPISODE_LENGTH, 1), generator=generator)
+            * 130.0
+        },
+        "context": {
+            "waypoints": torch.randn(
+                (BATCH_SIZE, EPISODE_LENGTH, 10, 2), generator=generator
+            )
+        },
+        "joint_actions": chunk,
+    }
+
+
+def test_block_causal_mask() -> None:
+    mask = block_causal_mask(3, 2)
+
+    frames = torch.arange(6) // 2
+    for i in range(6):
+        for j in range(6):
+            blocked = frames[j] > frames[i]
+            assert mask[i, j].item() == blocked, (i, j)
+
+    # within-frame: bidirectional (nothing blocked)
+    assert not mask[0, 1]
+    assert not mask[1, 0]
+    # across frames: strictly causal
+    assert mask[0, 2]
+    assert not mask[2, 0]
+
+
+def test_features_and_metrics_shapes() -> None:
+    model = _make_model()
+    batch = _make_batch()
+
+    features, chunk = model._features(batch)  # noqa: SLF001
+    assert features.shape == (BATCH_SIZE, EPISODE_LENGTH, POLICY_DIM)
+    assert chunk.shape == (BATCH_SIZE, EPISODE_LENGTH, ACTION_HORIZON, ACTION_FIELDS)
+
+    metrics = model._compute_metrics(batch)  # noqa: SLF001
+    losses = metrics["policy", "loss"]
+    assert set(losses.keys()) == {
+        *(f"code_{q}" for q in range(NUM_QUANTIZERS)),
+        "offset",
+    }
+    for value in losses.values():
+        assert value.isfinite()
+    assert metrics["policy", "metric", "offset_sampled_recon"].isfinite()
+
+
+def test_frozen_modules_receive_no_grad() -> None:
+    model = _make_model()
+
+    assert all(not p.requires_grad for p in model.tokenizer.parameters())
+    assert all(not p.requires_grad for p in model.goal_encoder.parameters())
+
+    model.train()
+    assert not model.tokenizer.training
+    assert not model.goal_encoder.training
+    assert not model.image_encoder.training
+
+    loss = model._compute_metrics(_make_batch())["policy", "loss"].sum(  # noqa: SLF001
+        reduce=True
+    )
+    loss.backward()
+
+    assert all(p.grad is None for p in model.tokenizer.parameters())
+    assert all(p.grad is None for p in model.goal_encoder.parameters())
+    assert any(
+        p.grad is not None and p.grad.abs().sum() > 0
+        for p in model.code_head.parameters()
+    )
+    assert any(
+        p.grad is not None and p.grad.abs().sum() > 0
+        for p in model.offset_head.parameters()
+    )
+
+
+def test_gather_offset_matches_joint_policy() -> None:
+    generator = torch.Generator().manual_seed(1)
+    offsets = torch.randn(
+        (BATCH_SIZE, NUM_QUANTIZERS, CODEBOOK_SIZE, ACTION_DIM), generator=generator
+    )
+    codes = torch.randint(
+        0, CODEBOOK_SIZE, (BATCH_SIZE, NUM_QUANTIZERS), generator=generator
+    )
+
+    torch.testing.assert_close(
+        PatchPolicy._gather_offset(offsets, codes),  # noqa: SLF001
+        JointPolicyObjective._gather_offset(offsets, codes),  # noqa: SLF001
+    )
+
+    # the batched form must equal per-frame application
+    offsets_bt = torch.randn(
+        (BATCH_SIZE, EPISODE_LENGTH, NUM_QUANTIZERS, CODEBOOK_SIZE, ACTION_DIM),
+        generator=generator,
+    )
+    codes_bt = torch.randint(
+        0,
+        CODEBOOK_SIZE,
+        (BATCH_SIZE, EPISODE_LENGTH, NUM_QUANTIZERS),
+        generator=generator,
+    )
+    gathered = PatchPolicy._gather_offset(offsets_bt, codes_bt)  # noqa: SLF001
+    for t in range(EPISODE_LENGTH):
+        torch.testing.assert_close(
+            gathered[:, t],
+            JointPolicyObjective._gather_offset(offsets_bt[:, t], codes_bt[:, t]),  # noqa: SLF001
+        )
+
+
+def test_teacher_forcing_gradient_routing() -> None:
+    """With teacher forcing, the offset loss must not push gradient through
+    entries at non-target codes."""
+    model = _make_model(teacher_force_offset=True)
+    batch = _make_batch()
+
+    features, chunk = model._features(batch)  # noqa: SLF001
+    with torch.no_grad():
+        target_codes = model.tokenizer(chunk)
+        target = model.tokenizer._normalize(chunk.flatten(-2, -1))  # noqa: SLF001
+
+    _, offsets = model._heads(features)  # noqa: SLF001
+    offsets = offsets.detach().requires_grad_()
+
+    predicted = model.tokenizer.invert(target_codes) + model._offset(  # noqa: SLF001
+        offsets, target_codes
+    )
+    model.losses["offset"](predicted, target).backward()
+
+    grad = offsets.grad
+    assert grad is not None
+    index = target_codes[..., None, None].expand(*target_codes.shape, 1, ACTION_DIM)
+    target_grad = grad.gather(-2, index)
+    assert target_grad.abs().sum() > 0
+    # zero out target-code entries: everything else must have zero gradient
+    grad_zeroed = grad.scatter(-2, index, torch.zeros_like(target_grad))
+    assert grad_zeroed.abs().sum() == 0
+
+
+def test_forward_and_predict_step() -> None:
+    model = _make_model()
+    batch = _make_batch()
+
+    output = model.forward(batch)
+    assert output["policy", "joint_actions"].shape == (
+        BATCH_SIZE,
+        ACTION_HORIZON,
+        ACTION_FIELDS,
+    )
+
+    predictions = model.predict_step(batch)
+    for key in (
+        ObjectivePredictionKey.GROUND_TRUTH,
+        ObjectivePredictionKey.PREDICTION_VALUE,
+        ObjectivePredictionKey.SCORE_L1,
+        ObjectivePredictionKey.SCORE_SIGNED_ERROR,
+    ):
+        prediction = predictions["policy", key]
+        assert prediction.value["continuous", "gas_pedal"].shape == (
+            BATCH_SIZE,
+            ACTION_HORIZON,
+        )
+        assert prediction.value["discrete", "turn_signal"].shape == (
+            BATCH_SIZE,
+            ACTION_HORIZON,
+        )
+
+    score = predictions["policy", ObjectivePredictionKey.SCORE_L1]
+    assert (score.value["continuous", "gas_pedal"] >= 0).all()
+
+
+def test_readout_is_causally_valid() -> None:
+    """Frame t's readout must not change when future frames' inputs change."""
+    model = _make_model()
+    batch = _make_batch()
+
+    features, _ = model._features(batch)  # noqa: SLF001
+
+    perturbed = _make_batch()
+    perturbed["image"]["cam_front_left"] = batch["image"]["cam_front_left"].clone()
+    perturbed["continuous"]["speed"] = batch["continuous"]["speed"].clone()
+    perturbed["context"]["waypoints"] = batch["context"]["waypoints"].clone()
+    perturbed["joint_actions"] = batch["joint_actions"].clone()
+    # change only the LAST frame's observations
+    perturbed["image"]["cam_front_left"][:, -1] += 1.0
+    perturbed["continuous"]["speed"][:, -1] = 100.0
+    perturbed["context"]["waypoints"][:, -1] += 1.0
+
+    features_perturbed, _ = model._features(perturbed)  # noqa: SLF001
+
+    torch.testing.assert_close(features[:, :-1], features_perturbed[:, :-1])
+    assert not torch.allclose(features[:, -1], features_perturbed[:, -1])

--- a/tests/test_patch_policy.py
+++ b/tests/test_patch_policy.py
@@ -5,9 +5,10 @@ teacher-forced offset semantics inherited from `JointPolicyObjective` (#258),
 and equivalence of the batched `_gather_offset` with the joint-policy original.
 """
 
-from typing import override
+from typing import Any, override
 
 import torch
+from tensordict import TensorDict
 from torch import Tensor
 from torch.nn import Identity, L1Loss, Linear, Module, Sequential
 from torchvision.ops import MLP
@@ -416,23 +417,30 @@ def test_argmax_decode_metrics_are_the_deployment_path() -> None:
         assert 0.0 <= acc <= 1.0
     assert joint <= min(marginals) + 1e-6
 
-    # recompute the argmax decode independently -- must match exactly
+    _assert_argmax_decode_matches(model, batch, metrics)
+
+
+def _assert_argmax_decode_matches(
+    model: PatchPolicy, batch: dict[str, Any], metrics: TensorDict
+) -> None:
+    """Recompute the argmax decode independently -- it must match exactly."""
     with torch.no_grad():
         features, chunk = model._features(batch)  # noqa: SLF001
         target = model.tokenizer._normalize(chunk.flatten(-2, -1))  # noqa: SLF001
         code_logits, offsets = model._heads(features)  # noqa: SLF001
         codes = code_logits.argmax(dim=-1)
         decoded = model.tokenizer.invert(codes) + model._offset(offsets, codes)  # noqa: SLF001
-        expected_last = model.losses["offset"](decoded[:, -1], target[:, -1])
-        expected_all = model.losses["offset"](decoded, target)
+        correct = codes[:, -1] == model.tokenizer(chunk)[:, -1]
 
-    torch.testing.assert_close(metrics["offset_argmax_recon_last"], expected_last)
-    torch.testing.assert_close(metrics["offset_argmax_recon"], expected_all)
+        torch.testing.assert_close(
+            metrics["offset_argmax_recon_last"],
+            model.losses["offset"](decoded[:, -1], target[:, -1]),
+        )
+        torch.testing.assert_close(
+            metrics["offset_argmax_recon"], model.losses["offset"](decoded, target)
+        )
 
-    # and the accuracies must be the argmax hit-rate against the tokenized targets
-    with torch.no_grad():
-        target_codes = model.tokenizer(chunk)
-        correct = codes[:, -1] == target_codes[:, -1]
+    # the accuracies must be the argmax hit-rate against the tokenized targets
     for q in range(NUM_QUANTIZERS):
         torch.testing.assert_close(
             metrics[f"code_acc_{q}_last"], correct[:, q].float().mean()

--- a/tests/test_patch_policy.py
+++ b/tests/test_patch_policy.py
@@ -381,3 +381,59 @@ def test_fusion_norm_calibration_deterministic() -> None:
     torch.manual_seed(7)
     b = _make_model(fusion_norm=True)
     torch.testing.assert_close(a.fusion_goal_gain, b.fusion_goal_gain)
+
+
+def test_argmax_decode_metrics_are_the_deployment_path() -> None:
+    """`offset_argmax_recon*` must be the ARGMAX decode -- what inference serves with
+    `sample_codes=false` -- and not an alias of the sampled-decode metric.
+
+    The distinction is the point of the metric: on dashing-dream-514 the val code losses
+    rose 256% across training while the argmax decode IMPROVED 13%, so selecting on the
+    code loss picks the worse checkpoint.
+    """
+    model = _make_model()
+    model.sample_codes = True  # make the sampled path genuinely differ from argmax
+    batch = _make_batch()
+
+    metrics = model._compute_metrics(batch)["policy", "metric"]  # noqa: SLF001
+
+    expected_keys = {
+        "offset_argmax_recon",
+        "offset_argmax_recon_last",
+        "code_acc_joint_last",
+        *(f"code_acc_{q}_last" for q in range(NUM_QUANTIZERS)),
+    }
+    assert expected_keys <= set(metrics.keys()), (
+        f"missing: {expected_keys - set(metrics.keys())}"
+    )
+    for key in expected_keys:
+        assert metrics[key].isfinite()
+
+    # accuracies are proportions, and joint correctness cannot exceed any marginal
+    marginals = [float(metrics[f"code_acc_{q}_last"]) for q in range(NUM_QUANTIZERS)]
+    joint = float(metrics["code_acc_joint_last"])
+    for acc in [*marginals, joint]:
+        assert 0.0 <= acc <= 1.0
+    assert joint <= min(marginals) + 1e-6
+
+    # recompute the argmax decode independently -- must match exactly
+    with torch.no_grad():
+        features, chunk = model._features(batch)  # noqa: SLF001
+        target = model.tokenizer._normalize(chunk.flatten(-2, -1))  # noqa: SLF001
+        code_logits, offsets = model._heads(features)  # noqa: SLF001
+        codes = code_logits.argmax(dim=-1)
+        decoded = model.tokenizer.invert(codes) + model._offset(offsets, codes)  # noqa: SLF001
+        expected_last = model.losses["offset"](decoded[:, -1], target[:, -1])
+        expected_all = model.losses["offset"](decoded, target)
+
+    torch.testing.assert_close(metrics["offset_argmax_recon_last"], expected_last)
+    torch.testing.assert_close(metrics["offset_argmax_recon"], expected_all)
+
+    # and the accuracies must be the argmax hit-rate against the tokenized targets
+    with torch.no_grad():
+        target_codes = model.tokenizer(chunk)
+        correct = codes[:, -1] == target_codes[:, -1]
+    for q in range(NUM_QUANTIZERS):
+        torch.testing.assert_close(
+            metrics[f"code_acc_{q}_last"], correct[:, q].float().mean()
+        )

--- a/tests/test_patch_policy.py
+++ b/tests/test_patch_policy.py
@@ -445,3 +445,80 @@ def _assert_argmax_decode_matches(
         torch.testing.assert_close(
             metrics[f"code_acc_{q}_last"], correct[:, q].float().mean()
         )
+
+
+def test_readout_is_the_last_patch_token_not_the_speed_token() -> None:
+    """The speed token is PREPENDED, so each frame block must END on a patch token.
+
+    `test_readout_is_causally_valid` cannot catch a readout moved to index 0: the
+    speed token attends bidirectionally within its frame, so it changes in
+    lockstep with the patch tokens. This pins the index arithmetic instead.
+    """
+    model = _make_model()
+    batch = _make_batch()
+    tokens_per_frame = NUM_PATCHES + 1
+
+    captured: dict[str, Tensor] = {}
+    encoder_forward = model.encoder.forward
+
+    def _capture(src: Tensor, *, num_frames: int) -> Tensor:
+        out = encoder_forward(src, num_frames=num_frames)
+        captured["embedding"] = out
+        return out
+
+    model.encoder.forward = _capture  # type: ignore[method-assign]
+    features, _ = model._features(batch)  # noqa: SLF001
+    model.encoder.forward = encoder_forward  # type: ignore[method-assign]
+
+    embedding = captured["embedding"]  # (b, t * k, d), pre-norm
+    assert embedding.shape[1] == EPISODE_LENGTH * tokens_per_frame
+
+    # the readout of frame t must be flat index t*(P+1) + P, i.e. its LAST token
+    for t in range(EPISODE_LENGTH):
+        expected = embedding[:, t * tokens_per_frame + NUM_PATCHES]
+        if model.norm is not None:
+            expected = model.norm(expected)
+        torch.testing.assert_close(features[:, t], expected)
+
+    # and NOT the frame's first token (the speed token)
+    speed_token = embedding[:, 0 * tokens_per_frame]
+    if model.norm is not None:
+        speed_token = model.norm(speed_token)
+    assert not torch.allclose(features[:, 0], speed_token)
+
+
+def test_teacher_forcing_routes_the_offset_loss_through_ground_truth_codes() -> None:
+    """`_compute_metrics` must gather offsets at GROUND-TRUTH codes when
+    `teacher_force_offset=True`.
+
+    The existing gradient test builds `predicted` by hand, so it would still pass
+    if `_compute_metrics` silently used the sampled codes. This asserts on the
+    loss value produced by `_compute_metrics` itself.
+    """
+    torch.manual_seed(0)
+    model = _make_model(teacher_force_offset=True)
+    model.sample_codes = True  # make the sampled path genuinely differ from argmax
+    batch = _make_batch()
+
+    offset_loss = model._compute_metrics(batch)["policy", "loss", "offset"]  # noqa: SLF001
+
+    with torch.no_grad():
+        features, chunk = model._features(batch)  # noqa: SLF001
+        target = model.tokenizer._normalize(chunk.flatten(-2, -1))  # noqa: SLF001
+        _, offsets = model._heads(features)  # noqa: SLF001
+        target_codes = model.tokenizer(chunk)
+        teacher_chunk = model.tokenizer.invert(target_codes) + model._offset(  # noqa: SLF001
+            offsets, target_codes
+        )
+        expected = model.losses["offset"](teacher_chunk, target)
+
+    torch.testing.assert_close(offset_loss, expected)
+
+    # the same model with teacher forcing OFF must NOT produce the teacher value
+    # (guards against the flag being ignored entirely)
+    torch.manual_seed(0)
+    free = _make_model(teacher_force_offset=False)
+    free.load_state_dict(model.state_dict())
+    free.sample_codes = True
+    free_loss = free._compute_metrics(batch)["policy", "loss", "offset"]  # noqa: SLF001
+    assert not torch.allclose(free_loss, expected)


### PR DESCRIPTION
Implements **Patch Policy** ([arXiv:2607.18236](https://arxiv.org/pdf/2607.18236), Zhou et al.) as a new rmind model variant, on top of the offset teacher-forcing fix (#258).

## Architecture

![PatchPolicy architecture](https://raw.githubusercontent.com/yaak-ai/rmind/cdbfc31f60992ee9f2619b22b461cb7c1d5d4b27/docs/patch_policy_architecture.svg)

<sub>blue = frozen ("PT" packing) · orange = trained ("FT") · also committed as `docs/patch_policy_architecture.svg`</sub>


**"PT" = frozen feature packing (nothing trained):**
- frozen **DINO ViT-S** patch features per frame: 256 patch tokens x 384 (16x16 grid)
- frozen **waypoints tokenizer** ([`gzxgumtf`](https://wandb.ai/yaak/waypoints-tokenizer/runs/gzxgumtf), ported from `feat/wpts-rvq`): per-frame waypoint path -> post-quantization RVQ latent `g_t` (384-d)
- the paper's **`T x P x (D + G)`** scheme: `g_t` concatenated to every patch token of frame `t` (per-frame goal, since waypoints are ego-frame), then a single `Linear(768 -> 512)`
- speed as **one extra embedded token per frame** (prepended, so each frame block still ends on a patch token = the readout position)

**Policy (their "simplified" trunk):**
- flatten to a `T*(P+1) = 6*257 = 1542`-token sequence, **learned 1D positional embedding**
- **block-causal attention mask**: bidirectional intra-frame, causal inter-frame
- plain pre-LN GPT blocks, **8 layers / 8 heads / 512 dim** (paper Table 9, Push-T) -> 31.5M trainable / 51.5M total (paper: 29.5M / 51.6M)

**FT head = bug-fixed VQ-BeT from #258:**
- frozen joint chunk tokenizer [`y74asdtd:v9`](https://wandb.ai/yaak/rmind) (6-step x 4-field chunk -> 4 RVQ codes), same as the #258 A/B
- code head (focal loss) + offset table gathered at codes, **`teacher_force_offset=true`**
- supervised at **every frame's** last patch token (paper section 2.2); inference decodes the newest frame's chunk
- history/chunking identical to the existing FT: `episode_length=6`, `action_horizon=6`, `clip_length=11`

## Ablation (in flight)

| arm | encoder | input | grid | box | run |
|---|---|---|---|---|---|
| dinov3 | `vit_small_patch16_dinov3.lvd1689m` | 256x256 | 16x16=256 | aboutblank.ml | [8crjqzii](https://wandb.ai/yaak/rmind/runs/8crjqzii) |
| dinov2 | `vit_small_patch14_dinov2.lvd142m` | 224x224 | 16x16=256 | kitkat.ml | [wxyp0bzq](https://wandb.ai/yaak/rmind/runs/wxyp0bzq) |
| dinov3_vitb | `vit_base_patch16_dinov3.lvd1689m` (768-d) | 256x256 | 16x16=256 | berghain.ml | [v609nf2a](https://wandb.ai/yaak/rmind/runs/v609nf2a) |
| dinov2_dinowm | `vit_small_patch14_dinov2.lvd142m`, final layer + final norm (`x_norm_patchtokens`, as [DINO-WM](https://github.com/gaoyuezhou/dino_wm)) | 224x224 | 16x16=256 | berghain.ml | [ifuusvwq](https://wandb.ai/yaak/rmind/runs/ifuusvwq) |
| dinov2_smalltrunk | as dinov2, trunk shrunk to the paper's LIBERO config (6L/**120-d**, 5 heads*, 5.4M trainable) — anti-overfitting arm | 224x224 | 16x16=256 | renate.ml | [cqtues6r](https://wandb.ai/yaak/rmind/runs/cqtues6r) |

<sub>*5 heads instead of the paper's 6: head_dim 120/6=20 is unsupported by fused SDPA kernels (needs %8), falling back to a math kernel that materializes the (B, H, 1542, 1542) attention matrix (OOM). head_dim 24 keeps fused kernels; the parameter count is unchanged by head count.</sub>

Same 256-token patch grid in all arms. vs the dinov3 arm: dinov2 changes only encoder + input size; dinov3_vitb scales the encoder to ViT-B (768-d patches; only the patch projection widens); dinov2_dinowm changes only the feature layer (DINO-WM's `x_norm_patchtokens`); dinov2_smalltrunk changes only trunk capacity (motivated by the dinov3 arm's val-code-loss gap: train 0.20–0.65 vs val 1.34–1.46 at epoch 3, while val offset loss is unaffected). 10 epochs @ **batch 128** = ~154k steps (~15.4k steps/epoch; the clip11 set is ~1.97M samples, measured via FT baseline zcglgth4's 308,038 steps @ 64), **LR 1e-4** (linear scaling from 5e-5 @ 64), 12.5k warmup + cosine to zero at 154k, bf16, otherwise identical configs. Batch-128 peak memory measured at 9.2 GiB (ViT-S) / 9.5 GiB (ViT-B).

```
just train experiment=yaak/patch_policy/{dinov3,dinov2,dinov3_vitb,dinov2_dinowm}
```

## Notes / deviations
- paper is vision-only; we keep speed as one token per frame (deliberate, per discussion)
- `out_indices=[10]` (pre-norm intermediates, repo convention) for the dinov3/dinov2/dinov3_vitb arms; the `dinov2_dinowm` arm instead uses DINO-WM's exact feature — final block + final LayerNorm (`x_norm_patchtokens`, verified bit-exact vs raw timm `forward_features`)
- `SelectiveAdamW` learned to classify timm ViT `pos_embed`/`gamma` (LayerScale) params — DINOv2 has them, DINOv3 (RoPE) doesn't
- `WaypointsTokenizer` port adapts `_step` to this repo's `ResidualVQ` contract; `encode()` is unchanged, checkpoint loads with `strict=false`
- eval comparability: `PredictMetricsCallback` wired with per-cluster `score_l1`/`score_signed_error` on the same rules as the FT configs
- later mix-ins (RoPE, factorized attention, ...) intentionally left out — this keeps the paper's simplicity as the baseline

## Post-review fixes (adversarial review before launch)
- **LR schedule**: sized to the measured run length — 10 epochs = ~308k steps (`zcglgth4` finished at global_step 308,038 @ batch 64) — as 25k warmup / 308k total, so the cosine reaches zero exactly at the end. Two pitfalls found on the way: (a) an intermediate fix mis-sized the schedule from a stale local rbyte cache (76.7k samples vs the real ~1.97M) — do not trust local `.rbyte_cache` counts; (b) `get_cosine_schedule_with_warmup` **rises again** past `num_training_steps` (no clamp), which is also why the 25k/250k FT baseline's LR climbed back to ~14% of peak over its last ~58k steps.
- **SelectiveAdamW**: param groups were built from unordered sets; torch maps optimizer state positionally on `load_state_dict`, so a cross-process resume mis-assigned Adam moments (shape crash, or silent corruption for same-shaped params). Groups are now sorted by param name. Pre-existing repo-wide issue, fixed here since the file was already touched.

## Tests
- `tests/test_patch_policy.py`: block-causal mask semantics, per-frame readout causality (future-frame perturbation), teacher-forced offset gradient routing, `_gather_offset` equivalence with `JointPolicyObjective`, frozen-module gradient isolation, forward/predict shapes
- full suite: 69 passed (2 pre-existing `test_models.py` fixture errors also fail on the base branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
