### PR TITLE
feat: nero-arms causal patch policy + SE(3) VQ-BeT action tokenizer

### DIFF
--- a/config/datamodule/yaak/nero_random.yaml
+++ b/config/datamodule/yaak/nero_random.yaml
@@ -1,0 +1,26 @@
+# Structured synthetic nero-arms batches at the EXACT contract §8 shapes.
+# For smoke runs and shape tests ONLY -- replace with the rbyte datamodule once
+# ingestion lands. See src/rmind/datamodules/nero_random.py for what is and is
+# not synthetic (poses are structured SE(3) walks; images are noise).
+_target_: rmind.datamodules.generic.GenericDataModule
+_convert_: all
+
+train:
+  _target_: rmind.datamodules.nero_random.NeroRandomDataLoader
+  num_batches: ${num_train_batches}
+  batch_size: ${batch_size}
+  episode_length: ${episode_length}
+  action_horizon: ${action_horizon}
+  image_size: ${image_size}
+  both_sides: ${both_sides}
+  seed: 0
+
+val:
+  _target_: rmind.datamodules.nero_random.NeroRandomDataLoader
+  num_batches: 8
+  batch_size: ${batch_size}
+  episode_length: ${episode_length}
+  action_horizon: ${action_horizon}
+  image_size: ${image_size}
+  both_sides: ${both_sides}
+  seed: 100000

--- a/config/datamodule/yaak/nero_random.yaml
+++ b/config/datamodule/yaak/nero_random.yaml
@@ -11,7 +11,6 @@ train:
   batch_size: ${batch_size}
   episode_length: ${episode_length}
   action_horizon: ${action_horizon}
-  image_size: ${image_size}
   both_sides: ${both_sides}
   seed: 0
 
@@ -21,6 +20,5 @@ val:
   batch_size: ${batch_size}
   episode_length: ${episode_length}
   action_horizon: ${action_horizon}
-  image_size: ${image_size}
   both_sides: ${both_sides}
   seed: 100000

--- a/config/experiment/yaak/nero_arms/causal.yaml
+++ b/config/experiment/yaak/nero_arms/causal.yaml
@@ -1,0 +1,88 @@
+# @package _global_
+#
+# Causal patch policy for the nero-arms bimanual manipulation contract (v0.1 + §11, §7.2).
+#
+# ⚠️ DATAMODULE. Defaults to the SYNTHETIC datamodule, because rbyte ingestion is
+# being implemented in parallel against the same contract. Point `/datamodule` at
+# the rbyte one when it lands; nothing else here should need to change, because
+# every key below is a contract §8 key.
+#
+# SEQUENCE LENGTH (compute this before launching anything -- PR #265's lesson):
+#
+#   tokens_per_frame = num_cameras * num_patches + 1 = 3 * 256 + 1 = 769
+#   flattened        = episode_length * tokens_per_frame = 6 * 769 = 4614
+#
+# For comparison on this same trunk: the 6-frame driving arm is 1542 and the
+# 16-frame causal driving arm is 4112. Attention cost scales quadratically, so
+# 4614 is ~9x the 6-frame driving arm and ~1.26x the 16-frame causal arm.
+#
+# ⚠️ head_dim = policy_embedding_dim / num_heads = 512 / 8 = 64, which is
+# divisible by 8. Below that, fused SDPA silently falls back to a math kernel
+# that materialises the full (B, H, 4614, 4614) score matrix and OOMs -- exactly
+# what PR #265 hit at head_dim 20. Do not change num_heads without rechecking.
+# (head_dim must also be EVEN for the trunk's frame-RoPE.)
+
+defaults:
+  - /model: yaak/nero_patch_policy/raw
+  - /datamodule: yaak/nero_random
+  - /trainer: default
+  - /trainer/callbacks: nero_patch_policy
+  - /paths: yaak/default
+  - /wandb: yaak/rmind
+  - _self_
+
+# --- contract §6.2: action(t) = future state chunk [t+1 .. t+H] at 30 Hz
+episode_length: 6
+action_horizon: 6
+clip_length: "${eval:'${episode_length} + ${action_horizon}'}"
+
+# --- contract §8 / §7.2
+cameras: [base, side_left, side_right]
+num_cameras: 3
+camera_cond_dim: 13
+# square LETTERBOX target (not a plain resize -- §7.2, different aspect ratios)
+image_size: 224
+image_encoder_name: vit_small_patch14_dinov2.lvd142m
+image_embedding_dim: 384
+num_patches: 256 # 224 / patch 14 -> 16x16
+
+# --- contract §6.1 state / action space
+num_sides: 2
+state_features: 60 # 9D form, per side
+# CONFIG SEAM (§11): the per-side ACTION dimensionality. 60 today; ~12 for the
+# Revo2 joint-angle variant of §11(B). Head widths derive from this.
+action_features: 60
+
+# --- contract §9 goal conditioning
+use_goal_image: true
+goal_embedding_dim: ${image_embedding_dim} # same-index concat of goal patches
+# goal dropout so the policy does not become goal-DEPENDENT for basic motion
+goal_dropout: 0.15
+
+# --- policy trunk (https://arxiv.org/pdf/2607.18236 Table 9)
+policy_embedding_dim: 512
+num_layers: 8
+num_heads: 8
+
+# --- VQ-BeT action tokenizer
+tokenizer_latent_dim: 256
+codebook_size: 16
+num_quantizers: 4
+teacher_force_offset: true
+
+# --- optimization. Placeholders: re-derive from the REAL sample count (contract
+# §8: "do not trust .rbyte_cache sample counts") before launching. The cosine
+# schedule rises again past num_training_steps.
+lr: 1e-4
+lr_warmup_steps: 500
+lr_total_steps: 10000
+
+batch_size: 8
+both_sides: true
+num_train_batches: 1000
+
+trainer:
+  max_epochs: 10
+
+wandb:
+  tags: [nero_arms, causal_patch_policy]

--- a/config/experiment/yaak/nero_arms/causal.yaml
+++ b/config/experiment/yaak/nero_arms/causal.yaml
@@ -23,7 +23,7 @@
 #
 # ⚠️ head_dim = policy_embedding_dim / num_heads = 512 / 8 = 64, which is
 # divisible by 8. Below that, fused SDPA silently falls back to a math kernel
-# that materialises the full (B, H, 4614, 4614) score matrix and OOMs -- exactly
+# that materialises the full (B, H, 2886, 2886) score matrix and OOMs -- exactly
 # what PR #265 hit at head_dim 20. Do not change num_heads without rechecking.
 # (head_dim must also be EVEN for the trunk's frame-RoPE.)
 

--- a/config/experiment/yaak/nero_arms/causal.yaml
+++ b/config/experiment/yaak/nero_arms/causal.yaml
@@ -9,12 +9,17 @@
 #
 # SEQUENCE LENGTH (compute this before launching anything -- PR #265's lesson):
 #
-#   tokens_per_frame = num_cameras * num_patches + 1 = 3 * 256 + 1 = 769
-#   flattened        = episode_length * tokens_per_frame = 6 * 769 = 4614
+#   tokens_per_frame = num_cameras * num_patches + 1 = 3 * 160 + 1 = 481
+#   flattened        = episode_length * tokens_per_frame = 6 * 481 = 2886
 #
 # For comparison on this same trunk: the 6-frame driving arm is 1542 and the
 # 16-frame causal driving arm is 4112. Attention cost scales quadratically, so
-# 4614 is ~9x the 6-frame driving arm and ~1.26x the 16-frame causal arm.
+# 2886 is ~3.5x the 6-frame driving arm and ~0.5x the 16-frame causal arm.
+#
+# num_patches = 160 (a 10x16 grid), NOT 256: the ViT input is 140x224, which is
+# the nero-arms 5:8 aspect at DINOv2's patch 14. Forcing a square 224x224 would
+# make 6 of 16 patch rows pure letterbox padding -- 37% of the sequence spent on
+# black bars -- for identical image content.
 #
 # ⚠️ head_dim = policy_embedding_dim / num_heads = 512 / 8 = 64, which is
 # divisible by 8. Below that, fused SDPA silently falls back to a math kernel
@@ -40,14 +45,19 @@ clip_length: "${eval:'${episode_length} + ${action_horizon}'}"
 cameras: [base, side_left, side_right]
 num_cameras: 3
 camera_cond_dim: 13
-# square LETTERBOX target (not a plain resize -- §7.2, different aspect ratios)
-image_size: 224
+# LETTERBOX target, not a plain resize (§7.2 + the rbyte per-camera grids).
+# 140x224 keeps the cameras' 5:8 aspect and is a whole number of patch 14s.
+image_height: 140
+image_width: 224
 image_encoder_name: vit_small_patch14_dinov2.lvd142m
 image_embedding_dim: 384
-num_patches: 256 # 224 / patch 14 -> 16x16
+num_patches: 160 # (140/14) x (224/14) = 10 x 16
 
 # --- contract §6.1 state / action space
 num_sides: 2
+# ⚠️ the LOADER emits 46 per side (contract §5.2 storage form: 6 poses x 7 + a
+# 4-dim hub quaternion); the model expands to the 60-dim 9D form at its input
+# boundary (rmind.data.nero.state_quat_to_9d). 60 is the MODEL-FACING width.
 state_features: 60 # 9D form, per side
 # CONFIG SEAM (§11): the per-side ACTION dimensionality. 60 today; ~12 for the
 # Revo2 joint-angle variant of §11(B). Head widths derive from this.

--- a/config/experiment/yaak/nero_arms/causal.yaml
+++ b/config/experiment/yaak/nero_arms/causal.yaml
@@ -39,7 +39,14 @@ defaults:
 # --- contract §6.2: action(t) = future state chunk [t+1 .. t+H] at 30 Hz
 episode_length: 6
 action_horizon: 6
-clip_length: "${eval:'${episode_length} + ${action_horizon}'}"
+# ⚠️ clip_length == episode_length here, NOT `episode_length + horizon - 1` as in
+# every driving config. rbyte materialises each row's future chunk AT BUILD TIME
+# (`future = stack(state[i+1 : i+1+H])`) and drops the rows without a full chunk,
+# so one sample row already carries both `state.pose[t]` and
+# `action.future_state[t]`; the window needs no extra frames. Verified against
+# rbyte@feat/nero-arms, which builds at clip_length 6 with the same [t+1 .. t+H]
+# shift this side assumes.
+clip_length: ${episode_length}
 
 # --- contract §8 / §7.2
 cameras: [base, side_left, side_right]

--- a/config/experiment/yaak/nero_arms/tokenizer.yaml
+++ b/config/experiment/yaak/nero_arms/tokenizer.yaml
@@ -29,7 +29,6 @@ num_quantizers: 4
 
 lr: 1e-3
 batch_size: 8
-image_size: 224
 both_sides: true
 num_train_batches: 2000
 

--- a/config/experiment/yaak/nero_arms/tokenizer.yaml
+++ b/config/experiment/yaak/nero_arms/tokenizer.yaml
@@ -1,0 +1,41 @@
+# @package _global_
+#
+# VQ-BeT action tokenizer for the nero-arms SE(3) action space (contract §5, §6).
+#
+# One tokenizer serves BOTH current-state encoding and action prediction, because
+# action(t) is future state (§6.2) -- same space, same statistics.
+#
+# ⚠️ Before a real fit: replace `model.standardizer` with a `PoseStandardizer`
+# fitted on the TRAIN SPLIT ONLY and ship the JSON next to the checkpoint (§5.4).
+# Without it, rotation error swamps translation error in the L1 objective and the
+# scalar recon loss looks healthy while translation is garbage.
+
+defaults:
+  - /model: yaak/nero_pose_tokenizer/raw
+  - /datamodule: yaak/nero_random
+  - /trainer: default
+  - /paths: yaak/default
+  - /wandb: yaak/rmind
+  - _self_
+
+episode_length: 6
+action_horizon: 6
+action_features: 60
+num_sides: 2
+
+tokenizer_latent_dim: 256
+codebook_size: 16
+num_quantizers: 4
+
+lr: 1e-3
+batch_size: 8
+image_size: 224
+both_sides: true
+num_train_batches: 2000
+
+trainer:
+  max_epochs: 5
+  gradient_clip_val: 1.0
+
+wandb:
+  tags: [nero_arms, pose_tokenizer]

--- a/config/model/yaak/nero_patch_policy/raw.yaml
+++ b/config/model/yaak/nero_patch_policy/raw.yaml
@@ -2,15 +2,17 @@ _target_: rmind.models.nero_patch_policy.NeroPatchPolicy
 _recursive_: false
 _convert_: all
 
-# Contract §7.2: the three cameras have DIFFERENT aspect ratios (base 16:9,
-# side_* 16:10). Letterbox (uniform scale + symmetric pad), NOT plain Resize --
-# an anisotropic resize scales fx and fy independently and invalidates the
-# resolution-normalised intrinsics carried in camera_cond (§7.1).
+# ⚠️ rbyte delivers each camera ISOTROPICALLY downscaled to its OWN grid
+# (base 270x480, side_* 300x480), so the three image tensors do NOT share H/W.
+# Unifying them is rmind's job. LetterboxResize (uniform scale + symmetric pad),
+# NEVER a plain anisotropic Resize -- that would scale fx and fy independently
+# and invalidate the resolution-normalised intrinsics in camera_cond (§7.1).
+# 300x480 -> 140x224 is EXACTLY isotropic (x0.4667), so only base is padded.
 image_transform:
   _target_: torch.nn.Sequential
   _args_:
     - _target_: rmind.components.image.LetterboxResize
-      size: ${image_size}
+      size: ["${image_height}", "${image_width}"]
     - _target_: torchvision.transforms.v2.ToDtype
       scale: true
       dtype:
@@ -29,7 +31,7 @@ image_encoder:
   _args_:
     - _target_: rmind.components.timm_backbone.TimmBackbone
       model_name: ${image_encoder_name}
-      img_size: ["${image_size}", "${image_size}"]
+      img_size: ["${image_height}", "${image_width}"]
       norm_patch_tokens: true
     - _target_: einops.layers.torch.Rearrange
       pattern: "... c h w -> ... (h w) c"

--- a/config/model/yaak/nero_patch_policy/raw.yaml
+++ b/config/model/yaak/nero_patch_policy/raw.yaml
@@ -1,0 +1,145 @@
+_target_: rmind.models.nero_patch_policy.NeroPatchPolicy
+_recursive_: false
+_convert_: all
+
+# Contract §7.2: the three cameras have DIFFERENT aspect ratios (base 16:9,
+# side_* 16:10). Letterbox (uniform scale + symmetric pad), NOT plain Resize --
+# an anisotropic resize scales fx and fy independently and invalidates the
+# resolution-normalised intrinsics carried in camera_cond (§7.1).
+image_transform:
+  _target_: torch.nn.Sequential
+  _args_:
+    - _target_: rmind.components.image.LetterboxResize
+      size: ${image_size}
+    - _target_: torchvision.transforms.v2.ToDtype
+      scale: true
+      dtype:
+        _target_: hydra.utils.get_object
+        path: torch.float32
+    - _target_: torchvision.transforms.v2.Normalize
+      mean: [0.485, 0.456, 0.406]
+      std: [0.229, 0.224, 0.225]
+
+# DINO-WM-faithful features: final block + final LayerNorm (x_norm_patchtokens),
+# same as config/experiment/yaak/patch_policy/dinov2_dinowm.yaml. The SAME frozen
+# encoder serves observation frames and goal frames (contract §9: "because it is
+# a plain image, it goes through the same encoder; no extra machinery").
+image_encoder:
+  _target_: torch.nn.Sequential
+  _args_:
+    - _target_: rmind.components.timm_backbone.TimmBackbone
+      model_name: ${image_encoder_name}
+      img_size: ["${image_size}", "${image_size}"]
+      norm_patch_tokens: true
+    - _target_: einops.layers.torch.Rearrange
+      pattern: "... c h w -> ... (h w) c"
+
+# per patch: [obs feature | goal feature (same patch index) | camera_cond 13]
+patch_projection:
+  _target_: rmind.components.nn.Linear
+  in_features: "${eval:'${image_embedding_dim} + ${goal_embedding_dim} + ${camera_cond_dim}'}"
+  out_features: ${policy_embedding_dim}
+
+# one state token per frame: bimanual state, invalid side zeroed, mask appended
+state_embedding:
+  _target_: torchvision.ops.MLP
+  in_channels: "${eval:'${num_sides} * ${state_features} + ${num_sides}'}"
+  hidden_channels: ["${policy_embedding_dim}", "${policy_embedding_dim}"]
+
+# decoder-only trunk, reused unchanged from feat/patch-policy-decoder-only.
+# tokens_per_frame = num_cameras * num_patches + 1 state token = 769
+encoder:
+  _target_: rmind.components.transformer.causal_frame.CausalFrameTransformer
+  dim_model: ${policy_embedding_dim}
+  num_layers: ${num_layers}
+  num_heads: ${num_heads}
+  tokens_per_frame: "${eval:'${num_cameras} * ${num_patches} + 1'}"
+  window: ${episode_length}
+  rope_base: 1000.0
+
+# ⚠️ A REAL run must override this with a trained checkpoint, e.g.
+#   model:
+#     tokenizer:
+#       _target_: rmind.models.nero_pose_tokenizer.NeroPoseTokenizer.load_from_wandb_artifact
+#       artifact: ${pose_tokenizer_artifact}
+#       weights_only: false
+# An inline (untrained) tokenizer has an uninitialised RVQ codebook and will
+# collapse every chunk onto code 0. Kept inline here only so the architecture is
+# instantiable before the first tokenizer checkpoint exists.
+tokenizer:
+  _target_: rmind.models.nero_pose_tokenizer.NeroPoseTokenizer
+  _recursive_: false
+  _convert_: all
+  action_features: ${action_features}
+  action_horizon: ${action_horizon}
+  encoder:
+    _target_: torchvision.ops.MLP
+    in_channels: "${eval:'${action_horizon} * ${action_features}'}"
+    hidden_channels: [512, "${tokenizer_latent_dim}"]
+  quantizer:
+    _target_: rmind.components.vq.ResidualVQ
+    dim: ${tokenizer_latent_dim}
+    codebook_size: ${codebook_size}
+    num_quantizers: ${num_quantizers}
+  decoder:
+    _target_: torchvision.ops.MLP
+    in_channels: ${tokenizer_latent_dim}
+    hidden_channels: [512, "${eval:'${action_horizon} * ${action_features}'}"]
+
+norm:
+  _target_: torch.nn.LayerNorm
+  normalized_shape: ${policy_embedding_dim}
+
+# CONFIG SEAM (contract §11): every head width is DERIVED. Swapping to the Revo2
+# joint-angle action space of §11(B) is `action_features: 12` -- not a rewrite.
+code_head:
+  _target_: torchvision.ops.MLP
+  in_channels: ${policy_embedding_dim}
+  hidden_channels: [1024, 1024, "${eval:'${num_quantizers} * ${codebook_size}'}"]
+
+# NOTE: the last hidden width is 512, not the driving config's 1024. At
+# g*c*a = 4*16*360 = 23040 outputs, a 1024-wide penultimate layer would be 23.6M
+# parameters -- comparable to the whole trunk. 512 halves it to 11.8M.
+offset_head:
+  _target_: torchvision.ops.MLP
+  in_channels: ${policy_embedding_dim}
+  hidden_channels:
+    - 1024
+    - 512
+    - "${eval:'${num_quantizers} * ${codebook_size} * ${action_horizon} * ${action_features}'}"
+
+losses:
+  _target_: rmind.components.containers.ModuleDict
+  modules:
+    code:
+      _target_: rmind.components.loss.FocalLoss
+    offset:
+      _target_: torch.nn.L1Loss
+
+image_embedding_dim: ${image_embedding_dim}
+policy_embedding_dim: ${policy_embedding_dim}
+cameras: ${cameras}
+use_goal_image: ${use_goal_image}
+goal_dropout: ${goal_dropout}
+teacher_force_offset: ${teacher_force_offset}
+
+optimizer:
+  _target_: rmind.components.optimizers.SelectiveAdamW
+  _recursive_: true
+  lr: ${lr}
+  betas: [0.9, 0.95]
+  weight_decay: 0.1
+  weight_decay_module_blacklist:
+    - _target_: hydra.utils.get_class
+      path: torch.nn.Embedding
+    - _target_: hydra.utils.get_class
+      path: torch.nn.LayerNorm
+
+# NOTE: get_cosine_schedule_with_warmup RISES AGAIN past num_training_steps --
+# size lr_total_steps to the actual planned optimizer steps.
+lr_scheduler:
+  interval: step
+  scheduler:
+    _target_: rmind.components.lr_schedulers.get_cosine_schedule_with_warmup
+    num_warmup_steps: ${lr_warmup_steps}
+    num_training_steps: ${lr_total_steps}

--- a/config/model/yaak/nero_patch_policy/raw.yaml
+++ b/config/model/yaak/nero_patch_policy/raw.yaml
@@ -8,16 +8,19 @@ _convert_: all
 # NEVER a plain anisotropic Resize -- that would scale fx and fy independently
 # and invalidate the resolution-normalised intrinsics in camera_cond (§7.1).
 # 300x480 -> 140x224 is EXACTLY isotropic (x0.4667), so only base is padded.
+#
+# ToDtype comes FIRST: letterboxing interpolates, and doing that in uint8 would
+# round every resampled pixel back to an integer before the network ever sees it.
 image_transform:
   _target_: torch.nn.Sequential
   _args_:
-    - _target_: rmind.components.image.LetterboxResize
-      size: ["${image_height}", "${image_width}"]
     - _target_: torchvision.transforms.v2.ToDtype
       scale: true
       dtype:
         _target_: hydra.utils.get_object
         path: torch.float32
+    - _target_: rmind.components.image.LetterboxResize
+      size: ["${image_height}", "${image_width}"]
     - _target_: torchvision.transforms.v2.Normalize
       mean: [0.485, 0.456, 0.406]
       std: [0.229, 0.224, 0.225]

--- a/config/model/yaak/nero_patch_policy/raw.yaml
+++ b/config/model/yaak/nero_patch_policy/raw.yaml
@@ -52,7 +52,7 @@ state_embedding:
   hidden_channels: ["${policy_embedding_dim}", "${policy_embedding_dim}"]
 
 # decoder-only trunk, reused unchanged from feat/patch-policy-decoder-only.
-# tokens_per_frame = num_cameras * num_patches + 1 state token = 769
+# tokens_per_frame = num_cameras * num_patches + 1 state token = 3*160 + 1 = 481
 encoder:
   _target_: rmind.components.transformer.causal_frame.CausalFrameTransformer
   dim_model: ${policy_embedding_dim}

--- a/config/model/yaak/nero_pose_tokenizer/raw.yaml
+++ b/config/model/yaak/nero_pose_tokenizer/raw.yaml
@@ -1,0 +1,42 @@
+_target_: rmind.models.nero_pose_tokenizer.NeroPoseTokenizer
+_recursive_: false
+_convert_: all
+
+# CONFIG SEAM (contract §11): `action_features` is the per-side action
+# dimensionality. 60 = the §6.1 9D pose layout; ~12 would be the Revo2
+# joint-angle variant of §11(B). Everything below derives from it.
+action_features: ${action_features}
+action_horizon: ${action_horizon}
+
+# ⚠️ Per-channel standardisation with TRAIN-SPLIT statistics (contract §5.4).
+# The default is identity, which is WRONG for real data: translations are
+# ~0.06-0.7 m while 6D rotation components are ~1, so an unstandardised L1 lets
+# rotation error swamp translation error. Fit once and ship the JSON artifact
+# next to the checkpoint:
+#   standardizer:
+#     _target_: rmind.data.nero.PoseStandardizer.load
+#     path: ${pose_standardizer_artifact}
+standardizer:
+  _target_: rmind.data.nero.PoseStandardizer
+  dim: ${action_features}
+
+encoder:
+  _target_: torchvision.ops.MLP
+  in_channels: "${eval:'${action_horizon} * ${action_features}'}"
+  hidden_channels: [512, "${tokenizer_latent_dim}"]
+
+quantizer:
+  _target_: rmind.components.vq.ResidualVQ
+  dim: ${tokenizer_latent_dim}
+  codebook_size: ${codebook_size}
+  num_quantizers: ${num_quantizers}
+
+decoder:
+  _target_: torchvision.ops.MLP
+  in_channels: ${tokenizer_latent_dim}
+  hidden_channels: [512, "${eval:'${action_horizon} * ${action_features}'}"]
+
+optimizer:
+  _target_: torch.optim.AdamW
+  lr: ${lr}
+  weight_decay: 0.0

--- a/config/trainer/callbacks/nero_patch_policy.yaml
+++ b/config/trainer/callbacks/nero_patch_policy.yaml
@@ -1,0 +1,11 @@
+# The driving PredictMetricsCallback is deliberately absent: its RuleBasedCluster
+# keys (gas_pedal / brake_pedal / speed) do not exist in the nero-arms contract.
+# The equivalent here is the tokenizer's translation-mm / rotation-degree split,
+# which the model logs directly.
+- _target_: pytorch_lightning.callbacks.ModelSummary
+  max_depth: 2
+- _target_: pytorch_lightning.callbacks.ModelCheckpoint
+  every_n_epochs: 1
+  save_on_train_epoch_end: True
+- _target_: pytorch_lightning.callbacks.LearningRateMonitor
+  logging_interval: step

--- a/docs/decoder_only_kv_cache.md
+++ b/docs/decoder_only_kv_cache.md
@@ -224,32 +224,50 @@ leaves the 333 ms tick at 64 frames (§9) while still using only an eighth of RA
 
 ```python
 # --- once, at engine load: the graph is the authority on every cache dimension
-for name in ("inputs_past_k", "inputs_past_v", "inputs_cache_bias",
-             "inputs_rope_cos", "inputs_rope_sin", "new_k", "new_v"):
+for name in (
+    "inputs_past_k",
+    "inputs_past_v",
+    "inputs_cache_bias",
+    "inputs_rope_cos",
+    "inputs_rope_sin",
+    "new_k",
+    "new_v",
+):
     expected = tuple(engine.get_tensor_shape(name))
-    if tuple(buffers[name].shape) != expected:      # set_tensor_address does NOT check
+    if tuple(buffers[name].shape) != expected:  # set_tensor_address does NOT check
         raise ValueError(f"{name}: engine wants {expected}, got {buffers[name].shape}")
 layers, _, heads, cache_tokens, head_dim = engine.get_tensor_shape("inputs_past_k")
-tokens_per_frame = engine.get_tensor_shape("new_k")[3]      # 257
-cache_frames = cache_tokens // tokens_per_frame             # context - 1
+tokens_per_frame = engine.get_tensor_shape("new_k")[3]  # 257
+cache_frames = cache_tokens // tokens_per_frame  # context - 1
+
 
 # --- on engage / disengage / manual override, wherever the action plan is cleared
 def reset_cache():
-    cache_bias.fill_(-1e4)     # every slot invalid; K/V contents then do not matter
-    frame_index = 0            # RoPE counter; fp64 host-side, monotone per episode
+    cache_bias.fill_(-1e4)  # every slot invalid; K/V contents then do not matter
+    frame_index = 0  # RoPE counter; fp64 host-side, monotone per episode
+
 
 # --- per tick
 rope_cos, rope_sin = frame_rope_cos_sin(frame_index, head_dim=head_dim, base=1000.0)
-out = engine.run(image=frame, speed=..., waypoints=...,
-                 past_k=past_k, past_v=past_v, cache_bias=cache_bias,
-                 rope_cos=rope_cos, rope_sin=rope_sin)
+out = engine.run(
+    image=frame,
+    speed=...,
+    waypoints=...,
+    past_k=past_k,
+    past_v=past_v,
+    cache_bias=cache_bias,
+    rope_cos=rope_cos,
+    rope_sin=rope_sin,
+)
 
 # ring advance: write into ONE slot and move nothing else
-slot = slice((frame_index % cache_frames) * tokens_per_frame,
-             (frame_index % cache_frames + 1) * tokens_per_frame)
+slot = slice(
+    (frame_index % cache_frames) * tokens_per_frame,
+    (frame_index % cache_frames + 1) * tokens_per_frame,
+)
 past_k[..., slot, :] = out["new_k"]
 past_v[..., slot, :] = out["new_v"]
-cache_bias[..., slot] = 0.0     # after the first `cache_frames` ticks: all zeros
+cache_bias[..., slot] = 0.0  # after the first `cache_frames` ticks: all zeros
 frame_index += 1
 ```
 

--- a/docs/nero_arms_architecture.svg
+++ b/docs/nero_arms_architecture.svg
@@ -1,0 +1,240 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 1580" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#555"/>
+    </marker>
+    <marker id="arrd" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#0891b2"/>
+    </marker>
+  </defs>
+
+  <rect width="1180" height="1580" fill="#fcfcfd"/>
+  <text x="590" y="36" text-anchor="middle" font-size="23" font-weight="bold" fill="#1a1a2e">nero-arms — causal patch policy, bimanual SE(3) VQ-BeT head</text>
+  <text x="590" y="57" text-anchor="middle" font-size="13" fill="#666">62.9M params (40.7M trainable) · T = 6 frames @ 30 Hz · 481 tokens/frame · 2886-token sequence</text>
+
+  <!-- legend -->
+  <rect x="600" y="70" width="14" height="14" rx="3" fill="#dbeafe" stroke="#3b82f6"/>
+  <text x="620" y="82" font-size="13" fill="#333">frozen</text>
+  <rect x="686" y="70" width="14" height="14" rx="3" fill="#ffedd5" stroke="#f97316"/>
+  <text x="706" y="82" font-size="13" fill="#333">trained</text>
+  <rect x="778" y="70" width="14" height="14" rx="3" fill="#ecfeff" stroke="#0891b2" stroke-dasharray="4 2"/>
+  <text x="798" y="82" font-size="13" fill="#333">optional depth arm (off by default)</text>
+
+  <!-- ================= BAND 1 ================= -->
+  <text x="30" y="116" font-size="16" font-weight="bold" fill="#1a1a2e">1 · Per-frame packing  Z_t   (each of T = 6 history frames)</text>
+
+  <!-- observation cameras -->
+  <rect x="30" y="132" width="250" height="112" rx="6" fill="#fff" stroke="#cbd5e1"/>
+  <text x="42" y="152" font-size="13" font-weight="bold" fill="#1a1a2e">observation — 3 cameras</text>
+  <text x="42" y="172" font-size="12" fill="#444">image.base       (T,3,270,480) uint8</text>
+  <text x="42" y="190" font-size="12" fill="#444">image.side_left  (T,3,300,480) uint8</text>
+  <text x="42" y="208" font-size="12" fill="#444">image.side_right (T,3,300,480) uint8</text>
+  <text x="42" y="230" font-size="11" fill="#b45309">⚠ heights differ — genuinely different sensors</text>
+
+  <!-- goal -->
+  <rect x="30" y="256" width="250" height="100" rx="6" fill="#fff" stroke="#cbd5e1"/>
+  <text x="42" y="276" font-size="13" font-weight="bold" fill="#1a1a2e">goal — final frame, per camera</text>
+  <text x="42" y="296" font-size="12" fill="#444">goal.image.{cam}  (3,H,W) uint8</text>
+  <text x="42" y="314" font-size="12" fill="#444">goal_valid        (n_cam,) bool</text>
+  <text x="42" y="336" font-size="11" fill="#666">false ⇒ frames may be omitted → no_goal</text>
+
+  <!-- letterbox -->
+  <rect x="316" y="150" width="128" height="52" rx="6" fill="#ffedd5" stroke="#f97316"/>
+  <text x="380" y="172" text-anchor="middle" font-size="12" font-weight="bold" fill="#7c2d12">LetterboxResize</text>
+  <text x="380" y="190" text-anchor="middle" font-size="11" fill="#7c2d12">→ 140 × 224</text>
+
+  <!-- dino -->
+  <rect x="316" y="222" width="128" height="66" rx="6" fill="#dbeafe" stroke="#3b82f6"/>
+  <text x="380" y="244" text-anchor="middle" font-size="12" font-weight="bold" fill="#1e3a8a">DINOv2 ViT-S</text>
+  <text x="380" y="261" text-anchor="middle" font-size="11" fill="#1e3a8a">frozen · 22M</text>
+  <text x="380" y="277" text-anchor="middle" font-size="11" fill="#1e3a8a">10×16 = 160 patches</text>
+
+  <line x1="280" y1="188" x2="312" y2="176" stroke="#555" marker-end="url(#arr)"/>
+  <line x1="280" y1="300" x2="312" y2="196" stroke="#555" marker-end="url(#arr)"/>
+  <line x1="380" y1="202" x2="380" y2="218" stroke="#555" marker-end="url(#arr)"/>
+
+  <!-- same-index concat -->
+  <rect x="480" y="196" width="196" height="92" rx="6" fill="#ffedd5" stroke="#f97316"/>
+  <text x="578" y="217" text-anchor="middle" font-size="12" font-weight="bold" fill="#7c2d12">same-index goal concat</text>
+  <text x="578" y="236" text-anchor="middle" font-size="11" fill="#7c2d12">obs patch (c,p) ↔ goal patch (c,p)</text>
+  <text x="578" y="253" text-anchor="middle" font-size="11" fill="#7c2d12">+ camera_cond (13) per patch</text>
+  <text x="578" y="272" text-anchor="middle" font-size="11" fill="#666">dropout 0.15 → learned no_goal</text>
+  <line x1="444" y1="252" x2="476" y2="244" stroke="#555" marker-end="url(#arr)"/>
+
+  <!-- camera cond -->
+  <rect x="480" y="132" width="196" height="52" rx="6" fill="#fff" stroke="#cbd5e1"/>
+  <text x="578" y="152" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a1a2e">camera_cond (n_cam, 13)</text>
+  <text x="578" y="170" text-anchor="middle" font-size="11" fill="#444">norm. fx,fy,cx,cy + t(3) + R as 6D</text>
+  <line x1="578" y1="184" x2="578" y2="192" stroke="#555" marker-end="url(#arr)"/>
+
+  <!-- state -->
+  <rect x="30" y="382" width="250" height="118" rx="6" fill="#fff" stroke="#cbd5e1"/>
+  <text x="42" y="402" font-size="13" font-weight="bold" fill="#1a1a2e">state</text>
+  <text x="42" y="422" font-size="12" fill="#444">state.pose  (T, 2, 46)  quaternion</text>
+  <text x="42" y="440" font-size="12" fill="#444">side_valid  (2,) bool</text>
+  <text x="42" y="462" font-size="11" fill="#b45309">46 → 60 via state_quat_to_9d</text>
+  <text x="42" y="479" font-size="11" fill="#666">(3 + 6D rotation; quats are discontinuous</text>
+  <text x="42" y="493" font-size="11" fill="#666">as a regression target)</text>
+
+  <rect x="316" y="400" width="196" height="80" rx="6" fill="#ffedd5" stroke="#f97316"/>
+  <text x="414" y="421" text-anchor="middle" font-size="12" font-weight="bold" fill="#7c2d12">state embedding</text>
+  <text x="414" y="440" text-anchor="middle" font-size="11" fill="#7c2d12">state × side_valid, mask appended</text>
+  <text x="414" y="457" text-anchor="middle" font-size="11" fill="#7c2d12">→ 1 state token</text>
+  <text x="414" y="473" text-anchor="middle" font-size="10" fill="#666">"zero because absent" ≠ "zero at origin"</text>
+  <line x1="280" y1="440" x2="312" y2="440" stroke="#555" marker-end="url(#arr)"/>
+
+  <!-- depth arm -->
+  <rect x="700" y="382" width="450" height="118" rx="6" fill="#ecfeff" stroke="#0891b2" stroke-dasharray="5 3"/>
+  <text x="716" y="402" font-size="13" font-weight="bold" fill="#0e7490">optional depth arm  (use_depth, off by default)</text>
+  <text x="716" y="422" font-size="12" fill="#155e75">disparity.base (uint8) + disparity_valid → 2 channels</text>
+  <text x="716" y="440" font-size="12" fill="#155e75">trainable patch embed  Linear(525 → 512)   ~269k params</text>
+  <text x="716" y="458" font-size="12" fill="#155e75">80×128 @ patch 16 → 5×8 = 40 tokens/frame</text>
+  <text x="716" y="478" font-size="11" fill="#0e7490">NOT the frozen DINO: disparity is outside its pretraining domain,</text>
+  <text x="716" y="492" font-size="11" fill="#0e7490">and a 4th ViT pass would cost 22M frozen params for a worse feature</text>
+
+  <!-- frame block -->
+  <rect x="316" y="520" width="600" height="74" rx="6" fill="#ffedd5" stroke="#f97316"/>
+  <text x="616" y="542" text-anchor="middle" font-size="13" font-weight="bold" fill="#7c2d12">frame block Z_t  =  [ state token │ (depth tokens) │ 3 × 160 patch tokens ]</text>
+  <text x="616" y="562" text-anchor="middle" font-size="12" fill="#7c2d12">481 tokens/frame  (521 with depth)  ·  patch_projection → d = 512</text>
+  <text x="616" y="581" text-anchor="middle" font-size="11" fill="#666">state first, so each frame block ENDS on a patch token — that is the readout position</text>
+  <line x1="578" y1="288" x2="578" y2="516" stroke="#555" marker-end="url(#arr)"/>
+  <line x1="414" y1="480" x2="414" y2="516" stroke="#555" marker-end="url(#arr)"/>
+  <line x1="880" y1="500" x2="860" y2="516" stroke="#0891b2" stroke-dasharray="5 3" marker-end="url(#arrd)"/>
+
+  <!-- ================= BAND 2 ================= -->
+  <text x="30" y="648" font-size="16" font-weight="bold" fill="#1a1a2e">2 · Trunk — CausalFrameTransformer (reused unchanged from the decoder-only branch)</text>
+
+  <rect x="30" y="666" width="1120" height="150" rx="6" fill="#ffedd5" stroke="#f97316"/>
+  <text x="590" y="690" text-anchor="middle" font-size="14" font-weight="bold" fill="#7c2d12">flatten to T × 481 = 2886 tokens   (3126 with depth)   ·   learned 1D positional embedding</text>
+
+  <!-- attention mask sketch -->
+  <text x="60" y="716" font-size="12" font-weight="bold" fill="#7c2d12">block-causal mask</text>
+  <g>
+    <rect x="60" y="726" width="26" height="26" fill="#f97316" opacity="0.85"/>
+    <rect x="88" y="726" width="26" height="26" fill="#fff" stroke="#f6b98a"/>
+    <rect x="116" y="726" width="26" height="26" fill="#fff" stroke="#f6b98a"/>
+    <rect x="60" y="754" width="26" height="26" fill="#f97316" opacity="0.85"/>
+    <rect x="88" y="754" width="26" height="26" fill="#f97316" opacity="0.85"/>
+    <rect x="116" y="754" width="26" height="26" fill="#fff" stroke="#f6b98a"/>
+    <rect x="60" y="782" width="26" height="26" fill="#f97316" opacity="0.85"/>
+    <rect x="88" y="782" width="26" height="26" fill="#f97316" opacity="0.85"/>
+    <rect x="116" y="782" width="26" height="26" fill="#f97316" opacity="0.85"/>
+  </g>
+  <text x="152" y="742" font-size="12" fill="#7c2d12">bidirectional WITHIN a frame,</text>
+  <text x="152" y="760" font-size="12" fill="#7c2d12">causal ACROSS frames</text>
+  <text x="152" y="781" font-size="11" fill="#666">so a KV-cached one-frame decode step</text>
+  <text x="152" y="796" font-size="11" fill="#666">runs the identical pipeline at serving</text>
+
+  <rect x="430" y="720" width="300" height="76" rx="6" fill="#fff" stroke="#f6b98a"/>
+  <text x="580" y="742" text-anchor="middle" font-size="12" font-weight="bold" fill="#7c2d12">pre-LN GPT blocks</text>
+  <text x="580" y="761" text-anchor="middle" font-size="11" fill="#7c2d12">d = 512 · head_dim 64</text>
+  <text x="580" y="780" text-anchor="middle" font-size="10" fill="#666">head_dim % 8 = 0 — otherwise fused SDPA falls back and OOMs</text>
+
+  <rect x="770" y="720" width="330" height="76" rx="6" fill="#fff" stroke="#f6b98a"/>
+  <text x="935" y="742" text-anchor="middle" font-size="12" font-weight="bold" fill="#7c2d12">readout</text>
+  <text x="935" y="761" text-anchor="middle" font-size="11" fill="#7c2d12">last patch token of each frame → (b, T, d)</text>
+  <text x="935" y="780" text-anchor="middle" font-size="10" fill="#666">supervised at EVERY frame; inference decodes the newest</text>
+
+  <line x1="616" y1="594" x2="616" y2="662" stroke="#555" marker-end="url(#arr)"/>
+
+  <!-- ================= BAND 3 ================= -->
+  <text x="30" y="856" font-size="16" font-weight="bold" fill="#1a1a2e">3 · VQ-BeT chunk head  (per side, weight-shared + learned side embedding)</text>
+
+  <rect x="30" y="874" width="250" height="96" rx="6" fill="#ffedd5" stroke="#f97316"/>
+  <text x="155" y="896" text-anchor="middle" font-size="12" font-weight="bold" fill="#7c2d12">code head</text>
+  <text x="155" y="915" text-anchor="middle" font-size="11" fill="#7c2d12">4 quantizers × 16 codes</text>
+  <text x="155" y="933" text-anchor="middle" font-size="11" fill="#7c2d12">focal loss vs target codes</text>
+  <text x="155" y="955" text-anchor="middle" font-size="10" fill="#666">targets from the frozen tokenizer</text>
+
+  <rect x="316" y="874" width="250" height="96" rx="6" fill="#ffedd5" stroke="#f97316"/>
+  <text x="441" y="896" text-anchor="middle" font-size="12" font-weight="bold" fill="#7c2d12">offset head</text>
+  <text x="441" y="915" text-anchor="middle" font-size="11" fill="#7c2d12">gathered at the codes</text>
+  <text x="441" y="933" text-anchor="middle" font-size="11" fill="#7c2d12">teacher_force_offset = true</text>
+  <text x="441" y="955" text-anchor="middle" font-size="10" fill="#666">offset trained on TARGET codes, not sampled</text>
+
+  <rect x="602" y="874" width="250" height="96" rx="6" fill="#dbeafe" stroke="#3b82f6"/>
+  <text x="727" y="896" text-anchor="middle" font-size="12" font-weight="bold" fill="#1e3a8a">RVQ pose tokenizer</text>
+  <text x="727" y="915" text-anchor="middle" font-size="11" fill="#1e3a8a">frozen · 6-step × 60-dim chunk</text>
+  <text x="727" y="933" text-anchor="middle" font-size="11" fill="#1e3a8a">invert(codes) + offset</text>
+  <text x="727" y="955" text-anchor="middle" font-size="10" fill="#1e3a8a">trained separately on 6D-rotation poses</text>
+
+  <rect x="888" y="874" width="262" height="96" rx="6" fill="#fff" stroke="#cbd5e1"/>
+  <text x="1019" y="896" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a1a2e">action chunk</text>
+  <text x="1019" y="916" text-anchor="middle" font-size="12" fill="#444">(b, 2, 6, 60)</text>
+  <text x="1019" y="935" text-anchor="middle" font-size="11" fill="#444">side × horizon × 9D pose</text>
+  <text x="1019" y="956" text-anchor="middle" font-size="10" fill="#666">200 ms at 30 Hz · standardised</text>
+
+  <line x1="280" y1="922" x2="312" y2="922" stroke="#555" marker-end="url(#arr)"/>
+  <line x1="566" y1="922" x2="598" y2="922" stroke="#555" marker-end="url(#arr)"/>
+  <line x1="852" y1="922" x2="884" y2="922" stroke="#555" marker-end="url(#arr)"/>
+  <line x1="935" y1="796" x2="935" y2="840" stroke="#555"/>
+  <line x1="935" y1="840" x2="155" y2="840" stroke="#555"/>
+  <line x1="155" y1="840" x2="155" y2="870" stroke="#555" marker-end="url(#arr)"/>
+
+  <!-- ================= NOTES ================= -->
+  <text x="30" y="1012" font-size="16" font-weight="bold" fill="#1a1a2e">Decisions worth knowing</text>
+
+  <rect x="30" y="1030" width="358" height="150" rx="6" fill="#fff" stroke="#cbd5e1"/>
+  <text x="46" y="1052" font-size="13" font-weight="bold" fill="#7c2d12">argmax, not sampling</text>
+  <text x="46" y="1073" font-size="11.5" fill="#444">sample_codes = false by default, so inference</text>
+  <text x="46" y="1089" font-size="11.5" fill="#444">is deterministic and the reported recon metrics</text>
+  <text x="46" y="1105" font-size="11.5" fill="#444">measure what serving actually produces.</text>
+  <text x="46" y="1127" font-size="11.5" fill="#444">No loss depends on it while the offset head is</text>
+  <text x="46" y="1143" font-size="11.5" fill="#444">teacher-forced — verified, all five losses</text>
+  <text x="46" y="1159" font-size="11.5" fill="#444">bit-identical under both settings.</text>
+
+  <rect x="404" y="1030" width="358" height="150" rx="6" fill="#fff" stroke="#cbd5e1"/>
+  <text x="420" y="1052" font-size="13" font-weight="bold" fill="#7c2d12">every stream carries a validity mask</text>
+  <text x="420" y="1073" font-size="11.5" fill="#444">side_valid  (2,)      per side — the dummy is</text>
+  <text x="420" y="1089" font-size="11.5" fill="#444">                      right-hand only</text>
+  <text x="420" y="1105" font-size="11.5" fill="#444">goal_valid  (n_cam,)  per camera → no_goal</text>
+  <text x="420" y="1121" font-size="11.5" fill="#444">depth_valid (b,)      per sample → no_depth</text>
+  <text x="420" y="1143" font-size="11.5" fill="#444">Absence is always a LEARNED embedding, never</text>
+  <text x="420" y="1159" font-size="11.5" fill="#444">zeros — zeros assert a value, absence does not.</text>
+
+  <rect x="778" y="1030" width="372" height="150" rx="6" fill="#fff" stroke="#cbd5e1"/>
+  <text x="794" y="1052" font-size="13" font-weight="bold" fill="#7c2d12">the action space is a config seam</text>
+  <text x="794" y="1073" font-size="11.5" fill="#444">120 dims here is the GLOVE parameterisation —</text>
+  <text x="794" y="1089" font-size="11.5" fill="#444">a stand-in. Iteration-1 teleop is robot-native, so</text>
+  <text x="794" y="1105" font-size="11.5" fill="#444">the real action is NERO joint commands:</text>
+  <text x="794" y="1121" font-size="11.5" fill="#444">7 DOF/arm + 6 actuated hand DOF ≈ 26 bimanual.</text>
+  <text x="794" y="1143" font-size="11.5" fill="#444">Verified by a real forward+backward at</text>
+  <text x="794" y="1159" font-size="11.5" fill="#444">action_features = 12 — not asserted.</text>
+
+  <!-- measured table -->
+  <text x="30" y="1224" font-size="16" font-weight="bold" fill="#1a1a2e">Measured — depth arm cost (RTX 5090, batch 8)</text>
+  <rect x="30" y="1242" width="560" height="132" rx="6" fill="#fff" stroke="#cbd5e1"/>
+  <text x="46" y="1264" font-size="12" font-weight="bold" fill="#1a1a2e">metric</text>
+  <text x="250" y="1264" font-size="12" font-weight="bold" fill="#1a1a2e" text-anchor="end">depth off</text>
+  <text x="400" y="1264" font-size="12" font-weight="bold" fill="#1a1a2e" text-anchor="end">depth on</text>
+  <text x="560" y="1264" font-size="12" font-weight="bold" fill="#1a1a2e" text-anchor="end">delta</text>
+  <line x1="46" y1="1272" x2="574" y2="1272" stroke="#e2e8f0"/>
+  <text x="46" y="1292" font-size="12" fill="#444">tokens / frame</text>
+  <text x="250" y="1292" font-size="12" fill="#444" text-anchor="end">481</text>
+  <text x="400" y="1292" font-size="12" fill="#444" text-anchor="end">521</text>
+  <text x="560" y="1292" font-size="12" fill="#7c2d12" text-anchor="end">+8.3%</text>
+  <text x="46" y="1312" font-size="12" fill="#444">sequence (T = 6)</text>
+  <text x="250" y="1312" font-size="12" fill="#444" text-anchor="end">2886</text>
+  <text x="400" y="1312" font-size="12" fill="#444" text-anchor="end">3126</text>
+  <text x="560" y="1312" font-size="12" fill="#7c2d12" text-anchor="end">+8.3%</text>
+  <text x="46" y="1332" font-size="12" fill="#444">peak memory</text>
+  <text x="250" y="1332" font-size="12" fill="#444" text-anchor="end">1.743 GiB</text>
+  <text x="400" y="1332" font-size="12" fill="#444" text-anchor="end">1.859 GiB</text>
+  <text x="560" y="1332" font-size="12" fill="#7c2d12" text-anchor="end">+6.7%</text>
+  <text x="46" y="1352" font-size="12" fill="#444">parameters</text>
+  <text x="250" y="1352" font-size="12" fill="#444" text-anchor="end">62,929,320</text>
+  <text x="400" y="1352" font-size="12" fill="#444" text-anchor="end">63,219,624</text>
+  <text x="560" y="1352" font-size="12" fill="#7c2d12" text-anchor="end">+290,304</text>
+  <text x="46" y="1368" font-size="10.5" fill="#666">all added parameters are TRAINABLE — zero frozen, vs ~22M for a fourth ViT pass</text>
+  <rect x="606" y="1242" width="544" height="132" rx="6" fill="#fff" stroke="#cbd5e1"/>
+  <text x="622" y="1264" font-size="13" font-weight="bold" fill="#b45309">⚠ what this diagram does NOT claim</text>
+  <text x="622" y="1288" font-size="11.5" fill="#444">Depth-off is byte-identical to the pre-depth model (verified two</text>
+  <text x="622" y="1304" font-size="11.5" fill="#444">independent ways), and the shapes above are measured. But no</text>
+  <text x="622" y="1320" font-size="11.5" fill="#444">real depth recording exists yet, so the depth arm is unvalidated</text>
+  <text x="622" y="1336" font-size="11.5" fill="#444">against a real disparity stream, and the smoke curves measure</text>
+  <text x="622" y="1352" font-size="11.5" fill="#444">memory and throughput only — they ran without a tokenizer</text>
+  <text x="622" y="1368" font-size="11.5" fill="#444">checkpoint, so every code loss is exactly 0.000. Not a learning claim.</text>
+
+  <text x="30" y="1420" font-size="12" fill="#666">Data contract: nero-arms/DATA_CONTRACT.md  ·  design record: docs/nero_arms_causal_patch_policy.md  ·  serving: docs/nero_serving_handover.md</text>
+  <text x="30" y="1440" font-size="12" fill="#666">Ingestion: rbyte#109 (+ depth rbyte#110)  ·  recording: nutron-cli#3 (teleop signals) and nutron-cli#4 (depth)</text>
+</svg>

--- a/docs/nero_arms_architecture.svg
+++ b/docs/nero_arms_architecture.svg
@@ -102,10 +102,11 @@
   <line x1="880" y1="500" x2="860" y2="516" stroke="#0891b2" stroke-dasharray="5 3" marker-end="url(#arrd)"/>
 
   <!-- ================= BAND 2 ================= -->
-  <text x="30" y="648" font-size="16" font-weight="bold" fill="#1a1a2e">2 · Trunk — CausalFrameTransformer (reused unchanged from the decoder-only branch)</text>
+  <text x="30" y="648" font-size="16" font-weight="bold" fill="#1a1a2e">2 · Trunk — CausalFrameTransformer, reused unchanged (rmind #269 stack, NOT the #265 flat-1D trunk)</text>
 
-  <rect x="30" y="666" width="1120" height="150" rx="6" fill="#ffedd5" stroke="#f97316"/>
-  <text x="590" y="690" text-anchor="middle" font-size="14" font-weight="bold" fill="#7c2d12">flatten to T × 481 = 2886 tokens   (3126 with depth)   ·   learned 1D positional embedding</text>
+  <rect x="30" y="666" width="1120" height="172" rx="6" fill="#ffedd5" stroke="#f97316"/>
+  <text x="590" y="688" text-anchor="middle" font-size="14" font-weight="bold" fill="#7c2d12">flatten to T × 481 = 2886 tokens   (3126 with depth)   ·   FACTORIZED position — not a flat 1D embedding</text>
+  <text x="590" y="708" text-anchor="middle" font-size="11.5" fill="#7c2d12">intra-frame: learned 481-slot embedding tiled onto every frame   ·   inter-frame: RoPE at FRAME granularity</text>
 
   <!-- attention mask sketch -->
   <text x="60" y="716" font-size="12" font-weight="bold" fill="#7c2d12">block-causal mask</text>
@@ -122,8 +123,8 @@
   </g>
   <text x="152" y="742" font-size="12" fill="#7c2d12">bidirectional WITHIN a frame,</text>
   <text x="152" y="760" font-size="12" fill="#7c2d12">causal ACROSS frames</text>
-  <text x="152" y="781" font-size="11" fill="#666">so a KV-cached one-frame decode step</text>
-  <text x="152" y="796" font-size="11" fill="#666">runs the identical pipeline at serving</text>
+  <text x="152" y="781" font-size="10.5" fill="#666">RoPE uses the EPISODE-ABSOLUTE frame index,</text>
+  <text x="152" y="795" font-size="10.5" fill="#666">so a slid window leaves cached keys valid</text>
 
   <rect x="430" y="720" width="300" height="76" rx="6" fill="#fff" stroke="#f6b98a"/>
   <text x="580" y="742" text-anchor="middle" font-size="12" font-weight="bold" fill="#7c2d12">pre-LN GPT blocks</text>
@@ -135,41 +136,42 @@
   <text x="935" y="761" text-anchor="middle" font-size="11" fill="#7c2d12">last patch token of each frame → (b, T, d)</text>
   <text x="935" y="780" text-anchor="middle" font-size="10" fill="#666">supervised at EVERY frame; inference decodes the newest</text>
 
+  <text x="590" y="826" text-anchor="middle" font-size="11" fill="#b45309">#265's flat 1D embedding is window-absolute — slot 0 means "oldest frame in the window", so sliding it stales every cached key</text>
   <line x1="616" y1="594" x2="616" y2="662" stroke="#555" marker-end="url(#arr)"/>
 
   <!-- ================= BAND 3 ================= -->
-  <text x="30" y="856" font-size="16" font-weight="bold" fill="#1a1a2e">3 · VQ-BeT chunk head  (per side, weight-shared + learned side embedding)</text>
+  <text x="30" y="872" font-size="16" font-weight="bold" fill="#1a1a2e">3 · VQ-BeT chunk head  (per side, weight-shared + learned side embedding)</text>
 
-  <rect x="30" y="874" width="250" height="96" rx="6" fill="#ffedd5" stroke="#f97316"/>
-  <text x="155" y="896" text-anchor="middle" font-size="12" font-weight="bold" fill="#7c2d12">code head</text>
-  <text x="155" y="915" text-anchor="middle" font-size="11" fill="#7c2d12">4 quantizers × 16 codes</text>
-  <text x="155" y="933" text-anchor="middle" font-size="11" fill="#7c2d12">focal loss vs target codes</text>
-  <text x="155" y="955" text-anchor="middle" font-size="10" fill="#666">targets from the frozen tokenizer</text>
+  <rect x="30" y="890" width="250" height="96" rx="6" fill="#ffedd5" stroke="#f97316"/>
+  <text x="155" y="912" text-anchor="middle" font-size="12" font-weight="bold" fill="#7c2d12">code head</text>
+  <text x="155" y="931" text-anchor="middle" font-size="11" fill="#7c2d12">4 quantizers × 16 codes</text>
+  <text x="155" y="949" text-anchor="middle" font-size="11" fill="#7c2d12">focal loss vs target codes</text>
+  <text x="155" y="971" text-anchor="middle" font-size="10" fill="#666">targets from the frozen tokenizer</text>
 
-  <rect x="316" y="874" width="250" height="96" rx="6" fill="#ffedd5" stroke="#f97316"/>
-  <text x="441" y="896" text-anchor="middle" font-size="12" font-weight="bold" fill="#7c2d12">offset head</text>
-  <text x="441" y="915" text-anchor="middle" font-size="11" fill="#7c2d12">gathered at the codes</text>
-  <text x="441" y="933" text-anchor="middle" font-size="11" fill="#7c2d12">teacher_force_offset = true</text>
-  <text x="441" y="955" text-anchor="middle" font-size="10" fill="#666">offset trained on TARGET codes, not sampled</text>
+  <rect x="316" y="890" width="250" height="96" rx="6" fill="#ffedd5" stroke="#f97316"/>
+  <text x="441" y="912" text-anchor="middle" font-size="12" font-weight="bold" fill="#7c2d12">offset head</text>
+  <text x="441" y="931" text-anchor="middle" font-size="11" fill="#7c2d12">gathered at the codes</text>
+  <text x="441" y="949" text-anchor="middle" font-size="11" fill="#7c2d12">teacher_force_offset = true</text>
+  <text x="441" y="971" text-anchor="middle" font-size="10" fill="#666">offset trained on TARGET codes, not sampled</text>
 
-  <rect x="602" y="874" width="250" height="96" rx="6" fill="#dbeafe" stroke="#3b82f6"/>
-  <text x="727" y="896" text-anchor="middle" font-size="12" font-weight="bold" fill="#1e3a8a">RVQ pose tokenizer</text>
-  <text x="727" y="915" text-anchor="middle" font-size="11" fill="#1e3a8a">frozen · 6-step × 60-dim chunk</text>
-  <text x="727" y="933" text-anchor="middle" font-size="11" fill="#1e3a8a">invert(codes) + offset</text>
-  <text x="727" y="955" text-anchor="middle" font-size="10" fill="#1e3a8a">trained separately on 6D-rotation poses</text>
+  <rect x="602" y="890" width="250" height="96" rx="6" fill="#dbeafe" stroke="#3b82f6"/>
+  <text x="727" y="912" text-anchor="middle" font-size="12" font-weight="bold" fill="#1e3a8a">RVQ pose tokenizer</text>
+  <text x="727" y="931" text-anchor="middle" font-size="11" fill="#1e3a8a">frozen · 6-step × 60-dim chunk</text>
+  <text x="727" y="949" text-anchor="middle" font-size="11" fill="#1e3a8a">invert(codes) + offset</text>
+  <text x="727" y="971" text-anchor="middle" font-size="10" fill="#1e3a8a">trained separately on 6D-rotation poses</text>
 
-  <rect x="888" y="874" width="262" height="96" rx="6" fill="#fff" stroke="#cbd5e1"/>
-  <text x="1019" y="896" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a1a2e">action chunk</text>
-  <text x="1019" y="916" text-anchor="middle" font-size="12" fill="#444">(b, 2, 6, 60)</text>
-  <text x="1019" y="935" text-anchor="middle" font-size="11" fill="#444">side × horizon × 9D pose</text>
-  <text x="1019" y="956" text-anchor="middle" font-size="10" fill="#666">200 ms at 30 Hz · standardised</text>
+  <rect x="888" y="890" width="262" height="96" rx="6" fill="#fff" stroke="#cbd5e1"/>
+  <text x="1019" y="912" text-anchor="middle" font-size="12" font-weight="bold" fill="#1a1a2e">action chunk</text>
+  <text x="1019" y="932" text-anchor="middle" font-size="12" fill="#444">(b, 2, 6, 60)</text>
+  <text x="1019" y="951" text-anchor="middle" font-size="11" fill="#444">side × horizon × 9D pose</text>
+  <text x="1019" y="972" text-anchor="middle" font-size="10" fill="#666">200 ms at 30 Hz · standardised</text>
 
-  <line x1="280" y1="922" x2="312" y2="922" stroke="#555" marker-end="url(#arr)"/>
-  <line x1="566" y1="922" x2="598" y2="922" stroke="#555" marker-end="url(#arr)"/>
-  <line x1="852" y1="922" x2="884" y2="922" stroke="#555" marker-end="url(#arr)"/>
-  <line x1="935" y1="796" x2="935" y2="840" stroke="#555"/>
-  <line x1="935" y1="840" x2="155" y2="840" stroke="#555"/>
-  <line x1="155" y1="840" x2="155" y2="870" stroke="#555" marker-end="url(#arr)"/>
+  <line x1="280" y1="938" x2="312" y2="938" stroke="#555" marker-end="url(#arr)"/>
+  <line x1="566" y1="938" x2="598" y2="938" stroke="#555" marker-end="url(#arr)"/>
+  <line x1="852" y1="938" x2="884" y2="938" stroke="#555" marker-end="url(#arr)"/>
+  <line x1="935" y1="838" x2="935" y2="856" stroke="#555"/>
+  <line x1="935" y1="856" x2="155" y2="856" stroke="#555"/>
+  <line x1="155" y1="856" x2="155" y2="886" stroke="#555" marker-end="url(#arr)"/>
 
   <!-- ================= NOTES ================= -->
   <text x="30" y="1012" font-size="16" font-weight="bold" fill="#1a1a2e">Decisions worth knowing</text>

--- a/docs/nero_arms_causal_patch_policy.md
+++ b/docs/nero_arms_causal_patch_policy.md
@@ -46,6 +46,14 @@ the model's input boundary:
 | state / action | `(T, 2, 60)` | **`(T, 2, 46)`** — the §5.2 quaternion storage form | `state_quat_to_9d` |
 | goal image | one `(3, 3, H, W)` | **three keys** `goal.image.{camera}`, each on its own grid | per-camera encode |
 
+The `[t+1 .. t+H]` shift of §6.2 is **verified identical on both sides**
+(`future = stack(state[i+1 : i+1+H])` in rbyte). Note the windowing convention
+differs from every driving config: rbyte materialises each row's future chunk at
+build time and drops rows without a full chunk, so `clip_length == episode_length
+== 6` rather than `episode_length + horizon - 1`. An off-by-one here would train
+the policy to predict the *current* state and would show up as a suspiciously
+good loss curve, not as an error.
+
 `action.commanded` is currently a byte-identical duplicate of
 `action.future_state` (~199 MB of a ~470 MB TensorDict). The policy reads exactly
 one path, chosen by config, so the duplicate is never consumed.

--- a/docs/nero_arms_causal_patch_policy.md
+++ b/docs/nero_arms_causal_patch_policy.md
@@ -1,0 +1,213 @@
+# nero-arms causal patch policy + SE(3) action tokenizer
+
+Design record for the nero-arms bimanual manipulation arm of the patch policy.
+Coded against `nero-arms/DATA_CONTRACT.md` v0.1 (+ §7.2, §11). Where this
+document and the contract disagree, the contract wins and the disagreement is
+listed in "Contract issues" below.
+
+Built on `feat/patch-policy-decoder-only`. The decoder-only trunk
+(`rmind/components/transformer/causal_frame.py`: frame-RoPE + tiled intra-frame
+embedding, bidirectional intra-frame / causal inter-frame, KV-cacheable) is
+**reused unchanged**; see `docs/decoder_only_kv_cache.md`. Everything above and
+below it is new.
+
+## Files
+
+| file                                                         | what                                                                                                                                                                                                                               |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/rmind/data/nero.py`                                     | contract §5 shared boundary: `pose_quat_to_9d` / `pose_9d_to_quat`, canonicalisation, 6D rotation, the 60-dim channel **layout**, `PoseStandardizer` (versioned artifact), physical-unit error split, letterbox intrinsics rewrite |
+| `src/rmind/components/image.py`                              | `LetterboxResize` (contract §7.2)                                                                                                                                                                                                  |
+| `src/rmind/models/nero_pose_tokenizer.py`                    | `NeroPoseTokenizer` — VQ-BeT residual-VQ over one side's action chunk                                                                                                                                                              |
+| `src/rmind/models/nero_patch_policy.py`                      | `NeroPatchPolicy`                                                                                                                                                                                                                  |
+| `src/rmind/datamodules/nero_random.py`                       | structured synthetic batches at the contract §8 shapes                                                                                                                                                                             |
+| `src/rmind/scripts/nero_smoke.py`                            | budget / tokenizer / policy smoke harness                                                                                                                                                                                          |
+| `config/model/yaak/nero_patch_policy/raw.yaml`               | policy model config                                                                                                                                                                                                                |
+| `config/model/yaak/nero_pose_tokenizer/raw.yaml`             | tokenizer model config                                                                                                                                                                                                             |
+| `config/experiment/yaak/nero_arms/{causal,tokenizer}.yaml`   | experiments                                                                                                                                                                                                                        |
+| `config/datamodule/yaak/nero_random.yaml`                    | synthetic datamodule                                                                                                                                                                                                               |
+| `tests/test_nero_pose.py`, `tests/test_nero_patch_policy.py` | tests                                                                                                                                                                                                                              |
+
+## Token layout and sequence length
+
+```
+frame block = [ state token (1) ][ base (256) ][ side_left (256) ][ side_right (256) ]
+tokens_per_frame = 3 * 256 + 1 = 769
+flattened        = episode_length * 769 = 6 * 769 = 4614
+```
+
+For comparison on the same trunk: the 6-frame driving arm is **1542**, the
+16-frame causal driving arm is **4112**. So this sits just above the largest arm
+already profiled, and the `episode_length = 6` choice is what keeps it there —
+`episode_length = 16` would be 12304 tokens (≈9× the attention cost of 4614).
+
+`head_dim = 512 / 8 = 64`: divisible by 8 (fused SDPA — at head_dim 20 PR #265
+fell back to a math kernel that materialises the full `(B, H, L, L)` score
+matrix and OOMed) and even (required by the trunk's frame-RoPE). The
+`nero_smoke --stage budget` pre-flight asserts both and probes the SDPA backend
+empirically rather than reasoning about it.
+
+The state token goes **first** so each frame block ends on a patch token, which
+is the readout position — unchanged from PR #265, where the speed token played
+the same role.
+
+## Design decisions
+
+### Camera conditioning → per-patch concatenation
+
+Each camera's 13-dim vector (§7.1) is concatenated to **that camera's** patch
+tokens before `patch_projection`. Alternatives considered: 3 extra tokens per
+frame, or FiLM.
+
+1. **Zero sequence cost.** At 769 tokens/frame attention is the binding
+   constraint.
+1. **It binds the geometry to the tokens it describes.** A `side_left` patch
+   carries `side_left`'s extrinsics. Extra tokens or FiLM would deliver all three
+   cameras' geometry to all three cameras' patches and make the trunk learn the
+   routing.
+1. **It doubles as camera identity.** The tiled intra-frame embedding gives each
+   slot an index, but that index is setup-specific; the conditioning vector is
+   what generalises across camera-setup changes, which is the stated point of
+   §7.1.
+
+Tested by `test_per_camera_conditioning_is_bound_to_that_camera` — swapping two
+cameras' vectors must change the output, which a shared-broadcast implementation
+would not do.
+
+### Goal conditioning → same-index concatenation of goal patch features
+
+The goal image is the episode's final frame **from the same camera**, so goal
+patch `(c, p)` and observation patch `(c, p)` are the same ray through the same
+lens. Index-aligned concatenation preserves that correspondence — which is
+exactly the "where did the object end up" signal. Mean-pooling the goal (the
+obvious cheap alternative) discards it, for identical cost. This is the natural
+generalisation of the paper's `T × P × (D + G)` scheme with `G = D`, the goal
+being constant over `t` (the driving arm's `g_t` varied per frame only because
+waypoints are ego-frame).
+
+**Goal dropout** (`goal_dropout = 0.15`, per sample per camera) replaces the goal
+features with a **learned** `no_goal` embedding, not zeros, so "no goal supplied"
+is distinguishable from "goal that happens to encode near zero".
+
+Goal xyz (§9 alternative) is emitted by the datamodule and left unconsumed; the
+second RVQ for it is scaffolded (`NeroGoalXYZTokenizer`) but not trained — it is
+only needed if the goal is to be *predicted* rather than conditioned on.
+
+### Image pipeline → letterbox, not resize (§7.2)
+
+`base` is 1920×1080 (16:9), `side_*` are 1280×800 (16:10). A plain `Resize` to a
+square scales x and y by different factors, which (a) scales `fx` and `fy`
+independently so the resolution-normalised intrinsics in `camera_cond` stop
+describing the pixels the policy sees, and (b) makes the same object a different
+shape in `base` than in the side views, which a shared frozen ViT cannot undo.
+`LetterboxResize` keeps the scale isotropic; `letterbox_camera_cond` rewrites the
+4 intrinsic entries to match (extrinsics are untouched — letterboxing does not
+move the camera).
+
+Consequence to watch: all three cameras land on the same 16×16 patch grid, so
+`base`'s wider field of view gets **coarser real-world coverage per patch** than
+the side cameras. If the overhead view underperforms, this is the first thing to
+look at.
+
+### Bimanual `side_valid` (§6.1)
+
+Consumed in two places, both falsifiable:
+
+- the state token is built from `state * side_valid` with the 2-dim mask
+  appended, so perturbing an invalid side's state cannot change any output
+  (`test_invalid_side_state_cannot_influence_the_output` asserts **bit**
+  identity, plus a control that the *valid* side does matter);
+- the action loss **selects** valid `(batch, frame, side)` rows. Normalisation is
+  therefore `sum / count`, never `mean` over a zero-padded tensor — the latter
+  silently halves the loss on right-only data, which changes the effective LR and
+  makes the curve incomparable to a future bimanual run.
+
+Not asserted, deliberately: independence of the *valid* side's prediction from
+the invalid side's inputs. The state token is shared, so that dependence is
+legitimate.
+
+### Per-side, weight-shared tokenizer and head
+
+One tokenizer is fitted on the pooled valid side-chunks of both hands, and one
+`code_head`/`offset_head` pair is applied twice with a learned per-side embedding
+added to the readout feature. This halves head parameters versus two independent
+heads and — more importantly — lets right-only dummy data produce a tokenizer and
+a head that are immediately meaningful for the left hand. A single 120-dim
+bimanual tokenizer was rejected: on right-only data it would learn "left ≡ 0",
+which breaks the moment real bimanual teleop lands.
+
+### Config seam for the Revo2 action space (§11)
+
+`action_features` (per-side action dimensionality) and `action_horizon` are
+config values; every head width derives from
+`num_quantizers * codebook_size * action_horizon * action_features`, and
+`NeroPoseTokenizer.has_pose_layout` switches the physical-unit metrics off
+automatically when `action_features != 60`.
+
+To move to §11 option **(B)** — policy predicts Revo2 joint targets, ~12 dims per
+side — what changes:
+
+- **config**: `action_features: 12`, a new tokenizer checkpoint and a new
+  `PoseStandardizer` artifact fitted on joint angles. No code change in the
+  policy or the tokenizer.
+- **rbyte**: the glove-SE(3) → Revo2 retargeting must be applied *at ingestion*
+  and `action.commanded` populated (the contract already reserves the slot).
+  This is the part that does not exist and cannot be faked.
+- **metrics**: `pose_error_metrics` no longer applies; the replacement is
+  per-joint degrees, which is a ~10-line addition guarded by `has_pose_layout`.
+- **state**: `state.pose` can stay SE(3) (it is a separate config path from the
+  action), so the observation side need not move at the same time. That
+  asymmetry is the cheapest first experiment if commanded targets arrive.
+
+Offset-head size is the one number that changes materially: at 60 dims it is
+`4 × 16 × 6 × 60 = 23040` outputs (11.8M params with the 512-wide penultimate
+layer used here); at 12 dims it is 4608 outputs (2.4M).
+
+## Tokenizer recipe (contract §5)
+
+- input is the **6D continuous rotation** form (3 translation + 6 rotation per
+  pose), never quaternions — quaternions are discontinuous as a reconstruction
+  target;
+- quaternions are **canonicalised** (`qw ≥ 0`) at the conversion boundary, so the
+  double cover cannot waste codebook capacity even if ingestion misses it;
+- **per-channel standardisation** with train-split statistics, shipped as a
+  versioned JSON artifact (`PoseStandardizer.save/load`, version-gated on load)
+  alongside the checkpoint;
+- translation and rotation reconstruction error are reported **separately and in
+  physical units** — mm and geodesic degrees. `test_pose_error_metrics_separates_ translation_from_rotation` asserts a translation-only error produces zero
+  rotation error and vice versa, so the split cannot silently degrade into one
+  scalar.
+
+## Contract issues
+
+1. **The 60-dim channel order is undefined.** §6.1 gives the blocks (arm 9,
+   fingers 45, hub rotation 6) but never their order *within* the 60 dims.
+   Without it, per-channel standardisation and the translation/rotation split are
+   both unimplementable. This work **defines** it in
+   `rmind.data.nero.POSE_BLOCK_LAYOUT` as
+   `[arm, thumb, index, middle, ring, little] × (t3, r6)` then `hub (r6)`, giving
+   18 translation indices `{0-2, 9-11, 18-20, 27-29, 36-38, 45-47}` and 42
+   rotation indices. **The rbyte side must confirm or correct this**; it is
+   exactly the kind of silent interface break the brief warns about. The layout
+   is also written into the standardisation artifact so a mismatch is detectable
+   rather than silent.
+1. **§5 names only the 7↔9 pose pair.** The hub-orientation block is
+   rotation-only and needs a 4↔6 pair. Added here as
+   `quat_to_rot6d` / `rot6d_to_quat`; the contract should name them.
+1. **§7 `placeholder: true` makes `camera_cond` a constant** (zero intrinsics,
+   identity extrinsics) until the real calibration file drops. The
+   generalisation claim behind §7.1 is therefore **untestable** on current data,
+   and any model trained before the file drop learns nothing from that vector.
+   The smoke harness randomises `camera_cond` so the path is at least exercised.
+1. **§8 emits both `action.future_state` and `action.commanded` as aliases.** The
+   policy reads `action.future_state` by config path; switching is one line. No
+   issue, noted so the alias is not accidentally consumed twice.
+
+## Open items for the user
+
+- the §11 retargeting decision (A vs B) — the single most valuable thing to
+  confirm about the incoming teleop format;
+- the 60-dim channel order (item 1 above) must be agreed with the rbyte side;
+- `lr_warmup_steps` / `lr_total_steps` in the experiment config are placeholders.
+  Re-derive from the **true** sample count (contract §8: do not trust
+  `.rbyte_cache` counts) before any real run — the cosine schedule rises again
+  past `num_training_steps`.

--- a/docs/nero_arms_causal_patch_policy.md
+++ b/docs/nero_arms_causal_patch_policy.md
@@ -297,28 +297,39 @@ versus the single-camera driving arm). 40.9M trainable / 63.1M total parameters.
 
 ## Contract issues
 
-1. **The 60-dim channel order is undefined.** §6.1 gives the blocks (arm 9,
-   fingers 45, hub rotation 6) but never their order *within* the 60 dims.
-   Without it, per-channel standardisation and the translation/rotation split are
-   both unimplementable. This work **defines** it in
-   `rmind.data.nero.POSE_BLOCK_LAYOUT` as
-   `[arm, thumb, index, middle, ring, little] × (t3, r6)` then `hub (r6)`, giving
-   18 translation indices `{0-2, 9-11, 18-20, 27-29, 36-38, 45-47}` and 42
-   rotation indices. **The rbyte side must confirm or correct this**; it is
-   exactly the kind of silent interface break the brief warns about. The layout
-   is also written into the standardisation artifact so a mismatch is detectable
-   rather than silent.
-1. **§5 names only the 7↔9 pose pair.** The hub-orientation block is
-   rotation-only and needs a 4↔6 pair. Added here as
-   `quat_to_rot6d` / `rot6d_to_quat`; the contract should name them.
-1. **§7 `placeholder: true` makes `camera_cond` a constant** (zero intrinsics,
-   identity extrinsics) until the real calibration file drops. The
-   generalisation claim behind §7.1 is therefore **untestable** on current data,
-   and any model trained before the file drop learns nothing from that vector.
-   The smoke harness randomises `camera_cond` so the path is at least exercised.
-1. **§8 emits both `action.future_state` and `action.commanded` as aliases.** The
-   policy reads `action.future_state` by config path; switching is one line. No
-   issue, noted so the alias is not accidentally consumed twice.
+1. **§8's `(T, 2, 60)` contradicts §5.2's quaternion storage.** rbyte implemented
+   §5.2 and emits **46** per side; this side does the 46→60 expansion at the model
+   boundary. Resolved in practice, but §8 should be corrected so the next reader
+   does not size a tensor from it. **Verified, not assumed**: `pose_quat_to_9d` is
+   bit-identical across the two repos and the block order agrees (arm `[0:7]`,
+   fingers `[7:42]` thumb→little, hub quaternion `[42:46]`).
+2. **The 60-dim channel order was undefined.** §6.1 gave blocks but not their
+   order, which makes per-channel standardisation and the translation/rotation
+   split unimplementable. It is now pinned on both sides — here as
+   `rmind.data.nero.POSE_BLOCK_LAYOUT`, giving 18 translation indices
+   `{0-2, 9-11, 18-20, 27-29, 36-38, 45-47}` and 42 rotation indices. The layout
+   is also written into the standardisation artifact, so a future mismatch is
+   detectable rather than silent. **§6.1 should state it.**
+3. **§5 names only the 7↔9 pose pair.** The hub-orientation block is
+   rotation-only and needs a 4↔6 pair (`quat_to_rot6d` / `rot6d_to_quat` here,
+   and the same pair exists in rbyte). The contract should name it.
+4. **§8's image row implies a common H/W across cameras; there is none.** rbyte
+   isotropically downscales per camera (`base` 270×480, `side_*` 300×480), which
+   is the right call for the intrinsics but makes "letterbox to a common grid" a
+   mandatory consumer-side step. §8 should say so explicitly — a consumer that
+   assumes a uniform patch grid fails at `torch.cat`, which is at least loud, but
+   one that resizes anisotropically fails **silently** and invalidates
+   `camera_cond`.
+5. **§7's `placeholder: true` makes `camera_cond` a constant** (zero intrinsics,
+   identity extrinsics) until the real calibration drops. The generalisation claim
+   behind §7.1 is therefore **untestable** on current data, and a model trained
+   before the file drop learns nothing from that vector. The smoke harness
+   randomises it so the path is at least exercised. §13.2's rectified-K-plus-
+   extrinsics choice is what the 13-dim layout already assumes.
+6. **`action.commanded` is a byte-identical duplicate** of
+   `action.future_state` — ~199 MB of a ~470 MB TensorDict, scaling linearly. The
+   policy reads exactly one path (config-selected), so nothing downstream pays
+   for it; the duplication is worth removing loader-side before the dataset grows.
 
 ## Open items for the user
 

--- a/docs/nero_arms_causal_patch_policy.md
+++ b/docs/nero_arms_causal_patch_policy.md
@@ -1,9 +1,16 @@
 # nero-arms causal patch policy + SE(3) action tokenizer
 
 Design record for the nero-arms bimanual manipulation arm of the patch policy.
-Coded against `nero-arms/DATA_CONTRACT.md` v0.1 (+ §7.2, §11). Where this
-document and the contract disagree, the contract wins and the disagreement is
-listed in "Contract issues" below.
+Coded against `nero-arms/DATA_CONTRACT.md` v0.1 (+ §7.2, §10 answers, §11, §13)
+and against what the rbyte ingestion side actually emits (`rbyte@feat/nero-arms`).
+Where this document and the contract disagree, the contract wins and the
+disagreement is listed in "Contract issues" below.
+
+⚠️ **The glove SE(3) parameterisation is a stand-in, not the observation space**
+(§10 A1). Iteration-1 teleoperation uses the gloves only as the *input device*;
+the recorded observations will be **robot arm/hand state** — Revo2 joint values,
+roughly 12 per side rather than 60. Everything below is therefore built so the
+action space is a **config value, not a constant**; see "Action-space seam".
 
 Built on `feat/patch-policy-decoder-only`. The decoder-only trunk
 (`rmind/components/transformer/causal_frame.py`: frame-RoPE + tiled intra-frame
@@ -27,24 +34,55 @@ below it is new.
 | `config/datamodule/yaak/nero_random.yaml`                    | synthetic datamodule                                                                                                                                                                                                               |
 | `tests/test_nero_pose.py`, `tests/test_nero_patch_policy.py` | tests                                                                                                                                                                                                                              |
 
+## What the loader actually hands over
+
+rbyte (`feat/nero-arms`, 15,047 samples across 104 episodes) emits shapes that
+differ from the §8 table in three ways that matter here. All three are handled at
+the model's input boundary:
+
+| | §8 said | rbyte emits | handled by |
+| --- | --- | --- | --- |
+| images | one `(T, 3, H, W)` per camera, implicitly common H/W | **different grids**: `base` `(T,3,270,480)`, `side_*` `(T,3,300,480)` | `LetterboxResize` |
+| state / action | `(T, 2, 60)` | **`(T, 2, 46)`** — the §5.2 quaternion storage form | `state_quat_to_9d` |
+| goal image | one `(3, 3, H, W)` | **three keys** `goal.image.{camera}`, each on its own grid | per-camera encode |
+
+`action.commanded` is currently a byte-identical duplicate of
+`action.future_state` (~199 MB of a ~470 MB TensorDict). The policy reads exactly
+one path, chosen by config, so the duplicate is never consumed.
+
+The 46↔60 conversion is the shared boundary of §5, and it is verified against the
+other side rather than assumed: `rmind.data.nero.pose_quat_to_9d` is
+**bit-identical** to `rbyte.io.nero.rotation.pose_quat_to_9d` on random poses,
+and `state_quat_to_9d` matches structurally (arm `[0:7]`, fingers `[7:42]` in
+thumb→little order, hub quaternion `[42:46]`).
+
 ## Token layout and sequence length
 
 ```
-frame block = [ state token (1) ][ base (256) ][ side_left (256) ][ side_right (256) ]
-tokens_per_frame = 3 * 256 + 1 = 769
-flattened        = episode_length * 769 = 6 * 769 = 4614
+frame block = [ state token (1) ][ base (160) ][ side_left (160) ][ side_right (160) ]
+tokens_per_frame = 3 * 160 + 1 = 481
+flattened        = episode_length * 481 = 6 * 481 = 2886
 ```
 
+The ViT input is **140×224**, a 10×16 = 160-patch grid at DINOv2's patch 14. That
+is the cameras' own 5:8 aspect, so **nothing is spent on padding except `base`'s
+two letterbox rows**. Forcing the usual square 224×224 would have put the same
+image content on a 16×16 grid with 6 of 16 rows pure black bars — 769 tokens per
+frame and 4614 flattened, i.e. **60% more sequence for zero extra information**.
+Since attention is quadratic, that is ~2.6× the attention cost.
+
+`TimmBackbone`'s `norm_patch_tokens` path assumed a square grid (`isqrt(P)`); it
+now reads `patch_embed.grid_size`, which is identical for square inputs and
+correct for these.
+
 For comparison on the same trunk: the 6-frame driving arm is **1542**, the
-16-frame causal driving arm is **4112**. So this sits just above the largest arm
-already profiled, and the `episode_length = 6` choice is what keeps it there —
-`episode_length = 16` would be 12304 tokens (≈9× the attention cost of 4614).
+16-frame causal driving arm is **4112**.
 
 `head_dim = 512 / 8 = 64`: divisible by 8 (fused SDPA — at head_dim 20 PR #265
-fell back to a math kernel that materialises the full `(B, H, L, L)` score
-matrix and OOMed) and even (required by the trunk's frame-RoPE). The
-`nero_smoke --stage budget` pre-flight asserts both and probes the SDPA backend
-empirically rather than reasoning about it.
+fell back to a math kernel that materialises the full `(B, H, L, L)` score matrix
+and OOMed) and even (required by the trunk's frame-RoPE). The
+`nero_smoke --stage budget` pre-flight asserts both, cross-checks `num_patches`
+against the image size, and probes the SDPA backend empirically.
 
 The state token goes **first** so each frame block ends on a patch token, which
 is the readout position — unchanged from PR #265, where the speed token played
@@ -92,23 +130,33 @@ Goal xyz (§9 alternative) is emitted by the datamodule and left unconsumed; the
 second RVQ for it is scaffolded (`NeroGoalXYZTokenizer`) but not trained — it is
 only needed if the goal is to be *predicted* rather than conditioned on.
 
-### Image pipeline → letterbox, not resize (§7.2)
+### Image pipeline → letterbox, not resize (§7.2 + the rbyte grids)
 
-`base` is 1920×1080 (16:9), `side_*` are 1280×800 (16:10). A plain `Resize` to a
-square scales x and y by different factors, which (a) scales `fx` and `fy`
-independently so the resolution-normalised intrinsics in `camera_cond` stop
-describing the pixels the policy sees, and (b) makes the same object a different
-shape in `base` than in the side views, which a shared frozen ViT cannot undo.
-`LetterboxResize` keeps the scale isotropic; `letterbox_camera_cond` rewrites the
-4 intrinsic entries to match (extrinsics are untouched — letterboxing does not
-move the camera).
+rbyte downscales each camera **isotropically to its own grid**, which keeps the
+resolution-normalised intrinsics in `camera_cond` exactly valid at zero
+propagation cost — and leaves the three streams on different grids. Unifying them
+is rmind's job, and it must be a letterbox (uniform scale + symmetric padding),
+never an anisotropic resize: that would scale `fx` and `fy` independently so the
+conditioning vector stops describing the pixels the policy sees, and would make
+the same object a different shape in `base` than in the side views.
 
-Consequence to watch: all three cameras land on the same 16×16 patch grid, so
-`base`'s wider field of view gets **coarser real-world coverage per patch** than
-the side cameras. If the overhead view underperforms, this is the first thing to
-look at.
+`300×480 → 140×224` is exactly isotropic, so the side cameras are resized and not
+padded; `base` (`270×480`) is padded by 7 rows top and bottom after scaling.
+`letterbox_camera_cond` rewrites the four intrinsic entries to match — for the
+side cameras it is a no-op, for `base` `fy` shrinks by `270/300` and the
+principal point is re-centred. Extrinsics are untouched; letterboxing does not
+move the camera.
 
-### Bimanual `side_valid` (§6.1)
+§13.2 confirms the conditioning vector should carry **rectified** K plus
+extrinsics and *not* distortion coefficients, which is what the 13-dim layout
+already assumes.
+
+Consequence to watch: all three cameras share one patch grid, so `base`'s wider
+field of view gets coarser real-world coverage per patch than the side cameras,
+and `base` additionally spends 2 of its 10 patch rows on letterbox padding. If
+the overhead view underperforms, this is the first thing to look at.
+
+### Bimanual `side_valid` (§6.1, §10 A2 — permanent contract)
 
 Consumed in two places, both falsifiable:
 
@@ -125,6 +173,11 @@ Not asserted, deliberately: independence of the *valid* side's prediction from
 the invalid side's inputs. The state token is shared, so that dependence is
 legitimate.
 
+§10 A2 confirms bimanual is permanent with one arm optionally absent, so this is
+contract behaviour rather than dummy-data scaffolding. It is exercised through a
+backward pass, not just a forward: a right-only overfit run reaches 1.37 mm /
+1.37° with `valid_rows` pinned at 48 = 8 samples × 6 frames × 1 side.
+
 ### Per-side, weight-shared tokenizer and head
 
 One tokenizer is fitted on the pooled valid side-chunks of both hands, and one
@@ -135,7 +188,7 @@ a head that are immediately meaningful for the left hand. A single 120-dim
 bimanual tokenizer was rejected: on right-only data it would learn "left ≡ 0",
 which breaks the moment real bimanual teleop lands.
 
-### Config seam for the Revo2 action space (§11)
+### Action-space seam (§10 A1, §13.3) — load-bearing
 
 `action_features` (per-side action dimensionality) and `action_horizon` are
 config values; every head width derives from

--- a/docs/nero_arms_causal_patch_policy.md
+++ b/docs/nero_arms_causal_patch_policy.md
@@ -134,9 +134,14 @@ waypoints are ego-frame).
 features with a **learned** `no_goal` embedding, not zeros, so "no goal supplied"
 is distinguishable from "goal that happens to encode near zero".
 
-Goal xyz (§9 alternative) is emitted by the datamodule and left unconsumed; the
-second RVQ for it is scaffolded (`NeroGoalXYZTokenizer`) but not trained — it is
-only needed if the goal is to be *predicted* rather than conditioned on.
+Goal xyz (§9 alternative) is emitted by the datamodule and left unconsumed.
+**The second RVQ for it is NOT delivered**: `NeroGoalXYZTokenizer` exists only as
+a named config seam with the right defaults, and its inherited `_gather` does not
+yet handle a `(b, 2, 3)` tensor. It is needed only if the goal is to be
+*predicted* rather than conditioned on — §13.1 notes the taped target squares are
+fixed in the world frame, so the goal xyz is knowable and this becomes worth
+building the moment anyone wants goal prediction or a cube-position auxiliary
+loss.
 
 ### Image pipeline → letterbox, not resize (§7.2 + the rbyte grids)
 

--- a/docs/nero_arms_causal_patch_policy.md
+++ b/docs/nero_arms_causal_patch_policy.md
@@ -177,6 +177,71 @@ layer used here); at 12 dims it is 4608 outputs (2.4M).
   rotation error and vice versa, so the split cannot silently degrade into one
   scalar.
 
+## Measured (synthetic data — see the caveat)
+
+Hardware: one RTX 5090 (32 GiB). `uv run python -m rmind.scripts.nero_smoke`.
+
+### Pre-flight budget
+
+| | |
+| --- | --- |
+| tokens per frame | 769 |
+| flattened sequence | **4614** |
+| head_dim | 64 (÷8 ✓, even ✓) |
+| SDPA memory-efficient backend | admissible (probed, not assumed) |
+| dense score matrix *if* a math fallback were taken | 0.32 GiB per sample, bf16 |
+
+### Tokenizer reconstruction — translation and rotation, separately
+
+Held-out synthetic chunks, `4 × 16` residual-VQ, 6000 steps. Codebook
+perplexity **15.2–15.8 of 16** (near-uniform usage).
+
+| path | translation | rotation | standardised L1 |
+| --- | --- | --- | --- |
+| predict the train mean (baseline) | 14.24 mm | 10.94° | 0.677 |
+| **codes only** (what the policy's code head must hit) | **9.77 mm** | **4.91°** | 0.283 |
+| unquantized autoencoder (ceiling) | 9.10 mm | 4.08° | 0.238 |
+
+The gap between rows 2 and 3 is the cost of the codebook; the gap between rows 1
+and 3 is what the encoder learned. The policy adds the VQ-BeT offset head on top
+of row 2, so row 2 is a *coarse* target by construction, not the end-to-end
+accuracy.
+
+⚠️ These are numbers on **synthetic** SE(3), and the synthetic generator's
+compressibility was tuned (a ~14-DOF latent, matching a real hand's DOF count)
+until the space was compressible at all. They demonstrate that the recipe and the
+split metric work; they are **not** a prediction of accuracy on real glove data.
+
+### Policy smoke
+
+| | fresh random batches | one fixed batch (control) |
+| --- | --- | --- |
+| batch | 16 | 8 |
+| total loss | 10.06 → 10.01 (flat) | 7.89 → **0.048** |
+| offset L1 | 0.302 → 0.303 | 0.242 → 0.023 |
+| translation | 16.7 → 16.6 mm | 17.2 → **1.44 mm** |
+| rotation | 14.3° → 14.2° | 13.8° → **1.66°** |
+
+**The flat fresh-data curve is a property of the synthetic data, not a wiring
+bug, and the control proves it.** The four code losses sit at
+2.4387 / 2.4508 / 2.4338 / 2.4367, which is exactly the uniform-prior focal-loss
+value: `(1 − 1/16)² · ln 16 = 2.4368`. With a near-uniform codebook (measured
+perplexity 15.2–15.8/16) that is the hard floor for any predictor with no
+information — and here there is none, because the synthetic images are pure
+noise, so 768 of the 769 tokens per frame are distractors and the one informative
+token (state) is attenuated ~1/769 at init. Trained on a *single* batch the same
+model drives every code loss to ≈0.003–0.01 and reaches 1.4 mm / 1.7°, so the
+whole path — readout → per-side embedding → shared head → tokenizer targets →
+gradients — is sound.
+
+**Memory and speed.** Peak **2.33 GiB** at batch 8 and 4.9 GiB at batch 16 —
+⚠️ **with the trunk's gradient checkpointing**, which
+`rmind.components.transformer.utils.run_layer_stack` applies whenever
+`training=True`. That is memory traded for recompute; a non-checkpointed
+estimate for these shapes is ~5 GiB at batch 8. Median step 0.357 s at batch 8
+(3 observation cameras + 3 goal images = 6× the frozen-ViT work per sample
+versus the single-camera driving arm). 40.9M trainable / 63.1M total parameters.
+
 ## Contract issues
 
 1. **The 60-dim channel order is undefined.** §6.1 gives the blocks (arm 9,

--- a/docs/nero_arms_causal_patch_policy.md
+++ b/docs/nero_arms_causal_patch_policy.md
@@ -96,7 +96,7 @@ Each camera's 13-dim vector (§7.1) is concatenated to **that camera's** patch
 tokens before `patch_projection`. Alternatives considered: 3 extra tokens per
 frame, or FiLM.
 
-1. **Zero sequence cost.** At 769 tokens/frame attention is the binding
+1. **Zero sequence cost.** At 481 tokens/frame attention is the binding
    constraint.
 1. **It binds the geometry to the tokens it describes.** A `side_left` patch
    carries `side_left`'s extrinsics. Extra tokens or FiLM would deliver all three
@@ -238,62 +238,74 @@ Hardware: one RTX 5090 (32 GiB). `uv run python -m rmind.scripts.nero_smoke`.
 
 | | |
 | --- | --- |
-| tokens per frame | 769 |
-| flattened sequence | **4614** |
+| patch grid | 10 × 16 |
+| tokens per frame | 481 |
+| flattened sequence | **2886** |
 | head_dim | 64 (÷8 ✓, even ✓) |
 | SDPA memory-efficient backend | admissible (probed, not assumed) |
-| dense score matrix *if* a math fallback were taken | 0.32 GiB per sample, bf16 |
+| dense score matrix *if* a math fallback were taken | 0.124 GiB per sample, bf16 |
 
 ### Tokenizer reconstruction — translation and rotation, separately
 
 Held-out synthetic chunks, `4 × 16` residual-VQ, 6000 steps. Codebook
-perplexity **15.2–15.8 of 16** (near-uniform usage).
+perplexity **15.5–15.8 of 16** on held-out data (near-uniform usage).
 
 | path | translation | rotation | standardised L1 |
 | --- | --- | --- | --- |
 | predict the train mean (baseline) | 14.24 mm | 10.94° | 0.677 |
-| **codes only** (what the policy's code head must hit) | **9.77 mm** | **4.91°** | 0.283 |
-| unquantized autoencoder (ceiling) | 9.10 mm | 4.08° | 0.238 |
+| **codes only** (what the policy's code head must hit) | **9.76 mm** | **4.89°** | 0.281 |
+| unquantized autoencoder (ceiling) | 9.22 mm | 4.12° | 0.241 |
 
-The gap between rows 2 and 3 is the cost of the codebook; the gap between rows 1
-and 3 is what the encoder learned. The policy adds the VQ-BeT offset head on top
-of row 2, so row 2 is a *coarse* target by construction, not the end-to-end
-accuracy.
+The baseline row is what makes the other two readable. The gap between rows 2
+and 3 is the cost of the codebook; the gap between rows 1 and 3 is what the
+encoder learned. The policy adds the VQ-BeT offset head on top of row 2, so row 2
+is a *coarse* target by construction, not the end-to-end accuracy.
 
-⚠️ These are numbers on **synthetic** SE(3), and the synthetic generator's
-compressibility was tuned (a ~14-DOF latent, matching a real hand's DOF count)
-until the space was compressible at all. They demonstrate that the recipe and the
-split metric work; they are **not** a prediction of accuracy on real glove data.
+⚠️ These are numbers on **synthetic** SE(3), and the generator's compressibility
+was deliberately built in (a ~14-DOF latent, matching a real hand's DOF count).
+They demonstrate that the recipe and the split metric work; they are **not** a
+prediction of accuracy on real data — which, per §10 A1, will not even be this
+action space.
 
-### Policy smoke
+### Policy smoke — 400 steps, batch 8, lr 3e-4
 
-| | fresh random batches | one fixed batch (control) |
-| --- | --- | --- |
-| batch | 16 | 8 |
-| total loss | 10.06 → 10.01 (flat) | 7.89 → **0.048** |
-| offset L1 | 0.302 → 0.303 | 0.242 → 0.023 |
-| translation | 16.7 → 16.6 mm | 17.2 → **1.44 mm** |
-| rotation | 14.3° → 14.2° | 13.8° → **1.66°** |
+| | fresh random batches | one fixed batch | one fixed batch, right-only |
+| --- | --- | --- | --- |
+| `side_valid` | both | both | `[False, True]` |
+| total loss | 10.11 → 10.04 (flat) | 8.12 → **0.013** | 6.78 → **0.039** |
+| offset L1 | 0.295 → 0.302 | 0.237 → 0.013 | 0.235 → 0.029 |
+| translation | 16.5 → 17.0 mm | 17.1 → **0.57 mm** | 17.6 → **1.12 mm** |
+| rotation | 13.9° → 14.4° | 13.9° → **1.41°** | 13.9° → **1.31°** |
+| `valid_rows` | 96 | 96 | **48** |
 
 **The flat fresh-data curve is a property of the synthetic data, not a wiring
-bug, and the control proves it.** The four code losses sit at
-2.4387 / 2.4508 / 2.4338 / 2.4367, which is exactly the uniform-prior focal-loss
+bug, and the controls prove it.** The four code losses sit at
+2.4316 / 2.4388 / 2.4356 / 2.4368, which is exactly the uniform-prior focal-loss
 value: `(1 − 1/16)² · ln 16 = 2.4368`. With a near-uniform codebook (measured
-perplexity 15.2–15.8/16) that is the hard floor for any predictor with no
+perplexity 15.5–15.8/16) that is the hard floor for any predictor with no
 information — and here there is none, because the synthetic images are pure
-noise, so 768 of the 769 tokens per frame are distractors and the one informative
-token (state) is attenuated ~1/769 at init. Trained on a *single* batch the same
-model drives every code loss to ≈0.003–0.01 and reaches 1.4 mm / 1.7°, so the
-whole path — readout → per-side embedding → shared head → tokenizer targets →
+noise, so 480 of the 481 tokens per frame are distractors and the one informative
+token (state) is attenuated ~1/481 at init. Trained on a *single* batch the same
+model drives every code loss to 0.000 and reaches 0.57 mm / 1.41°, so the whole
+path — readout → per-side embedding → shared head → tokenizer targets →
 gradients — is sound.
 
-**Memory and speed.** Peak **2.33 GiB** at batch 8 and 4.9 GiB at batch 16 —
+The third column is the contract's headline bimanual case (§10 A2) exercised
+through a **backward** pass, not just a forward: with the left side masked out,
+`valid_rows` is pinned at 48 = 8 samples × 6 frames × 1 side and the run still
+converges.
+
+**Memory and speed.** Peak **1.74 GiB** at batch 8, median step **0.21 s** —
 ⚠️ **with the trunk's gradient checkpointing**, which
 `rmind.components.transformer.utils.run_layer_stack` applies whenever
-`training=True`. That is memory traded for recompute; a non-checkpointed
-estimate for these shapes is ~5 GiB at batch 8. Median step 0.357 s at batch 8
-(3 observation cameras + 3 goal images = 6× the frozen-ViT work per sample
-versus the single-camera driving arm). 40.9M trainable / 63.1M total parameters.
+`training=True`. That is memory traded for recompute, so it is not the number to
+size a non-checkpointed run from. 40.7M trainable / 62.9M total parameters. Wall
+time is dominated by synthetic image generation on the CPU, not by the model.
+
+<sub>Footnote: the fresh-batch run composed its config just before the
+`ToDtype`/`LetterboxResize` reorder and the other two just after. On pure-noise
+images the difference is uint8 rounding, i.e. nothing measurable — but the three
+are not a controlled comparison of that change.</sub>
 
 ## Contract issues
 

--- a/docs/nero_serving_handover.md
+++ b/docs/nero_serving_handover.md
@@ -1,0 +1,94 @@
+# nero-arms policy — serving handover
+
+A **random-weight** checkpoint you can build a serving app against today, before any model is
+trained. Shapes and the interface are real; the numbers it outputs are meaningless.
+
+## Get it
+
+```bash
+git clone -b feat/nero-arms-causal-patch-policy git@github.com:yaak-ai/rmind.git
+cd rmind && uv sync
+uv run python -m rmind.scripts.nero_serving_stub --out ./nero-serving
+```
+
+Writes `policy_random.ckpt` (~250 MB) and `io_contract.json`. Load with
+`torch.load(..., weights_only=False)` → `{"state_dict", "experiment"}`, and build the module with
+`hydra` from experiment `yaak/nero_arms/causal`.
+
+**62.9M parameters** (40.7M trainable; the rest is the frozen DINOv2 image encoder).
+
+## Inputs — 9 tensors, batch dim first
+
+| key | shape (batch 1) | dtype |
+|---|---|---|
+| `image.base` | `(1, 6, 3, 270, 480)` | **uint8** |
+| `image.side_left` | `(1, 6, 3, 300, 480)` | **uint8** |
+| `image.side_right` | `(1, 6, 3, 300, 480)` | **uint8** |
+| `goal.image.base` | `(1, 3, 270, 480)` | uint8 |
+| `goal.image.side_left` | `(1, 3, 300, 480)` | uint8 |
+| `goal.image.side_right` | `(1, 3, 300, 480)` | uint8 |
+| `camera_cond` | `(1, 3, 13)` | float32 |
+| `state.pose` | `(1, 6, 2, 46)` | float32 |
+| `side_valid` | `(1, 2)` | bool |
+
+`6` is the history length `T` (30 Hz, so 200 ms of context). `2` is `[left, right]`.
+
+**Verified: these 9 are all the forward pass needs.** `action.future_state`,
+`action.commanded`, `goal.xyz` and `align_residual_ms` appear in a training batch but are labels
+and diagnostics — a serving app must not supply them.
+
+## Output
+
+| key | shape | meaning |
+|---|---|---|
+| `policy.action` | `(1, 2, 6, 60)` | `(batch, side, horizon, action_dim)` |
+
+Horizon 6 at 30 Hz = a 200 ms action chunk. Values are **standardised** — de-standardise with the
+stats shipped beside the tokenizer checkpoint.
+
+## Four things that will bite you
+
+**1. The policy is STOCHASTIC by default.** Same input, different output — this is VQ-BeT
+sampling from a categorical over action codes, and it is deliberate (the point is a multimodal
+action distribution, not a single regressed action). Verified: identical inputs give outputs
+differing by ~1.1 in standardised units.
+
+For a deterministic serving path set `model.sample_codes = False` (falls back to `argmax`);
+verified bit-identical across repeated calls. **Decide which you want early** — a serving app
+written assuming determinism will look broken otherwise.
+
+**2. State goes in as 46 dims, actions come out as 60.** Different spaces, not a typo. Input is
+canonical-quaternion storage (`3 + 4` per pose); output is the model-facing form
+(`3 + 6D rotation`). Convert with `rmind.data.nero.state_quat_to_9d`. Quaternions are
+discontinuous as a regression target, which is why the output uses 6D.
+
+**3. The three cameras have different heights.** `base` is 270×480, the sides are 300×480 — the
+real sensors differ (OAK-D W vs two OAK-D SR). Do not assume a common size, and do not resize
+without propagating the change into `camera_cond`, which carries resolution-normalised
+intrinsics.
+
+**4. Images are `uint8`, not normalised floats.** Normalisation happens inside the model.
+
+## `camera_cond`, and the current caveat
+
+`(3, 13)` per sample: for each camera, resolution-normalised `fx/W, fy/H, cx/W, cy/H`, then
+translation (3) and rotation as 6D (6) in the world frame. It is what lets the policy generalise
+across camera-setup changes.
+
+⚠️ **Extrinsics are still placeholders (identity).** Intrinsics are real, read from device EEPROM;
+the camera→world poses are not yet calibrated. Until they are, only the first 4 of 13 dims carry
+information. Plumb the full vector now; the values will improve without a shape change.
+
+## What will change
+
+- **Action space.** Iteration-1 teleop is robot-native, so the real action becomes NERO joint
+  commands (7 DOF/arm + 6 actuated hand DOF ≈ **26 bimanual**), not the 120 here. This is a
+  config seam — verified by a real forward/backward at `action_features=12` — so expect the last
+  dimension to change and nothing else about the interface.
+- **Depth** may be added as a fourth stream (in progress).
+- Weights become real. Nothing above changes shape when they do.
+
+## Reference
+
+Full data contract: `nero-arms/DATA_CONTRACT.md`. Model design:
+`docs/nero_arms_causal_patch_policy.md`. Machine-readable I/O spec: `io_contract.json`.

--- a/docs/nero_serving_handover.md
+++ b/docs/nero_serving_handover.md
@@ -35,7 +35,20 @@ Writes `policy_random.ckpt` (~250 MB) and `io_contract.json`. Load with
 
 **Verified: these 9 are all the forward pass needs.** `action.future_state`,
 `action.commanded`, `goal.xyz` and `align_residual_ms` appear in a training batch but are labels
-and diagnostics — a serving app must not supply them.
+and diagnostics — a serving app must not supply them. (`goal.xyz` is plumbed in the data but not
+consumed by the model; goal conditioning is image-based today.)
+
+### Running without a goal
+
+Pass **`goal_valid`** — `(1, 3)` bool, per camera (a `(1,)` flag broadcasts to all three) — and
+you may then **omit that camera's `goal.image.*` entirely**. The model routes to a learned
+`no_goal` embedding, which is the same path goal-dropout trains, so it is in-distribution.
+
+- absent `goal_valid` ⇒ all-true, i.e. existing callers are unaffected;
+- a **missing** `goal.image.*` with `goal_valid` **true** still raises `KeyError` — that is a real
+  error, not an implicit "no goal";
+- do **not** substitute a black image for a missing goal: it is read as a genuine goal, and it is
+  out of distribution because training never saw one.
 
 ## Output
 

--- a/docs/nero_serving_handover.md
+++ b/docs/nero_serving_handover.md
@@ -48,14 +48,18 @@ stats shipped beside the tokenizer checkpoint.
 
 ## Four things that will bite you
 
-**1. The policy is STOCHASTIC by default.** Same input, different output — this is VQ-BeT
-sampling from a categorical over action codes, and it is deliberate (the point is a multimodal
-action distribution, not a single regressed action). Verified: identical inputs give outputs
-differing by ~1.1 in standardised units.
+**1. Inference is DETERMINISTIC by default** (`sample_codes=False`, i.e. `argmax` over action
+codes). Verified: repeated calls on identical inputs are bit-identical.
 
-For a deterministic serving path set `model.sample_codes = False` (falls back to `argmax`);
-verified bit-identical across repeated calls. **Decide which you want early** — a serving app
-written assuming determinism will look broken otherwise.
+Set `model.sample_codes = True` for stochastic sampling — VQ-BeT can sample from its categorical
+over codes, giving a multimodal action distribution. That is a real capability, but it is opt-in,
+because a serving app that assumes determinism should not be surprised. Measured: sampling makes
+repeated calls on identical inputs differ by ~1.1 in standardised units.
+
+No loss depends on this flag while `teacher_force_offset` is true (the default): the code losses
+are cross-entropy against tokenizer-encoded targets and the offset loss is teacher-forced from
+those same codes. Verified — all five losses bit-identical under both settings. It changes only
+the reported reconstruction metrics, which are now computed the way serving decodes.
 
 **2. State goes in as 46 dims, actions come out as 60.** Different spaces, not a typo. Input is
 canonical-quaternion storage (`3 + 4` per pose); output is the model-facing form

--- a/docs/nero_serving_io_contract.json
+++ b/docs/nero_serving_io_contract.json
@@ -1,0 +1,138 @@
+{
+  "note": "RANDOM WEIGHTS. Shapes are real; values are meaningless.",
+  "experiment": "yaak/nero_arms/causal",
+  "batch_size": 1,
+  "parameters": {
+    "total": 62929320,
+    "trainable": 40704960
+  },
+  "inputs": {
+    "image.base": {
+      "shape": [
+        1,
+        6,
+        3,
+        270,
+        480
+      ],
+      "dtype": "torch.uint8"
+    },
+    "goal.image.base": {
+      "shape": [
+        1,
+        3,
+        270,
+        480
+      ],
+      "dtype": "torch.uint8"
+    },
+    "image.side_left": {
+      "shape": [
+        1,
+        6,
+        3,
+        300,
+        480
+      ],
+      "dtype": "torch.uint8"
+    },
+    "goal.image.side_left": {
+      "shape": [
+        1,
+        3,
+        300,
+        480
+      ],
+      "dtype": "torch.uint8"
+    },
+    "image.side_right": {
+      "shape": [
+        1,
+        6,
+        3,
+        300,
+        480
+      ],
+      "dtype": "torch.uint8"
+    },
+    "goal.image.side_right": {
+      "shape": [
+        1,
+        3,
+        300,
+        480
+      ],
+      "dtype": "torch.uint8"
+    },
+    "camera_cond": {
+      "shape": [
+        1,
+        3,
+        13
+      ],
+      "dtype": "torch.float32"
+    },
+    "state.pose": {
+      "shape": [
+        1,
+        6,
+        2,
+        46
+      ],
+      "dtype": "torch.float32"
+    },
+    "side_valid": {
+      "shape": [
+        1,
+        2
+      ],
+      "dtype": "torch.bool"
+    },
+    "action.future_state": {
+      "shape": [
+        1,
+        6,
+        6,
+        2,
+        46
+      ],
+      "dtype": "torch.float32"
+    },
+    "action.commanded": {
+      "shape": [
+        1,
+        6,
+        6,
+        2,
+        46
+      ],
+      "dtype": "torch.float32"
+    },
+    "goal.xyz": {
+      "shape": [
+        1,
+        2,
+        3
+      ],
+      "dtype": "torch.float32"
+    },
+    "align_residual_ms": {
+      "shape": [
+        1,
+        6
+      ],
+      "dtype": "torch.float32"
+    }
+  },
+  "outputs": {
+    "policy.action": {
+      "shape": [
+        1,
+        2,
+        6,
+        60
+      ],
+      "dtype": "torch.float32"
+    }
+  }
+}

--- a/src/rmind/components/image.py
+++ b/src/rmind/components/image.py
@@ -1,0 +1,53 @@
+"""Image-pipeline pieces that the driving configs never needed."""
+
+from typing import final, override
+
+from torch import Tensor
+from torch.nn import Module
+from torch.nn import functional as F
+
+__all__ = ["LetterboxResize"]
+
+
+@final
+class LetterboxResize(Module):
+    """Uniform-scale resize to a square with symmetric padding.
+
+    Contract §7.2: the nero-arms cameras have DIFFERENT aspect ratios (`base`
+    1920x1080 = 16:9, `side_left`/`side_right` 1280x800 = 16:10). Feeding all
+    three through the driving configs' plain `Resize(S)` would scale x and y by
+    different factors, which:
+
+    * scales `fx` and `fy` independently, so the resolution-normalised
+      intrinsics in `camera_cond` (§7.1) no longer describe the pixels the
+      policy sees -- the conditioning vector's whole purpose is defeated;
+    * makes the same physical object a different shape in `base` than in the
+      side views, which a shared frozen ViT has no way to undo.
+
+    Letterboxing keeps the scale isotropic; the matching rewrite of the
+    conditioning vector is `rmind.data.nero.letterbox_camera_cond`.
+
+    NOTE: all three cameras still land on the SAME patch grid, so `base`'s wider
+    field of view gets coarser real-world coverage per patch than the side
+    cameras. Expected, and worth watching if the overhead view underperforms.
+    """
+
+    def __init__(self, *, size: int, fill: float = 0.0) -> None:
+        super().__init__()
+        self.size = size
+        self.fill = fill
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        *batch, c, h, w = x.shape
+        scale = min(self.size / w, self.size / h)
+        new_w, new_h = max(1, round(w * scale)), max(1, round(h * scale))
+        flat = x.reshape(-1, c, h, w)
+        if (new_w, new_h) != (w, h):
+            flat = F.interpolate(
+                flat.float(), size=(new_h, new_w), mode="bilinear", align_corners=False
+            ).to(x.dtype)
+        pad_w, pad_h = self.size - new_w, self.size - new_h
+        left, top = pad_w // 2, pad_h // 2
+        flat = F.pad(flat, (left, pad_w - left, top, pad_h - top), value=self.fill)
+        return flat.reshape(*batch, c, self.size, self.size)

--- a/src/rmind/components/image.py
+++ b/src/rmind/components/image.py
@@ -43,7 +43,9 @@ class LetterboxResize(Module):
 
     def __init__(self, *, size: int | tuple[int, int], fill: float = 0.0) -> None:
         super().__init__()
-        self.size: tuple[int, int] = (size, size) if isinstance(size, int) else tuple(size)
+        self.size: tuple[int, int] = (
+            (size, size) if isinstance(size, int) else tuple(size)
+        )
         self.fill = fill
 
     @override

--- a/src/rmind/components/image.py
+++ b/src/rmind/components/image.py
@@ -11,43 +11,53 @@ __all__ = ["LetterboxResize"]
 
 @final
 class LetterboxResize(Module):
-    """Uniform-scale resize to a square with symmetric padding.
+    """Uniform-scale resize to a fixed grid with symmetric padding.
 
-    Contract §7.2: the nero-arms cameras have DIFFERENT aspect ratios (`base`
-    1920x1080 = 16:9, `side_left`/`side_right` 1280x800 = 16:10). Feeding all
-    three through the driving configs' plain `Resize(S)` would scale x and y by
-    different factors, which:
+    Why nero-arms needs this and the driving configs did not
+    -------------------------------------------------------
+    The three nero-arms cameras have different aspect ratios (contract §7.2:
+    `base` 1920x1080 = 16:9, `side_left`/`side_right` 1280x800 = 16:10), and
+    rbyte delivers each one **isotropically downscaled to its own grid** --
+    `base` `(270, 480)`, `side_*` `(300, 480)`. That choice keeps the
+    resolution-normalised intrinsics in `camera_cond` exactly valid with no
+    propagation work, but it means the three image tensors do **not** share H/W,
+    so unifying them is rmind's job, here.
 
-    * scales `fx` and `fy` independently, so the resolution-normalised
-      intrinsics in `camera_cond` (§7.1) no longer describe the pixels the
-      policy sees -- the conditioning vector's whole purpose is defeated;
-    * makes the same physical object a different shape in `base` than in the
-      side views, which a shared frozen ViT has no way to undo.
-
-    Letterboxing keeps the scale isotropic; the matching rewrite of the
+    A plain anisotropic `Resize` would be wrong twice over: it scales `fx` and
+    `fy` by different factors, so the conditioning vector stops describing the
+    pixels the policy sees; and it makes the same physical object a different
+    shape in `base` than in the side views, which a shared frozen ViT cannot
+    undo. Letterboxing keeps the scale isotropic. The matching rewrite of the
     conditioning vector is `rmind.data.nero.letterbox_camera_cond`.
 
-    NOTE: all three cameras still land on the SAME patch grid, so `base`'s wider
-    field of view gets coarser real-world coverage per patch than the side
-    cameras. Expected, and worth watching if the overhead view underperforms.
+    `size` may be a single int (square) or `(height, width)`. With
+    `(300, 480)` this pads `base` by 15 rows top and bottom and leaves the side
+    cameras untouched; a following isotropic resize to the ViT grid then needs
+    no further intrinsics correction.
+
+    NOTE: all three cameras land on the same patch grid, so `base`'s wider field
+    of view gets coarser real-world coverage per patch than the side cameras --
+    and `base` additionally spends 2 of its 10 patch rows on letterbox padding.
+    Expected; the first thing to look at if the overhead view underperforms.
     """
 
-    def __init__(self, *, size: int, fill: float = 0.0) -> None:
+    def __init__(self, *, size: int | tuple[int, int], fill: float = 0.0) -> None:
         super().__init__()
-        self.size = size
+        self.size: tuple[int, int] = (size, size) if isinstance(size, int) else tuple(size)
         self.fill = fill
 
     @override
     def forward(self, x: Tensor) -> Tensor:
         *batch, c, h, w = x.shape
-        scale = min(self.size / w, self.size / h)
+        target_h, target_w = self.size
+        scale = min(target_w / w, target_h / h)
         new_w, new_h = max(1, round(w * scale)), max(1, round(h * scale))
         flat = x.reshape(-1, c, h, w)
         if (new_w, new_h) != (w, h):
             flat = F.interpolate(
                 flat.float(), size=(new_h, new_w), mode="bilinear", align_corners=False
             ).to(x.dtype)
-        pad_w, pad_h = self.size - new_w, self.size - new_h
+        pad_w, pad_h = target_w - new_w, target_h - new_h
         left, top = pad_w // 2, pad_h // 2
         flat = F.pad(flat, (left, pad_w - left, top, pad_h - top), value=self.fill)
-        return flat.reshape(*batch, c, self.size, self.size)
+        return flat.reshape(*batch, c, target_h, target_w)

--- a/src/rmind/components/timm_backbone.py
+++ b/src/rmind/components/timm_backbone.py
@@ -68,8 +68,14 @@ class TimmBackbone(nn.Module):
             # (B, prefix + P, D), final norm applied by timm's forward_features
             tokens = self.model.forward_features(x)
             tokens = tokens[:, self.model.num_prefix_tokens :]
-            grid = isqrt(tokens.shape[1])
-            x = tokens.transpose(1, 2).reshape(-1, tokens.shape[-1], grid, grid)
+            # NON-SQUARE inputs are legal (nero-arms feeds a 10x16 grid), so take
+            # the grid from the patch embedding rather than assuming isqrt(P).
+            # Identical result for square inputs.
+            grid = getattr(getattr(self.model, "patch_embed", None), "grid_size", None)
+            if grid is None or grid[0] * grid[1] != tokens.shape[1]:
+                side = isqrt(tokens.shape[1])
+                grid = (side, side)
+            x = tokens.transpose(1, 2).reshape(-1, tokens.shape[-1], *grid)
         else:
             x = self.model(x)[-1]
 

--- a/src/rmind/data/nero.py
+++ b/src/rmind/data/nero.py
@@ -1,0 +1,486 @@
+"""nero-arms data primitives: SE(3) pose representations, standardisation, layout.
+
+This module is the *shared boundary* named by the nero-arms data contract §5:
+`pose_quat_to_9d` / `pose_9d_to_quat` are referenced by the rbyte ingestion side
+and used identically by the policy and the action tokenizer here. Nothing in
+this file may become model-specific.
+
+Representation rules (contract §5)
+----------------------------------
+* storage / dataframe form: canonicalised quaternion, **7 floats** per pose
+  `(x, y, z, qx, qy, qz, qw)` with `qw >= 0`;
+* model-facing form: **9 floats** per pose, `3` translation + the **6D continuous
+  rotation** of Zhou et al. (the first two *columns* of `R`). Quaternions are
+  discontinuous as a regression/reconstruction target; 6D is not.
+
+Channel layout of the 60-dim per-side vector (contract §6.1)
+------------------------------------------------------------
+The contract specifies the *blocks* but not their order within the 60 dims, so
+this module **defines** it, and `POSE_BLOCK_LAYOUT` is the single source of truth
+that both sides must agree on:
+
+    [ arm_world      : 9  ]  (t3 + r6)   indices  0..8
+    [ thumb_rel_hub  : 9  ]              indices  9..17
+    [ index_rel_hub  : 9  ]              indices 18..26
+    [ middle_rel_hub : 9  ]              indices 27..35
+    [ ring_rel_hub   : 9  ]              indices 36..44
+    [ little_rel_hub : 9  ]              indices 45..53
+    [ hub_orientation: 6  ]  (r6 only)   indices 54..59
+                       ---
+                        60
+
+⚠️ CONTRACT GAP: §5 names only the 7<->9 pose pair, but the hub-orientation block
+is rotation-only, so a 4<->6 pair is also needed. It is provided here as
+`quat_to_rot6d` / `rot6d_to_quat`; the contract should name it.
+"""
+
+import json
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final, Self, final, override
+
+import torch
+from torch import Tensor, nn
+
+__all__ = [
+    "BIMANUAL_DIM",
+    "NUM_SIDES",
+    "POSE_9D_DIM",
+    "POSE_BLOCK_LAYOUT",
+    "POSE_QUAT_DIM",
+    "ROTATION_INDICES",
+    "SIDE_DIM",
+    "TRANSLATION_INDICES",
+    "PoseStandardizer",
+    "canonicalize_quat",
+    "geodesic_angle_error",
+    "letterbox_camera_cond",
+    "pose_9d_to_quat",
+    "pose_quat_to_9d",
+    "quat_to_rot6d",
+    "quat_to_rotmat",
+    "rot6d_to_quat",
+    "rot6d_to_rotmat",
+    "rotmat_to_quat",
+    "rotmat_to_rot6d",
+    "translation_rotation_split",
+]
+
+
+@final
+@dataclass(frozen=True)
+class PoseBlock:
+    name: str
+    offset: int
+    has_translation: bool
+
+    @property
+    def width(self) -> int:
+        return 9 if self.has_translation else 6
+
+    @property
+    def translation_slice(self) -> slice:
+        if not self.has_translation:
+            msg = f"block {self.name} has no translation"
+            raise ValueError(msg)
+        return slice(self.offset, self.offset + 3)
+
+    @property
+    def rotation_slice(self) -> slice:
+        start = self.offset + (3 if self.has_translation else 0)
+        return slice(start, start + 6)
+
+
+def _layout() -> tuple[PoseBlock, ...]:
+    names = (
+        "arm_world",
+        "thumb_rel_hub",
+        "index_rel_hub",
+        "middle_rel_hub",
+        "ring_rel_hub",
+        "little_rel_hub",
+    )
+    blocks: list[PoseBlock] = []
+    offset = 0
+    for name in names:
+        blocks.append(PoseBlock(name=name, offset=offset, has_translation=True))
+        offset += 9
+    blocks.append(
+        PoseBlock(name="hub_orientation", offset=offset, has_translation=False)
+    )
+    return tuple(blocks)
+
+
+POSE_BLOCK_LAYOUT: Final[tuple[PoseBlock, ...]] = _layout()
+SIDE_DIM: Final[int] = sum(block.width for block in POSE_BLOCK_LAYOUT)  # 60
+NUM_SIDES: Final[int] = 2
+#: storage form (contract §5.2) and model-facing form (§5.3) widths, per pose
+POSE_QUAT_DIM: Final[int] = 7
+POSE_9D_DIM: Final[int] = 9
+BIMANUAL_DIM: Final[int] = NUM_SIDES * SIDE_DIM  # 120
+
+TRANSLATION_INDICES: Final[tuple[int, ...]] = tuple(
+    i
+    for block in POSE_BLOCK_LAYOUT
+    if block.has_translation
+    for i in range(block.translation_slice.start, block.translation_slice.stop)
+)  # 18 dims
+ROTATION_INDICES: Final[tuple[int, ...]] = tuple(
+    i
+    for block in POSE_BLOCK_LAYOUT
+    for i in range(block.rotation_slice.start, block.rotation_slice.stop)
+)  # 42 dims
+
+# ------------------------------------------------------------------ rotations
+
+
+def canonicalize_quat(q: Tensor) -> Tensor:
+    """Remove the quaternion double cover: flip so `qw >= 0`.
+
+    `q` is `(..., 4)` ordered `(qx, qy, qz, qw)` -- the contract's storage order.
+    13-21% of the dummy's arm samples have `qw < 0`; without this every
+    downstream regressor/quantiser wastes capacity on the sign flip (§5).
+    """
+    sign = torch.where(
+        q[..., 3:4] < 0, -torch.ones_like(q[..., 3:4]), torch.ones_like(q[..., 3:4])
+    )
+    return q * sign
+
+
+def quat_to_rotmat(q: Tensor) -> Tensor:
+    """`(..., 4)` `(qx, qy, qz, qw)` -> `(..., 3, 3)` rotation matrix."""
+    # NOTE: a NEW name, never `q /= ...`. `q` is frequently a view into a caller's
+    # pose tensor and an in-place normalisation would silently mutate it.
+    unit = q / q.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+    x, y, z, w = unit.unbind(-1)
+    return torch.stack(
+        [
+            1 - 2 * (y * y + z * z),
+            2 * (x * y - z * w),
+            2 * (x * z + y * w),
+            2 * (x * y + z * w),
+            1 - 2 * (x * x + z * z),
+            2 * (y * z - x * w),
+            2 * (x * z - y * w),
+            2 * (y * z + x * w),
+            1 - 2 * (x * x + y * y),
+        ],
+        dim=-1,
+    ).unflatten(-1, (3, 3))
+
+
+def rotmat_to_quat(r: Tensor) -> Tensor:
+    """`(..., 3, 3)` -> canonical `(..., 4)` `(qx, qy, qz, qw)` with `qw >= 0`.
+
+    Shepperd's method: pick the largest of the four candidate denominators, so
+    the result is numerically stable for every rotation including `w ~ 0`.
+    """
+    m = r.reshape(*r.shape[:-2], 9).unbind(-1)
+    m00, m01, m02, m10, m11, m12, m20, m21, m22 = m
+
+    # the four candidates, each stable near its own maximum
+    candidates = torch.stack(
+        [
+            torch.stack([m21 - m12, m02 - m20, m10 - m01, 1 + m00 + m11 + m22], dim=-1),
+            torch.stack([1 + m00 - m11 - m22, m01 + m10, m02 + m20, m21 - m12], dim=-1),
+            torch.stack([m01 + m10, 1 - m00 + m11 - m22, m12 + m21, m02 - m20], dim=-1),
+            torch.stack([m02 + m20, m12 + m21, 1 - m00 - m11 + m22, m10 - m01], dim=-1),
+        ],
+        dim=-2,
+    )  # (..., 4, 4)
+    trace = 1 + m00 + m11 + m22
+    magnitudes = torch.stack(
+        [trace, 1 + m00 - m11 - m22, 1 - m00 + m11 - m22, 1 - m00 - m11 + m22], dim=-1
+    )
+    best = magnitudes.argmax(dim=-1, keepdim=True)[..., None].expand(
+        *magnitudes.shape[:-1], 1, 4
+    )
+    picked = candidates.gather(-2, best).squeeze(-2)
+    return canonicalize_quat(
+        picked / picked.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+    )
+
+
+def rotmat_to_rot6d(r: Tensor) -> Tensor:
+    """`(..., 3, 3)` -> `(..., 6)`: the first two COLUMNS of `R` (Zhou et al.)."""
+    return r[..., :, :2].transpose(-2, -1).reshape(*r.shape[:-2], 6)
+
+
+def rot6d_to_rotmat(x: Tensor) -> Tensor:
+    """`(..., 6)` -> `(..., 3, 3)` via Gram-Schmidt.
+
+    This is a PROJECTION, not an inverse: an arbitrary 6-vector is mapped onto
+    the nearest (in the Gram-Schmidt sense) element of SO(3). `rotmat_to_rot6d`
+    followed by this is the identity; the reverse composition is not.
+    """
+    a1, a2 = x[..., :3], x[..., 3:]
+    b1 = a1 / a1.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+    # NOTE: a NEW name. `a2` is a VIEW into the caller's `x`; `a2 -= ...` would
+    # silently corrupt the caller's tensor (and this function is called on
+    # prediction/target slices inside the error metrics).
+    orthogonal = a2 - (b1 * a2).sum(dim=-1, keepdim=True) * b1
+    b2 = orthogonal / orthogonal.norm(dim=-1, keepdim=True).clamp_min(1e-12)
+    b3 = torch.cross(b1, b2, dim=-1)
+    return torch.stack([b1, b2, b3], dim=-1)  # columns
+
+
+def quat_to_rot6d(q: Tensor) -> Tensor:
+    """Rotation-only 4 -> 6. Needed by the hub-orientation block (contract gap)."""
+    return rotmat_to_rot6d(quat_to_rotmat(canonicalize_quat(q)))
+
+
+def rot6d_to_quat(x: Tensor) -> Tensor:
+    """Rotation-only 6 -> 4, canonical (`qw >= 0`)."""
+    return rotmat_to_quat(rot6d_to_rotmat(x))
+
+
+# ---------------------------------------------------------------------- poses
+
+
+def pose_quat_to_9d(pose: Tensor) -> Tensor:
+    """Contract §5: `(..., 7)` `(x,y,z,qx,qy,qz,qw)` -> `(..., 9)` `(t3, rot6d)`.
+
+    Canonicalises the quaternion on the way through, so this is safe to call on
+    raw storage-form data that has not been canonicalised at ingestion.
+
+    Raises:
+        ValueError: if the last dimension is not `POSE_QUAT_DIM`.
+    """
+    if pose.shape[-1] != POSE_QUAT_DIM:
+        msg = f"expected a 7-dim pose, got {pose.shape[-1]}"
+        raise ValueError(msg)
+    return torch.cat([pose[..., :3], quat_to_rot6d(pose[..., 3:])], dim=-1)
+
+
+def pose_9d_to_quat(pose: Tensor) -> Tensor:
+    """Contract §5: `(..., 9)` `(t3, rot6d)` -> `(..., 7)` with a canonical quaternion.
+
+    Raises:
+        ValueError: if the last dimension is not `POSE_9D_DIM`.
+    """
+    if pose.shape[-1] != POSE_9D_DIM:
+        msg = f"expected a 9-dim pose, got {pose.shape[-1]}"
+        raise ValueError(msg)
+    return torch.cat([pose[..., :3], rot6d_to_quat(pose[..., 3:])], dim=-1)
+
+
+def translation_rotation_split(x: Tensor) -> tuple[Tensor, Tensor]:
+    """Split a `(..., 60)` per-side vector into its translation and rotation channels.
+
+    Raises:
+        ValueError: if the last dimension is not `SIDE_DIM`.
+
+    Returns `(translation (..., 18), rotation (..., 42))`. This is what makes the
+    contract's "report translation and rotation error SEPARATELY" (§5.5)
+    mechanically possible.
+    """
+    if x.shape[-1] != SIDE_DIM:
+        msg = f"expected a {SIDE_DIM}-dim per-side vector, got {x.shape[-1]}"
+        raise ValueError(msg)
+    index = torch.as_tensor(TRANSLATION_INDICES, device=x.device)
+    rot_index = torch.as_tensor(ROTATION_INDICES, device=x.device)
+    return x.index_select(-1, index), x.index_select(-1, rot_index)
+
+
+def pose_error_metrics(pred: Tensor, target: Tensor) -> dict[str, Tensor]:
+    """Physical-unit reconstruction error for `(..., 60)` UNSTANDARDISED pose vectors.
+
+    Contract §5.5 demands translation and rotation error be reported separately.
+    A standardised scalar L1 is not interpretable, so this reports:
+
+    * `translation_mm` -- mean Euclidean distance per translation block, in mm;
+    * `rotation_deg`   -- mean geodesic angle per rotation block, in degrees.
+
+    Both are averaged over blocks and over the leading batch dimensions.
+    """
+    translation: list[Tensor] = []
+    rotation: list[Tensor] = []
+    for block in POSE_BLOCK_LAYOUT:
+        if block.has_translation:
+            delta = (
+                pred[..., block.translation_slice]
+                - target[..., block.translation_slice]
+            )
+            translation.append(delta.norm(dim=-1))
+        rotation.append(
+            geodesic_angle_error(
+                pred[..., block.rotation_slice], target[..., block.rotation_slice]
+            )
+        )
+    return {
+        "translation_mm": torch.stack(translation, dim=-1).mean() * 1000.0,
+        "rotation_deg": torch.stack(rotation, dim=-1).mean(),
+    }
+
+
+def geodesic_angle_error(a: Tensor, b: Tensor) -> Tensor:
+    """Per-rotation geodesic angle in DEGREES between two `(..., 6)` 6D rotations.
+
+    Both sides are projected onto SO(3) first, so this is well-defined even for a
+    reconstruction that has drifted off the manifold.
+    """
+    ra, rb = rot6d_to_rotmat(a), rot6d_to_rotmat(b)
+    trace = (ra.transpose(-2, -1) @ rb).diagonal(dim1=-2, dim2=-1).sum(-1)
+    return torch.rad2deg(torch.acos(((trace - 1) / 2).clamp(-1.0, 1.0)))
+
+
+# ------------------------------------------------------------- standardisation
+
+
+@final
+class PoseStandardizer(nn.Module):
+    """Per-channel standardisation over the 60-dim per-side pose vector (§5.4).
+
+    Translations are ~0.06-0.7 m while 6D rotation components are ~1, so an
+    unstandardised L2/L1 reconstruction loss lets rotation error swamp
+    translation error. Statistics are computed over the **training split only**
+    and shipped as a versioned artifact alongside the tokenizer checkpoint
+    (`save` / `load`).
+
+    The buffers are registered (not parameters), so they travel inside the
+    checkpoint as well -- the JSON artifact is the human-auditable copy and the
+    provenance record.
+    """
+
+    VERSION: Final[int] = 1
+
+    # declared so the type checker sees the registered buffers as tensors
+    mean: Tensor
+    std: Tensor
+
+    def __init__(
+        self,
+        *,
+        mean: Tensor | Sequence[float] | None = None,
+        std: Tensor | Sequence[float] | None = None,
+        dim: int = SIDE_DIM,
+        eps: float = 1e-6,
+        source: str = "identity",
+    ) -> None:
+        super().__init__()
+        self.dim = dim
+        self.eps = eps
+        self.source = source
+        self.register_buffer(
+            "mean",
+            torch.zeros(dim)
+            if mean is None
+            else torch.as_tensor(mean, dtype=torch.float32),
+        )
+        self.register_buffer(
+            "std",
+            torch.ones(dim)
+            if std is None
+            else torch.as_tensor(std, dtype=torch.float32),
+        )
+
+    @classmethod
+    def from_samples(
+        cls, samples: Tensor, *, source: str = "train-split", **kwargs: object
+    ) -> Self:
+        """Fit from `(..., dim)` training-split samples (masked rows removed by the caller)."""
+        flat = samples.reshape(-1, samples.shape[-1]).float()
+        return cls(
+            mean=flat.mean(0),
+            std=flat.std(0).clamp_min(1e-6),
+            dim=samples.shape[-1],
+            source=source,
+            **kwargs,  # ty:ignore[invalid-argument-type]
+        )
+
+    def standardize(self, x: Tensor) -> Tensor:
+        return (x - self.mean) / (self.std + self.eps)
+
+    def unstandardize(self, x: Tensor) -> Tensor:
+        return x * (self.std + self.eps) + self.mean
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        return self.standardize(x)
+
+    # -------------------------------------------------------------- artifact
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "version": self.VERSION,
+            "dim": self.dim,
+            "eps": self.eps,
+            "source": self.source,
+            "layout": [
+                {"name": b.name, "offset": b.offset, "width": b.width}
+                for b in POSE_BLOCK_LAYOUT
+            ],
+            "translation_indices": list(TRANSLATION_INDICES),
+            "rotation_indices": list(ROTATION_INDICES),
+            "mean": self.mean.tolist(),
+            "std": self.std.tolist(),
+        }
+
+    def save(self, path: str | Path) -> Path:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _ = path.write_text(json.dumps(self.to_dict(), indent=2))
+        return path
+
+    @classmethod
+    def load(cls, path: str | Path) -> Self:
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        version = payload["version"]
+        if version != cls.VERSION:
+            msg = f"pose standardisation artifact version {version} != {cls.VERSION}"
+            raise ValueError(msg)
+        return cls(
+            mean=payload["mean"],
+            std=payload["std"],
+            dim=payload["dim"],
+            eps=payload["eps"],
+            source=payload["source"],
+        )
+
+
+# ------------------------------------------------------- camera conditioning
+
+#: contract §7.1: `fx/W, fy/H, cx/W, cy/H` (4) + `t_world_cam` (3) + `R_world_cam` 6D (6)
+CAMERA_COND_DIM: Final[int] = 13
+
+
+def letterbox_camera_cond(
+    cond: Tensor, *, source_size: Tensor, target_size: int
+) -> Tensor:
+    """Rewrite the 4 resolution-normalised intrinsics of `camera_cond` for a letterbox.
+
+    Contract §7.2: the three cameras have DIFFERENT aspect ratios (`base`
+    1920x1080 = 16:9, `side_*` 1280x800 = 16:10). Anisotropic resize to a square
+    patch grid would scale `fx` and `fy` by different factors and destroy the
+    geometric meaning of the conditioning vector, so the image pipeline
+    letterboxes (uniform scale + symmetric padding) to `target_size` -- and the
+    conditioning vector must be rewritten to match, otherwise the policy is told
+    intrinsics that no longer describe the pixels it is looking at.
+
+    With `s = min(S/W, S/H)`, `rx = sW/S`, `ry = sH/S`:
+
+        fx/S = rx * (fx/W)          cx/S = rx * (cx/W) + (1 - rx)/2
+        fy/S = ry * (fy/H)          cy/S = ry * (cy/H) + (1 - ry)/2
+
+    Extrinsics are untouched -- letterboxing does not move the camera.
+
+    Args:
+        cond: `(..., n_cameras, 13)`.
+        source_size: `(..., n_cameras, 2)` native `(W, H)` in pixels.
+        target_size: the square side the letterboxed image is resized to.
+    """
+    w, h = source_size[..., 0], source_size[..., 1]
+    scale = torch.minimum(target_size / w, target_size / h)
+    rx, ry = scale * w / target_size, scale * h / target_size
+    fx, fy, cx, cy = cond[..., 0], cond[..., 1], cond[..., 2], cond[..., 3]
+    return torch.cat(
+        [
+            torch.stack(
+                [rx * fx, ry * fy, rx * cx + (1 - rx) / 2, ry * cy + (1 - ry) / 2],
+                dim=-1,
+            ),
+            cond[..., 4:],
+        ],
+        dim=-1,
+    )

--- a/src/rmind/data/nero.py
+++ b/src/rmind/data/nero.py
@@ -51,6 +51,7 @@ __all__ = [
     "POSE_QUAT_DIM",
     "ROTATION_INDICES",
     "SIDE_DIM",
+    "STATE_QUAT_DIM",
     "TRANSLATION_INDICES",
     "PoseStandardizer",
     "canonicalize_quat",
@@ -64,6 +65,8 @@ __all__ = [
     "rot6d_to_rotmat",
     "rotmat_to_quat",
     "rotmat_to_rot6d",
+    "state_9d_to_quat",
+    "state_quat_to_9d",
     "translation_rotation_split",
 ]
 
@@ -118,6 +121,9 @@ NUM_SIDES: Final[int] = 2
 #: storage form (contract §5.2) and model-facing form (§5.3) widths, per pose
 POSE_QUAT_DIM: Final[int] = 7
 POSE_9D_DIM: Final[int] = 9
+#: per-side width of the STORAGE form: 6 poses x 7 + a 4-dim hub quaternion.
+#: rbyte emits this (contract §5.2); the model-facing 60 is produced here.
+STATE_QUAT_DIM: Final[int] = 6 * POSE_QUAT_DIM + 4  # 46
 BIMANUAL_DIM: Final[int] = NUM_SIDES * SIDE_DIM  # 120
 
 TRANSLATION_INDICES: Final[tuple[int, ...]] = tuple(
@@ -263,6 +269,45 @@ def pose_9d_to_quat(pose: Tensor) -> Tensor:
         msg = f"expected a 9-dim pose, got {pose.shape[-1]}"
         raise ValueError(msg)
     return torch.cat([pose[..., :3], rot6d_to_quat(pose[..., 3:])], dim=-1)
+
+
+def state_quat_to_9d(state: Tensor) -> Tensor:
+    """Per-side STORAGE form `(..., 46)` -> model-facing `(..., 60)`.
+
+    ⚠️ CONTRACT INCONSISTENCY (resolved in rbyte's favour): §5.2 specifies
+    canonical-quaternion storage (7 floats per pose) while §8 tabulated
+    `state.pose` as `(T, 2, 60)`. rbyte implements §5.2, so the loader emits
+    **46** per side -- 6 poses x 7 plus the hub's 4-dim orientation quaternion --
+    and the 9D expansion happens **here**, at the model boundary. This is the
+    mirror of `rbyte.io.nero.state_quat_to_9d`; the two must stay in step.
+
+    Raises:
+        ValueError: if the last dimension is not `STATE_QUAT_DIM`.
+    """
+    if state.shape[-1] != STATE_QUAT_DIM:
+        msg = f"expected a {STATE_QUAT_DIM}-dim per-side state, got {state.shape[-1]}"
+        raise ValueError(msg)
+    poses = state[..., : 6 * POSE_QUAT_DIM].unflatten(-1, (6, POSE_QUAT_DIM))
+    hub = state[..., 6 * POSE_QUAT_DIM :]
+    return torch.cat(
+        [pose_quat_to_9d(poses).flatten(-2, -1), quat_to_rot6d(hub)], dim=-1
+    )
+
+
+def state_9d_to_quat(state: Tensor) -> Tensor:
+    """Inverse of `state_quat_to_9d`: `(..., 60)` -> `(..., 46)`.
+
+    Raises:
+        ValueError: if the last dimension is not `SIDE_DIM`.
+    """
+    if state.shape[-1] != SIDE_DIM:
+        msg = f"expected a {SIDE_DIM}-dim per-side state, got {state.shape[-1]}"
+        raise ValueError(msg)
+    poses = state[..., : 6 * POSE_9D_DIM].unflatten(-1, (6, POSE_9D_DIM))
+    hub = state[..., 6 * POSE_9D_DIM :]
+    return torch.cat(
+        [pose_9d_to_quat(poses).flatten(-2, -1), rot6d_to_quat(hub)], dim=-1
+    )
 
 
 def translation_rotation_split(x: Tensor) -> tuple[Tensor, Tensor]:
@@ -446,33 +491,42 @@ CAMERA_COND_DIM: Final[int] = 13
 
 
 def letterbox_camera_cond(
-    cond: Tensor, *, source_size: Tensor, target_size: int
+    cond: Tensor, *, source_size: Tensor, target_size: tuple[int, int] | int
 ) -> Tensor:
     """Rewrite the 4 resolution-normalised intrinsics of `camera_cond` for a letterbox.
 
-    Contract §7.2: the three cameras have DIFFERENT aspect ratios (`base`
-    1920x1080 = 16:9, `side_*` 1280x800 = 16:10). Anisotropic resize to a square
-    patch grid would scale `fx` and `fy` by different factors and destroy the
-    geometric meaning of the conditioning vector, so the image pipeline
-    letterboxes (uniform scale + symmetric padding) to `target_size` -- and the
-    conditioning vector must be rewritten to match, otherwise the policy is told
-    intrinsics that no longer describe the pixels it is looking at.
+    Contract §7.2 + the rbyte hand-off: rbyte delivers each camera **isotropically
+    downscaled to its own H/W** (`base` 270x480, `side_*` 300x480), which keeps
+    the normalised intrinsics exactly valid but leaves the three streams on
+    DIFFERENT grids. Unifying them is rmind's job, and it must be a letterbox
+    (uniform scale + symmetric padding): an anisotropic resize would scale `fx`
+    and `fy` independently and destroy the geometric meaning of this vector.
+    Padding does change the normalisation denominator, so the vector is rewritten
+    to match -- otherwise the policy is told intrinsics that no longer describe
+    the pixels it is looking at.
 
-    With `s = min(S/W, S/H)`, `rx = sW/S`, `ry = sH/S`:
+    With target `(TH, TW)`, `s = min(TW/W, TH/H)`, `rx = sW/TW`, `ry = sH/TH`:
 
-        fx/S = rx * (fx/W)          cx/S = rx * (cx/W) + (1 - rx)/2
-        fy/S = ry * (fy/H)          cy/S = ry * (cy/H) + (1 - ry)/2
+        fx/TW = rx * (fx/W)          cx/TW = rx * (cx/W) + (1 - rx)/2
+        fy/TH = ry * (fy/H)          cy/TH = ry * (cy/H) + (1 - ry)/2
+
+    A subsequent ISOTROPIC resize with no padding leaves all four untouched
+    (both numerator and denominator scale together), which is why the pipeline
+    pads first and resizes second.
 
     Extrinsics are untouched -- letterboxing does not move the camera.
 
     Args:
         cond: `(..., n_cameras, 13)`.
         source_size: `(..., n_cameras, 2)` native `(W, H)` in pixels.
-        target_size: the square side the letterboxed image is resized to.
+        target_size: the target `(height, width)`, or one int for a square.
     """
+    height, width = (
+        (target_size, target_size) if isinstance(target_size, int) else target_size
+    )
     w, h = source_size[..., 0], source_size[..., 1]
-    scale = torch.minimum(target_size / w, target_size / h)
-    rx, ry = scale * w / target_size, scale * h / target_size
+    scale = torch.minimum(width / w, height / h)
+    rx, ry = scale * w / width, scale * h / height
     fx, fy, cx, cy = cond[..., 0], cond[..., 1], cond[..., 2], cond[..., 3]
     return torch.cat(
         [

--- a/src/rmind/datamodules/nero_random.py
+++ b/src/rmind/datamodules/nero_random.py
@@ -1,0 +1,271 @@
+"""Structured synthetic nero-arms batches at the EXACT contract §8 shapes.
+
+This exists for smoke runs and tests, not for research. Two properties matter:
+
+1. **The shapes are the real ones** (contract §8): 3 cameras, `(T, 2, 60)` state,
+   `(T, H, 2, 60)` action, `(3, 13)` camera conditioning, `(3, 3, H, W)` goal
+   images, `(2,)` `side_valid`. A smoke run on the old driving shapes proves
+   nothing.
+2. **The poses are structured SE(3), not uniform noise.** A residual-VQ fitted to
+   uniform-random 9D vectors has nothing to compress: translation and rotation
+   error both sit at the data std and "rotation is garbage" becomes
+   indistinguishable from the real silent failure of §5.5. So trajectories are
+   smooth SE(3) walks driven by a ~14-DOF latent (see `_side_trajectory`), with
+   contract-plausible magnitudes (§4), canonicalised quaternions (§5), and an
+   action chunk that is the genuine future of the state trajectory (§6.2).
+
+Images are uniform noise -- there is no synthetic-vision claim here, only a
+shape/dtype/throughput claim.
+"""
+
+from collections.abc import Iterator
+from typing import Any, final, override
+
+import torch
+from torch import Tensor
+
+from rmind.data.nero import (
+    BIMANUAL_DIM,
+    CAMERA_COND_DIM,
+    NUM_SIDES,
+    SIDE_DIM,
+    canonicalize_quat,
+    pose_quat_to_9d,
+    quat_to_rot6d,
+)
+
+__all__ = [
+    "CAMERA_NAMES",
+    "CAMERA_RESOLUTIONS",
+    "NeroRandomDataset",
+    "nero_random_batch",
+]
+
+#: contract §8
+CAMERA_NAMES: tuple[str, ...] = ("base", "side_left", "side_right")
+#: contract §7.2 -- DIFFERENT resolutions and aspect ratios per camera
+CAMERA_RESOLUTIONS: dict[str, tuple[int, int]] = {
+    "base": (1920, 1080),
+    "side_left": (1280, 800),
+    "side_right": (1280, 800),
+}
+
+#: contract §4: start-pose spread std ~[0.037, 0.021, 0.009] m, within-episode
+#: motion range ~[0.32, 0.19, 0.06] m -- i.e. episodes START in a narrow region
+#: and MOVE a lot. That ratio is what makes the space compressible at all, so it
+#: is reproduced here rather than sampling starts uniformly.
+_START_XYZ = torch.tensor([0.30, 0.10, 0.05])
+_START_SPREAD_XYZ = torch.tensor([0.037, 0.021, 0.009])
+_STEP_XYZ = torch.tensor([0.010, 0.006, 0.002])  # per 30 Hz frame
+#: nominal fingertip offsets from the hub (a hand in a neutral grasp posture)
+_FINGER_NOMINAL = torch.tensor([
+    [0.04, -0.03, 0.02],  # thumb
+    [0.08, -0.01, 0.01],  # index
+    [0.08, 0.01, 0.00],  # middle
+    [0.07, 0.03, -0.01],  # ring
+    [0.06, 0.05, -0.02],  # little
+])
+#: per-episode fingertip jitter. Deliberately SMALL: on a real hand the
+#: fingertip offset is determined by the finger's curl, not independently random
+#: per episode. Large i.i.d. jitter here would make the 15 finger translation
+#: dims incompressible and the translation metric uninformative.
+_FINGER_SPREAD = 0.001
+#: direction a fingertip travels as its curl scalar goes 0 -> 1, and the axis it
+#: rotates about. One scalar per finger drives both -- fingers are kinematically
+#: coupled, which is what makes the 45 finger dims compressible.
+_FINGER_CURL_DIRECTION = torch.tensor([
+    [-0.030, 0.020, -0.025],
+    [-0.045, 0.005, -0.030],
+    [-0.048, 0.000, -0.032],
+    [-0.042, -0.005, -0.028],
+    [-0.035, -0.010, -0.024],
+])
+_FINGER_AXIS = torch.tensor([
+    [0.0, 1.0, 0.3],
+    [0.0, 1.0, 0.0],
+    [0.0, 1.0, 0.0],
+    [0.0, 1.0, -0.1],
+    [0.0, 1.0, -0.2],
+])
+
+
+def _axis_angle_quat(axis: Tensor, angle: Tensor) -> Tensor:
+    """`(..., 3)` unit axis and `(...)` angle -> canonical quaternion `(..., 4)`."""
+    # NOTE: a NEW name -- `axis` is typically an `expand`ed view, on which an
+    # in-place op is either an error or silent corruption.
+    unit = axis / axis.norm(dim=-1, keepdim=True).clamp_min(1e-9)
+    half = angle[..., None] / 2
+    return canonicalize_quat(torch.cat([unit * half.sin(), half.cos()], dim=-1))
+
+
+def _smooth_walk(
+    steps: int, dim: int, generator: torch.Generator, *, scale: float
+) -> Tensor:
+    """`(steps, dim)` zero-mean smooth random walk (cumulative Gaussian increments)."""
+    return (scale * torch.randn(steps, dim, generator=generator)).cumsum(0)
+
+
+def _side_trajectory(steps: int, generator: torch.Generator) -> Tensor:
+    """`(steps, 60)` per-side state trajectory in the contract §6.1 layout.
+
+    ⚠️ Generated from a LOW-DIMENSIONAL latent, deliberately. A human hand has
+    ~20 DOF; the contract's 60-dim 9D encoding is a redundant overparameterisation
+    of that, and it is exactly this redundancy that a VQ codebook exploits.
+    Sampling all 60 dims independently would make the action space incompressible
+    -- the tokenizer would score at the mean baseline and the reported numbers
+    would say nothing about the recipe. The latent here is:
+
+        6  arm pose (translation walk + orientation walk)
+        3  hub orientation walk
+        5  per-finger curl (one scalar per finger, driving both the fingertip
+           offset and its orientation -- i.e. fingers are kinematically coupled
+           to their curl, as on a real hand)
+    """
+    # --- arm in world (contract §4 magnitudes)
+    arm_start = _START_XYZ + _START_SPREAD_XYZ * torch.randn(3, generator=generator)
+    arm_t = arm_start + _smooth_walk(steps, 3, generator, scale=1.0) * _STEP_XYZ
+    arm_axis = torch.randn(3, generator=generator)
+    arm_angle = 0.35 * torch.randn(1, generator=generator) + _smooth_walk(
+        steps, 1, generator, scale=0.03
+    ).squeeze(-1)
+    arm_q = _axis_angle_quat(arm_axis.expand(steps, 3), arm_angle)
+    columns: list[Tensor] = [pose_quat_to_9d(torch.cat([arm_t, arm_q], dim=-1))]
+
+    # --- fingers, each driven by ONE curl scalar
+    curl = 0.6 * torch.rand(5, generator=generator)[None, :] + _smooth_walk(
+        steps, 5, generator, scale=0.02
+    )
+    for finger in range(5):
+        c = curl[:, finger : finger + 1]
+        translation = (
+            _FINGER_NOMINAL[finger]
+            + c * _FINGER_CURL_DIRECTION[finger]
+            + _FINGER_SPREAD * torch.randn(1, 3, generator=generator)
+        )
+        rotation = _axis_angle_quat(
+            _FINGER_AXIS[finger].expand(steps, 3), c.squeeze(-1) * 1.2
+        )
+        columns.append(pose_quat_to_9d(torch.cat([translation, rotation], dim=-1)))
+
+    # --- hub orientation (rotation only)
+    hub_axis = torch.randn(3, generator=generator)
+    hub_angle = 0.25 * torch.randn(1, generator=generator) + _smooth_walk(
+        steps, 1, generator, scale=0.02
+    ).squeeze(-1)
+    columns.append(
+        quat_to_rot6d(_axis_angle_quat(hub_axis.expand(steps, 3), hub_angle))
+    )
+
+    return torch.cat(columns, dim=-1)
+
+
+def nero_random_batch(  # noqa: PLR0913
+    *,
+    batch_size: int = 2,
+    episode_length: int = 6,
+    action_horizon: int = 6,
+    image_size: int = 224,
+    both_sides: bool = True,
+    seed: int = 0,
+    device: torch.device | str = "cpu",
+) -> dict[str, Any]:
+    """One batch at the contract §8 shapes, images already letterboxed to a square.
+
+    `both_sides=False` reproduces the dummy recording: `side_valid = [False, True]`
+    (left absent) with the invalid side's state and action zeroed, which is what
+    the contract §6.1 mandates and what the policy's mask path must handle.
+    """
+    generator = torch.Generator().manual_seed(seed)
+    steps = episode_length + action_horizon
+
+    trajectories = torch.stack([
+        torch.stack(
+            [_side_trajectory(steps, generator) for _ in range(NUM_SIDES)], dim=1
+        )
+        for _ in range(batch_size)
+    ])  # (b, steps, 2, 60)
+
+    state = trajectories[:, :episode_length]  # (b, T, 2, 60)
+    action = torch.stack(
+        [
+            trajectories[:, t + 1 : t + 1 + action_horizon]
+            for t in range(episode_length)
+        ],
+        dim=1,
+    )  # (b, T, H, 2, 60) -- §6.2: action(t) = future states [t+1 .. t+H]
+
+    valid = torch.ones(batch_size, NUM_SIDES, dtype=torch.bool)
+    if not both_sides:
+        valid[:, 0] = False
+        state = state * valid[:, None, :, None]  # noqa: PLR6104
+        action = action * valid[:, None, None, :, None]  # noqa: PLR6104
+
+    images = {
+        f"image.{name}": torch.randint(
+            0,
+            256,
+            (batch_size, episode_length, 3, image_size, image_size),
+            dtype=torch.uint8,
+        )
+        for name in CAMERA_NAMES
+    }
+
+    batch: dict[str, Any] = {
+        **images,
+        "goal.image": torch.randint(
+            0,
+            256,
+            (batch_size, len(CAMERA_NAMES), 3, image_size, image_size),
+            dtype=torch.uint8,
+        ),
+        # ⚠️ randomised on purpose: with contract §7 `placeholder: true` the real
+        # camera_cond is a CONSTANT (zero intrinsics, identity extrinsics), which
+        # would leave this path untested. Randomising exercises it.
+        "camera_cond": torch.randn(batch_size, len(CAMERA_NAMES), CAMERA_COND_DIM),
+        "state.pose": state,
+        "side_valid": valid,
+        "action.future_state": action,
+        "goal.xyz": torch.randn(batch_size, NUM_SIDES, 3) * _START_XYZ,
+        "align_residual_ms": torch.rand(batch_size, episode_length) * 3.0,
+    }
+    return {k: v.to(device) for k, v in batch.items()}
+
+
+@final
+class NeroRandomDataset(torch.utils.data.IterableDataset):
+    """Infinite stream of `nero_random_batch` batches (already collated)."""
+
+    def __init__(
+        self, *, num_batches: int = 1000, seed: int = 0, **kwargs: Any
+    ) -> None:
+        super().__init__()
+        self.num_batches = num_batches
+        self.seed = seed
+        self.kwargs = kwargs
+
+    def __len__(self) -> int:
+        return self.num_batches
+
+    @override
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        for i in range(self.num_batches):
+            yield nero_random_batch(seed=self.seed + i, **self.kwargs)
+
+
+@final
+class NeroRandomDataLoader:
+    """Trivial `DataLoader`-shaped wrapper (the dataset already yields batches)."""
+
+    def __init__(
+        self, *, num_batches: int = 1000, seed: int = 0, **kwargs: Any
+    ) -> None:
+        self.dataset = NeroRandomDataset(num_batches=num_batches, seed=seed, **kwargs)
+
+    def __len__(self) -> int:
+        return len(self.dataset)
+
+    def __iter__(self) -> Iterator[dict[str, Any]]:
+        return iter(self.dataset)
+
+
+assert SIDE_DIM * NUM_SIDES == BIMANUAL_DIM  # noqa: S101

--- a/src/rmind/datamodules/nero_random.py
+++ b/src/rmind/datamodules/nero_random.py
@@ -32,6 +32,7 @@ from rmind.data.nero import (
     canonicalize_quat,
     pose_quat_to_9d,
     quat_to_rot6d,
+    state_9d_to_quat,
 )
 
 __all__ = [
@@ -43,11 +44,20 @@ __all__ = [
 
 #: contract §8
 CAMERA_NAMES: tuple[str, ...] = ("base", "side_left", "side_right")
-#: contract §7.2 -- DIFFERENT resolutions and aspect ratios per camera
+#: contract §7.2 -- DIFFERENT native resolutions and aspect ratios per camera
 CAMERA_RESOLUTIONS: dict[str, tuple[int, int]] = {
     "base": (1920, 1080),
     "side_left": (1280, 800),
     "side_right": (1280, 800),
+}
+#: ⚠️ what rbyte actually delivers: each camera ISOTROPICALLY downscaled to its
+#: OWN grid `(H, W)`, so the three image tensors do NOT share H/W. Unifying them
+#: is rmind's job (`LetterboxResize`), and a consumer that assumes a uniform grid
+#: across cameras breaks here rather than silently.
+CAMERA_GRIDS: dict[str, tuple[int, int]] = {
+    "base": (270, 480),
+    "side_left": (300, 480),
+    "side_right": (300, 480),
 }
 
 #: contract §4: start-pose spread std ~[0.037, 0.021, 0.009] m, within-episode
@@ -164,12 +174,20 @@ def nero_random_batch(  # noqa: PLR0913
     batch_size: int = 2,
     episode_length: int = 6,
     action_horizon: int = 6,
-    image_size: int = 224,
+    grids: dict[str, tuple[int, int]] | None = None,
     both_sides: bool = True,
     seed: int = 0,
     device: torch.device | str = "cpu",
 ) -> dict[str, Any]:
-    """One batch at the contract §8 shapes, images already letterboxed to a square.
+    """One batch in the shapes rbyte actually emits.
+
+    Note what is deliberately NOT normalised away here, because the model has to
+    cope with all three:
+
+    * the three cameras are on **different grids** (`CAMERA_GRIDS`);
+    * `goal.image.*` is **three separate keys**, each on its own grid;
+    * state and action are the contract §5.2 **storage form, 46 per side**
+      (quaternions), not the 60-dim 9D form -- the expansion is the model's job.
 
     `both_sides=False` reproduces the dummy recording: `side_valid = [False, True]`
     (left absent) with the invalid side's state and action zeroed, which is what
@@ -200,31 +218,36 @@ def nero_random_batch(  # noqa: PLR0913
         state = state * valid[:, None, :, None]  # noqa: PLR6104
         action = action * valid[:, None, None, :, None]  # noqa: PLR6104
 
-    images = {
-        f"image.{name}": torch.randint(
-            0,
-            256,
-            (batch_size, episode_length, 3, image_size, image_size),
-            dtype=torch.uint8,
+    # back to the 46-dim storage form the loader emits
+    state_quat = state_9d_to_quat(state)
+    action_quat = state_9d_to_quat(action)
+
+    images: dict[str, Tensor] = {}
+    for name in CAMERA_NAMES:
+        h, w = (grids or CAMERA_GRIDS)[name]
+        images[f"image.{name}"] = torch.randint(
+            0, 256, (batch_size, episode_length, 3, h, w), dtype=torch.uint8
         )
-        for name in CAMERA_NAMES
-    }
+        # ⚠️ THREE SEPARATE goal keys, not one stacked tensor: rbyte cannot index
+        # one stream by several columns and the final frame index differs per
+        # camera (199 vs 200 in the dummy).
+        images[f"goal.image.{name}"] = torch.randint(
+            0, 256, (batch_size, 3, h, w), dtype=torch.uint8
+        )
 
     batch: dict[str, Any] = {
         **images,
-        "goal.image": torch.randint(
-            0,
-            256,
-            (batch_size, len(CAMERA_NAMES), 3, image_size, image_size),
-            dtype=torch.uint8,
-        ),
         # ⚠️ randomised on purpose: with contract §7 `placeholder: true` the real
         # camera_cond is a CONSTANT (zero intrinsics, identity extrinsics), which
         # would leave this path untested. Randomising exercises it.
         "camera_cond": torch.randn(batch_size, len(CAMERA_NAMES), CAMERA_COND_DIM),
-        "state.pose": state,
+        "state.pose": state_quat,
         "side_valid": valid,
-        "action.future_state": action,
+        "action.future_state": action_quat,
+        # §6.2 reserves this as an alias and rbyte currently materialises it as a
+        # byte-identical duplicate (~199 MB of a ~470 MB TensorDict). The policy
+        # reads exactly ONE of the two, so the duplicate is never paid for here.
+        "action.commanded": action_quat,
         "goal.xyz": torch.randn(batch_size, NUM_SIDES, 3) * _START_XYZ,
         "align_residual_ms": torch.rand(batch_size, episode_length) * 3.0,
     }

--- a/src/rmind/models/nero_patch_policy.py
+++ b/src/rmind/models/nero_patch_policy.py
@@ -147,6 +147,7 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
         camera_cond: Path = ("camera_cond",),
         state: Path = ("state.pose",),
         side_valid: Path = ("side_valid",),
+        goal_valid: Path = ("goal_valid",),
         chunk: Path = ("action.future_state",),
         use_goal_image: bool = True,
         # rbyte emits the contract §5.2 STORAGE form (46 per side: 6 poses x 7 +
@@ -214,6 +215,7 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
         self.camera_cond: Path = camera_cond
         self.state: Path = state
         self.side_valid: Path = side_valid
+        self.goal_valid: Path = goal_valid
         self.chunk: Path = chunk
         self.use_goal_image = use_goal_image
         self.convert_state_to_9d = convert_state_to_9d
@@ -230,6 +232,7 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
             "camera_cond": camera_cond,
             "state": state,
             "side_valid": side_valid,
+            "goal_valid": goal_valid,
             "chunk": chunk,
             "use_goal_image": use_goal_image,
             "convert_state_to_9d": convert_state_to_9d,
@@ -303,23 +306,58 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
         """
         if not self.use_goal_image:
             return None
-        features = torch.stack(
-            [
-                self._encode_images(
+
+        n_cam = len(self.cameras)
+        # (b, n_cam) bool. Absent => all-true, so existing batches are unaffected.
+        supplied = self._lookup(batch, self.goal_valid)
+        if supplied is None:
+            present = torch.ones(batch_size, n_cam, dtype=torch.bool, device=device)
+        else:
+            present = supplied.to(device=device, dtype=torch.bool)
+            if present.ndim == 1:  # (b,) broadcasts to every camera
+                present = present[:, None].expand(batch_size, n_cam)
+            present = present.reshape(batch_size, n_cam)
+
+        encoded: list[Tensor | None] = []
+        for index, camera in enumerate(self.cameras):
+            images = self._lookup(batch, (self.goal_image_key.format(camera=camera),))
+            if images is None:
+                # Omitting the frames is only legal where nothing claims a goal:
+                # a missing key with `goal_valid` true is a real error, not an
+                # implicit "no goal".
+                if bool(present[:, index].any()):
                     self._get(batch, (self.goal_image_key.format(camera=camera),))
-                )
-                for camera in self.cameras
-            ],
+                encoded.append(None)
+                continue
+            encoded.append(self._encode_images(images))
+
+        reference = next((e for e in encoded if e is not None), None)
+        if reference is None:
+            # Every goal omitted. `num_patches` is not knowable from the goal
+            # side alone, so borrow it from the observation stream, which is
+            # always present and lands on the same grid via `image_transform`.
+            reference = self._encode_images(
+                self._get(batch, (self.image_key.format(camera=self.cameras[0]),))[
+                    :, :1
+                ]
+            ).squeeze(1)
+        features = torch.stack(
+            [self.no_goal.expand_as(reference) if e is None else e for e in encoded],
             dim=1,
         )  # (b, n_cam, P, D)
 
         if self.training and self.goal_dropout > 0:
-            drop = (
-                torch.rand(batch_size, features.shape[1], 1, 1, device=device)
-                < self.goal_dropout
-            )
-            features = torch.where(drop, self.no_goal.to(features.dtype), features)
-        return features
+            keep = torch.rand(batch_size, n_cam, device=device) >= self.goal_dropout
+            # ⚠️ NOT `present &= keep`. `present` may ALIAS `batch["goal_valid"]`
+            # (`.to()` returns self when dtype/device already match), so an
+            # in-place op would corrupt the loader's tensor for the rest of its
+            # life -- invisibly, and worse with a cached TensorDict. Same bug a
+            # ruff PLR6104 autofix introduced in the depth path.
+            present &= keep
+
+        return torch.where(
+            present[:, :, None, None], features, self.no_goal.to(features.dtype)
+        )
 
     def _state(self, batch: Any) -> Tensor:
         """`state.pose` in the model-facing 9D form, converting from storage if needed."""

--- a/src/rmind/models/nero_patch_policy.py
+++ b/src/rmind/models/nero_patch_policy.py
@@ -1,0 +1,506 @@
+"""Causal patch policy for the nero-arms bimanual manipulation contract.
+
+Reuses the decoder-only trunk from `feat/patch-policy-decoder-only` unchanged --
+`rmind.components.transformer.causal_frame.CausalFrameTransformer` (frame-RoPE +
+tiled intra-frame embedding, bidirectional intra-frame / causal inter-frame,
+KV-cacheable) -- and replaces everything above and below it to match the
+nero-arms data contract.
+
+Token layout (one frame block)
+------------------------------
+::
+
+    [ state token (1) ][ base patches (P) ][ side_left (P) ][ side_right (P) ]
+                                                          tokens_per_frame = 3P + 1
+
+with `P = 256` -> **769 tokens per frame**. At `episode_length = 6` the flattened
+sequence is **4614** tokens, versus 1542 for the 6-frame driving arm and 4112 for
+the 16-frame causal driving arm -- i.e. just above the longest sequence already
+profiled on this trunk. The state token goes FIRST so that each frame block ends
+on a patch token, which is the readout position (unchanged from PR #265).
+
+Design decisions, and why
+-------------------------
+
+**Camera conditioning (contract §7.1) -> per-patch concatenation, not extra
+tokens and not FiLM.** Each camera's 13-dim vector is concatenated to *that
+camera's* patch tokens before `patch_projection`. Reasons, in order of weight:
+
+1. *zero sequence cost*. At 769 tokens/frame attention is the binding constraint;
+   3 extra tokens per frame is cheap but the pattern does not stay cheap, and
+   FiLM would need a broadcast anyway.
+2. *it binds the geometry to the tokens it describes*. A patch of `side_left`
+   carries `side_left`'s extrinsics; an extra token or a FiLM vector would carry
+   all three cameras' geometry to all three cameras' patches, and the trunk would
+   have to learn the routing.
+3. *it doubles as camera identity*. The tiled intra-frame positional embedding
+   gives each slot an index, but that index is setup-specific; the conditioning
+   vector is what generalises across camera-setup changes, which is the stated
+   point of §7.1.
+
+**Goal conditioning (contract §9) -> same-index concatenation of the goal
+image's patch features.** The goal image is the episode's final frame *from the
+same camera*, so goal patch `(c, p)` and observation patch `(c, p)` are the same
+ray through the same lens. Concatenating them index-aligned preserves that
+spatial correspondence, which is exactly the "where did the object end up"
+signal; mean-pooling the goal (the obvious cheap alternative) discards it. Cost
+is identical -- both are a channel concat, no extra tokens. This is the natural
+generalisation of the paper's `T x P x (D + G)` scheme, with `G = D` and the
+goal constant over `t` (the driving arm's `g_t` varied per frame because
+waypoints are ego-frame; a goal image does not).
+
+**Goal dropout.** With probability `goal_dropout` (per sample, per camera) the
+goal features are replaced by a *learned* `no_goal` embedding rather than zeros,
+so "no goal supplied" is distinguishable from "goal that happens to encode near
+zero". Without this the policy becomes goal-dependent for basic motion (§9).
+
+**Bimanual `side_valid` (contract §6.1).** Consumed in two places, both
+falsifiable:
+
+* the state token is built from `state * side_valid` with the 2-dim mask
+  appended, so perturbing an invalid side's state cannot change any output;
+* the action loss selects only valid `(batch, frame, side)` rows. Normalisation
+  is `sum / count`, never `mean` over a zero-padded tensor -- the latter silently
+  halves the loss on right-only data, which changes the effective LR and makes
+  the curve incomparable to a future bimanual run.
+
+**Per-side, weight-shared head.** One readout token per frame feeds a shared
+`code_head`/`offset_head`, applied twice with a learned per-side embedding added
+to the feature. This halves the head parameter count versus two independent
+heads and -- more importantly -- lets right-only dummy data train a head that is
+immediately meaningful for the left hand, matching the weight-shared tokenizer.
+
+Configuration seam (contract §11)
+---------------------------------
+`action_features` (per-side action dimensionality) and `action_horizon` come from
+the tokenizer, and every head width is derived in config from
+`num_quantizers * codebook_size * action_horizon * action_features`. Swapping to
+§11 option (B) -- Revo2 joint targets, ~12 dims per side instead of 60 -- is a
+new tokenizer checkpoint plus the derived config values; no code change here.
+What WOULD change: `rbyte` must apply the glove-SE(3) -> Revo2 retargeting at
+ingestion, `state.pose` would become joint angles (or stay SE(3) as a separate
+observation block, which this model supports by pointing `state` elsewhere), and
+`NeroPoseTokenizer.has_pose_layout` goes False so the mm/degree metrics are
+replaced by joint-angle degrees.
+"""
+
+from collections.abc import Mapping, Sequence
+from typing import Annotated, Any, final, override
+
+import pytorch_lightning as pl
+import torch
+from einops import rearrange
+from pydantic import Field, InstanceOf, validate_call
+from pytorch_lightning.utilities.types import STEP_OUTPUT, OptimizerLRScheduler
+from tensordict import TensorDict
+from torch import Tensor, nn
+from torch.nn import Module
+from torch.optim import Optimizer
+
+from rmind.components import optimizers
+from rmind.components.containers import ModuleDict
+from rmind.config import HydraConfig, init_hydra_param
+from rmind.data.nero import NUM_SIDES, pose_error_metrics
+from rmind.models.action_tokenizer import LRSchedulerHydraConfig
+from rmind.models.control_transformer import PredictionConfig
+from rmind.utils._wandb import LoadableFromArtifact
+
+__all__ = ["NeroPatchPolicy"]
+
+type Path = tuple[str, ...]
+
+
+@final
+class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
+    """Causal patch policy over 3 cameras + bimanual SE(3) state. See module docstring."""
+
+    @validate_call
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        image_transform: HydraConfig[Module] | InstanceOf[Module],
+        image_encoder: HydraConfig[Module] | InstanceOf[Module],
+        patch_projection: HydraConfig[Module] | InstanceOf[Module],
+        state_embedding: HydraConfig[Module] | InstanceOf[Module],
+        encoder: HydraConfig[Module] | InstanceOf[Module],
+        tokenizer: HydraConfig[Module] | InstanceOf[Module],
+        code_head: HydraConfig[Module] | InstanceOf[Module],
+        offset_head: HydraConfig[Module] | InstanceOf[Module],
+        losses: HydraConfig[ModuleDict] | InstanceOf[ModuleDict],
+        image_embedding_dim: int,
+        policy_embedding_dim: int,
+        norm: HydraConfig[Module] | InstanceOf[Module] | None = None,
+        cameras: Sequence[str] = ("base", "side_left", "side_right"),
+        image_key: str = "image.{camera}",
+        goal_image: Path = ("goal.image",),
+        camera_cond: Path = ("camera_cond",),
+        state: Path = ("state.pose",),
+        side_valid: Path = ("side_valid",),
+        chunk: Path = ("action.future_state",),
+        use_goal_image: bool = True,
+        goal_dropout: float = 0.15,
+        sample_codes: bool = True,
+        teacher_force_offset: bool = True,
+        offset_scale: float | None = None,
+        optimizer: HydraConfig[Optimizer] | None = None,
+        lr_scheduler: LRSchedulerHydraConfig | None = None,
+        prediction_config: Annotated[
+            PredictionConfig, Field(default_factory=PredictionConfig)
+        ],
+    ) -> None:
+        super().__init__()
+
+        hparams: dict[str, Any] = {}
+
+        self.image_transform = init_hydra_param(
+            hparams, "image_transform", image_transform
+        )
+        # frozen feature extractor: never trains, never leaves eval mode (see train())
+        self.image_encoder = (
+            init_hydra_param(hparams, "image_encoder", image_encoder)
+            .requires_grad_(False)  # noqa: FBT003
+            .eval()
+        )
+        self.tokenizer = (
+            init_hydra_param(hparams, "tokenizer", tokenizer)
+            .requires_grad_(False)  # noqa: FBT003
+            .eval()
+        )
+
+        self.patch_projection = init_hydra_param(
+            hparams, "patch_projection", patch_projection
+        )
+        self.state_embedding = init_hydra_param(
+            hparams, "state_embedding", state_embedding
+        )
+        self.encoder: Module = init_hydra_param(hparams, "encoder", encoder)
+        self.code_head = init_hydra_param(hparams, "code_head", code_head)
+        self.offset_head = init_hydra_param(hparams, "offset_head", offset_head)
+        self.losses: ModuleDict = init_hydra_param(hparams, "losses", losses)
+        self.norm: Module | None = init_hydra_param(hparams, "norm", norm)
+
+        # learned "no goal supplied" feature -- see the docstring on goal dropout
+        self.no_goal = nn.Parameter(torch.zeros(image_embedding_dim))
+        nn.init.trunc_normal_(self.no_goal, std=0.02)
+        # per-side identity for the weight-shared head
+        self.side_embedding = nn.Embedding(NUM_SIDES, policy_embedding_dim)
+        nn.init.trunc_normal_(self.side_embedding.weight, std=0.02)
+
+        self.cameras = tuple(cameras)
+        self.image_key = image_key
+        self.goal_image: Path = goal_image
+        self.camera_cond: Path = camera_cond
+        self.state: Path = state
+        self.side_valid: Path = side_valid
+        self.chunk: Path = chunk
+        self.use_goal_image = use_goal_image
+        self.goal_dropout = goal_dropout
+        self.sample_codes = sample_codes
+        self.teacher_force_offset = teacher_force_offset
+        self.offset_scale = offset_scale
+        self.image_embedding_dim = image_embedding_dim
+        self.policy_embedding_dim = policy_embedding_dim
+        hparams |= {
+            "cameras": self.cameras,
+            "image_key": image_key,
+            "goal_image": goal_image,
+            "camera_cond": camera_cond,
+            "state": state,
+            "side_valid": side_valid,
+            "chunk": chunk,
+            "use_goal_image": use_goal_image,
+            "goal_dropout": goal_dropout,
+            "sample_codes": sample_codes,
+            "teacher_force_offset": teacher_force_offset,
+            "offset_scale": offset_scale,
+            "image_embedding_dim": image_embedding_dim,
+            "policy_embedding_dim": policy_embedding_dim,
+        }
+
+        if optimizer is not None:
+            hparams["optimizer"] = optimizer.model_dump()
+        self.optimizer: HydraConfig[Optimizer] | None = optimizer
+
+        if lr_scheduler is not None:
+            hparams["lr_scheduler"] = lr_scheduler.model_dump()
+        self.lr_scheduler: LRSchedulerHydraConfig | None = lr_scheduler
+
+        self.prediction_config = prediction_config
+
+        self.save_hyperparameters(hparams)
+
+    @override
+    def train(self, mode: bool = True) -> "NeroPatchPolicy":
+        super().train(mode)
+        self.image_encoder.eval()
+        self.tokenizer.eval()
+        return self
+
+    # ------------------------------------------------------------------ input
+
+    @staticmethod
+    def _lookup(inputs: Mapping[str, Any], path: Path) -> Tensor | None:
+        value: Any = inputs
+        for key in path:
+            if not isinstance(value, Mapping) or key not in value:
+                return None
+            value = value[key]
+        return value
+
+    @classmethod
+    def _get(cls, inputs: Mapping[str, Any], path: Path) -> Tensor:
+        """Fetch a required contract key, raising rather than propagating `None`.
+
+        Raises:
+            KeyError: if the path is absent from the batch.
+        """
+        value = cls._lookup(inputs, path)
+        if value is None:
+            msg = f"input {path!r} missing from batch"
+            raise KeyError(msg)
+        return value
+
+    def _encode_images(self, images: Tensor) -> Tensor:
+        """`(..., 3, H, W)` uint8 -> frozen patch features `(..., P, D)`."""
+        with torch.no_grad():
+            return self.image_encoder(self.image_transform(images))
+
+    def _goal_features(
+        self, batch: Any, *, batch_size: int, device: torch.device
+    ) -> Tensor | None:
+        """`(b, n_cameras, P, D)` goal patch features, or None when goals are off."""
+        if not self.use_goal_image:
+            return None
+        goal = self._get(batch, self.goal_image)
+        features = self._encode_images(goal)  # (b, n_cam, P, D)
+
+        if self.training and self.goal_dropout > 0:
+            drop = (
+                torch.rand(batch_size, features.shape[1], 1, 1, device=device)
+                < self.goal_dropout
+            )
+            features = torch.where(drop, self.no_goal.to(features.dtype), features)
+        return features
+
+    def _frame_tokens(self, batch: Any) -> Tensor:  # noqa: PLR0914
+        """Per-frame token blocks `(b, T, 3P + 1, d)` -- everything below the trunk.
+
+        Factored out so a KV-cached one-frame decode step (the
+        `PatchPolicyDecoderStep` equivalent) can run the identical pipeline on a
+        single frame; nothing here is temporal.
+        """
+        state = self._get(batch, self.state)  # (b, T, 2, A_state)
+        valid = self._get(batch, self.side_valid)  # (b, 2) bool
+        cond = self._get(batch, self.camera_cond)  # (b, n_cam, 13)
+        b, t = state.shape[0], state.shape[1]
+        device = state.device
+
+        goal = self._goal_features(batch, batch_size=b, device=device)
+
+        per_camera: list[Tensor] = []
+        for index, camera in enumerate(self.cameras):
+            images = self._get(batch, (self.image_key.format(camera=camera),))
+            patches = self._encode_images(images)  # (b, T, P, D)
+            parts = [patches]
+            if goal is not None:
+                # same-index concat: obs patch (c, p) <-> goal patch (c, p)
+                parts.append(goal[:, index].unsqueeze(1).expand(-1, t, -1, -1))
+            parts.append(
+                cond[:, index][:, None, None, :].expand(b, t, patches.shape[-2], -1)
+            )
+            per_camera.append(torch.cat(parts, dim=-1))
+
+        patch_tokens = self.patch_projection(
+            torch.cat(per_camera, dim=-2)
+        )  # (b, T, 3P, d)
+
+        # `side_valid` consumption #1: the invalid side is zeroed BEFORE it can
+        # reach any token, and the mask itself is appended so "zero because
+        # absent" is distinguishable from "zero because at the origin".
+        mask = valid.to(state.dtype)  # (b, 2)
+        masked_state = state * mask[:, None, :, None]
+        state_input = torch.cat(
+            [masked_state.flatten(-2, -1), mask[:, None, :].expand(b, t, NUM_SIDES)],
+            dim=-1,
+        )  # (b, T, 2 * A_state + 2)
+        state_token = self.state_embedding(state_input).unsqueeze(-2)  # (b, T, 1, d)
+
+        # state first, so each frame block ends on a patch token (the readout)
+        return torch.cat([state_token, patch_tokens], dim=-2)
+
+    def _features(self, batch: Any) -> Tensor:
+        """Per-frame readout features `(b, T, d)`."""
+        tokens = self._frame_tokens(batch)
+        _, num_frames, _, _ = tokens.shape
+        embedding = self.encoder(
+            rearrange(tokens, "b t k d -> b (t k) d"), num_frames=num_frames
+        )
+        features = rearrange(embedding, "b (t k) d -> b t k d", t=num_frames)[:, :, -1]
+        if self.norm is not None:
+            features = self.norm(features)
+        return features
+
+    # ------------------------------------------------------- VQ-BeT head
+
+    def _per_side_features(self, features: Tensor) -> Tensor:
+        """`(b, T, d)` -> `(b, T, 2, d)`: the shared readout plus a side identity."""
+        sides = torch.arange(NUM_SIDES, device=features.device)
+        return features.unsqueeze(-2) + self.side_embedding(sides)
+
+    def _heads(self, features: Tensor) -> tuple[Tensor, Tensor]:
+        """Code logits `(..., g, c)` and the offset table `(..., g, c, action_dim)`."""
+        quantizer = self.tokenizer.quantizer
+        g, c = quantizer.num_quantizers, quantizer.codebook_size
+        code_logits = rearrange(
+            self.code_head(features), "... (g c) -> ... g c", g=g, c=c
+        )
+        offsets = rearrange(
+            self.offset_head(features), "... (g c a) -> ... g c a", g=g, c=c
+        )
+        return code_logits, offsets
+
+    @staticmethod
+    def _gather_offset(offsets: Tensor, codes: Tensor) -> Tensor:
+        index = codes[..., None, None].expand(*codes.shape, 1, offsets.shape[-1])
+        # https://arxiv.org/pdf/2403.03181 Figure 2.
+        return offsets.gather(-2, index).squeeze(-2).sum(dim=-2)
+
+    def _offset(self, offsets: Tensor, codes: Tensor) -> Tensor:
+        offset = self._gather_offset(offsets, codes)
+        if self.offset_scale is None:
+            return offset
+        return torch.tanh(offset / self.offset_scale) * self.offset_scale
+
+    def _sample_codes(self, code_logits: Tensor) -> Tensor:
+        *batch, g, c = code_logits.shape
+        if self.sample_codes:
+            return rearrange(
+                torch.multinomial(code_logits.softmax(dim=-1).reshape(-1, c), 1),
+                "(b g) 1 -> b g",
+                g=g,
+            ).reshape(*batch, g)
+        return code_logits.argmax(dim=-1)
+
+    def _predict_chunk(self, features: Tensor) -> Tensor:
+        """`(..., d)` -> STANDARDISED chunk `(..., 2, horizon, action_features)`."""
+        code_logits, offsets = self._heads(self._per_side_features(features))
+        codes = self._sample_codes(code_logits)
+        offset = self._offset(offsets, codes)
+        return (self.tokenizer.invert(codes) + offset).unflatten(
+            -1,
+            (-1, self.tokenizer._action_features),  # noqa: SLF001
+        )
+
+    # ------------------------------------------------------------------ loss
+
+    def _compute_metrics(self, batch: Any) -> TensorDict:  # noqa: PLR0914
+        tokenizer = self.tokenizer
+        features = self._features(batch)  # (b, T, d)
+        chunk = self._get(batch, self.chunk)  # (b, T, H, 2, A)
+        valid = self._get(batch, self.side_valid)  # (b, 2)
+
+        b, t = features.shape[0], features.shape[1]
+        # (b, T, 2, H, A) -> select valid (batch, frame, side) rows
+        per_side_chunk = chunk.permute(0, 1, 3, 2, 4)
+        row_valid = valid[:, None, :].expand(b, t, NUM_SIDES).reshape(-1)
+        flat_chunk = per_side_chunk.reshape(-1, *per_side_chunk.shape[-2:])[row_valid]
+
+        with torch.no_grad():
+            target_codes = tokenizer(flat_chunk)  # (n, g)
+            target = tokenizer._normalize(flat_chunk.flatten(-2, -1))  # noqa: SLF001
+
+        side_features = self._per_side_features(features).reshape(
+            -1, features.shape[-1]
+        )[row_valid]
+        code_logits, offsets = self._heads(side_features)
+
+        losses: dict[str, Tensor] = {}
+        for q in range(tokenizer.quantizer.num_quantizers):
+            losses[f"code_{q}"] = self.losses["code"](
+                code_logits[..., q, :], target_codes[..., q]
+            )
+
+        codes = self._sample_codes(code_logits)
+        sampled_chunk = tokenizer.invert(codes) + self._offset(offsets, codes)
+
+        if self.teacher_force_offset:
+            predicted_chunk = tokenizer.invert(target_codes) + self._offset(
+                offsets, target_codes
+            )
+        else:
+            predicted_chunk = sampled_chunk
+
+        losses["offset"] = self.losses["offset"](predicted_chunk, target)
+
+        with torch.no_grad():
+            metrics: dict[str, Tensor] = {
+                "offset_sampled_recon": self.losses["offset"](
+                    sampled_chunk.detach(), target
+                ),
+                "valid_rows": row_valid.sum().to(features.dtype),
+            }
+            # ⚠️ contract §5.5: translation and rotation, ALWAYS separately.
+            if getattr(tokenizer, "has_pose_layout", False):
+                shape = (-1, tokenizer.action_horizon, tokenizer.action_features)
+                metrics |= pose_error_metrics(
+                    tokenizer._denormalize(sampled_chunk.detach()).reshape(shape),  # noqa: SLF001
+                    flat_chunk.reshape(shape),
+                )
+
+        return TensorDict(
+            {"policy": {"loss": losses, "metric": metrics}}, batch_size=[]
+        )
+
+    def _step(self, batch: Any, prefix: str) -> STEP_OUTPUT:
+        metrics = self._compute_metrics(batch)
+        losses = metrics.select(*((k, "loss") for k in metrics.keys()))  # noqa: SIM118
+        metrics["loss", "total"] = losses.sum(reduce=True)
+        self.log_dict(
+            {
+                "/".join([prefix, *k]): v
+                for k, v in metrics.detach().items(
+                    include_nested=True, leaves_only=True
+                )
+            },
+            sync_dist=True,
+        )
+        return {"loss": metrics["loss", "total"]}
+
+    @override
+    def training_step(self, batch: dict[str, Any], _batch_idx: int) -> STEP_OUTPUT:
+        return self._step(batch, "train")
+
+    @override
+    def validation_step(self, batch: dict[str, Any], _batch_idx: int) -> STEP_OUTPUT:
+        if self.trainer.sanity_checking:
+            return {
+                "loss": self._compute_metrics(batch)["policy", "loss"].sum(reduce=True)
+            }
+        return self._step(batch, "val")
+
+    @override
+    def forward(self, batch: Any) -> TensorDict:
+        """Newest frame's bimanual action chunk, `(b, 2, horizon, action_features)`."""
+        chunk = self._predict_chunk(self._features(batch)[:, -1])
+        return TensorDict({"policy": {"action": chunk}}, batch_size=[])
+
+    @override
+    def configure_optimizers(self) -> OptimizerLRScheduler:
+        if self.optimizer is None:
+            msg = "optimizer not specified"
+            raise ValueError(msg)
+
+        match self.optimizer.target:
+            case optimizers.SelectiveAdamW:
+                optimizer = self.optimizer.instantiate(module=self)
+            case _:
+                optimizer = self.optimizer.instantiate(params=self.parameters())
+
+        if self.lr_scheduler is not None:
+            scheduler = self.lr_scheduler.scheduler.instantiate(optimizer=optimizer)
+            lr_scheduler = {"scheduler": scheduler} | self.lr_scheduler.model_dump(
+                exclude={"scheduler"}
+            )
+            return {"optimizer": optimizer, "lr_scheduler": lr_scheduler}
+
+        return {"optimizer": optimizer}

--- a/src/rmind/models/nero_patch_policy.py
+++ b/src/rmind/models/nero_patch_policy.py
@@ -13,11 +13,17 @@ Token layout (one frame block)
     [ state token (1) ][ base patches (P) ][ side_left (P) ][ side_right (P) ]
                                                           tokens_per_frame = 3P + 1
 
-with `P = 256` -> **769 tokens per frame**. At `episode_length = 6` the flattened
-sequence is **4614** tokens, versus 1542 for the 6-frame driving arm and 4112 for
-the 16-frame causal driving arm -- i.e. just above the longest sequence already
-profiled on this trunk. The state token goes FIRST so that each frame block ends
-on a patch token, which is the readout position (unchanged from PR #265).
+with `P = 160` -- a 10x16 grid at DINOv2's patch 14 on a 140x224 input, which is
+the cameras' own 5:8 aspect -> **481 tokens per frame**. At `episode_length = 6`
+the flattened sequence is **2886**, versus 1542 for the 6-frame driving arm and
+4112 for the 16-frame causal driving arm.
+
+Forcing the usual SQUARE 224x224 input would put identical image content on a
+16x16 grid with 6 of 16 rows pure letterbox padding: 769 tokens per frame, 4614
+flattened, ~2.6x the attention cost for no extra information.
+
+The state token goes FIRST so that each frame block ends on a patch token, which
+is the readout position (unchanged from PR #265).
 
 Design decisions, and why
 -------------------------
@@ -26,7 +32,7 @@ Design decisions, and why
 tokens and not FiLM.** Each camera's 13-dim vector is concatenated to *that
 camera's* patch tokens before `patch_projection`. Reasons, in order of weight:
 
-1. *zero sequence cost*. At 769 tokens/frame attention is the binding constraint;
+1. *zero sequence cost*. At 481 tokens/frame attention is the binding constraint;
    3 extra tokens per frame is cheap but the pattern does not stay cheap, and
    FiLM would need a broadcast anyway.
 2. *it binds the geometry to the tokens it describes*. A patch of `side_left`

--- a/src/rmind/models/nero_patch_policy.py
+++ b/src/rmind/models/nero_patch_policy.py
@@ -100,7 +100,12 @@ from torch.optim import Optimizer
 from rmind.components import optimizers
 from rmind.components.containers import ModuleDict
 from rmind.config import HydraConfig, init_hydra_param
-from rmind.data.nero import NUM_SIDES, pose_error_metrics
+from rmind.data.nero import (
+    NUM_SIDES,
+    STATE_QUAT_DIM,
+    pose_error_metrics,
+    state_quat_to_9d,
+)
 from rmind.models.action_tokenizer import LRSchedulerHydraConfig
 from rmind.models.control_transformer import PredictionConfig
 from rmind.utils._wandb import LoadableFromArtifact
@@ -132,12 +137,16 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
         norm: HydraConfig[Module] | InstanceOf[Module] | None = None,
         cameras: Sequence[str] = ("base", "side_left", "side_right"),
         image_key: str = "image.{camera}",
-        goal_image: Path = ("goal.image",),
+        goal_image_key: str = "goal.image.{camera}",
         camera_cond: Path = ("camera_cond",),
         state: Path = ("state.pose",),
         side_valid: Path = ("side_valid",),
         chunk: Path = ("action.future_state",),
         use_goal_image: bool = True,
+        # rbyte emits the contract §5.2 STORAGE form (46 per side: 6 poses x 7 +
+        # a 4-dim hub quaternion). The 9D expansion happens here, at the model
+        # boundary -- set False if a loader ever hands over 60 directly.
+        convert_state_to_9d: bool = True,
         goal_dropout: float = 0.15,
         sample_codes: bool = True,
         teacher_force_offset: bool = True,
@@ -188,12 +197,13 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
 
         self.cameras = tuple(cameras)
         self.image_key = image_key
-        self.goal_image: Path = goal_image
+        self.goal_image_key = goal_image_key
         self.camera_cond: Path = camera_cond
         self.state: Path = state
         self.side_valid: Path = side_valid
         self.chunk: Path = chunk
         self.use_goal_image = use_goal_image
+        self.convert_state_to_9d = convert_state_to_9d
         self.goal_dropout = goal_dropout
         self.sample_codes = sample_codes
         self.teacher_force_offset = teacher_force_offset
@@ -203,12 +213,13 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
         hparams |= {
             "cameras": self.cameras,
             "image_key": image_key,
-            "goal_image": goal_image,
+            "goal_image_key": goal_image_key,
             "camera_cond": camera_cond,
             "state": state,
             "side_valid": side_valid,
             "chunk": chunk,
             "use_goal_image": use_goal_image,
+            "convert_state_to_9d": convert_state_to_9d,
             "goal_dropout": goal_dropout,
             "sample_codes": sample_codes,
             "teacher_force_offset": teacher_force_offset,
@@ -268,11 +279,26 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
     def _goal_features(
         self, batch: Any, *, batch_size: int, device: torch.device
     ) -> Tensor | None:
-        """`(b, n_cameras, P, D)` goal patch features, or None when goals are off."""
+        """`(b, n_cameras, P, D)` goal patch features, or None when goals are off.
+
+        ⚠️ The goal frames are THREE SEPARATE KEYS, not one stacked tensor: rbyte
+        cannot index one stream by several columns, and the final frame index
+        differs per camera (199 vs 200 in the dummy). They are also on different
+        native grids, so each is letterboxed by `image_transform` before being
+        stacked -- which is only valid because the transform lands them all on
+        the same grid.
+        """
         if not self.use_goal_image:
             return None
-        goal = self._get(batch, self.goal_image)
-        features = self._encode_images(goal)  # (b, n_cam, P, D)
+        features = torch.stack(
+            [
+                self._encode_images(
+                    self._get(batch, (self.goal_image_key.format(camera=camera),))
+                )
+                for camera in self.cameras
+            ],
+            dim=1,
+        )  # (b, n_cam, P, D)
 
         if self.training and self.goal_dropout > 0:
             drop = (
@@ -282,6 +308,27 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
             features = torch.where(drop, self.no_goal.to(features.dtype), features)
         return features
 
+    def _state(self, batch: Any) -> Tensor:
+        """`state.pose` in the model-facing 9D form, converting from storage if needed."""
+        state = self._get(batch, self.state)
+        if self.convert_state_to_9d and state.shape[-1] == STATE_QUAT_DIM:
+            return state_quat_to_9d(state)
+        return state
+
+    def _chunk(self, batch: Any) -> Tensor:
+        """The action chunk in the model-facing 9D form.
+
+        Contract §6.2 reserves `action.commanded` as an alias of
+        `action.future_state`; rbyte currently materialises BOTH as
+        byte-identical tensors (~199 MB of a ~470 MB TensorDict). This model
+        reads exactly one path, so the duplicate is never paid for downstream --
+        point `chunk` at whichever slot is populated.
+        """
+        chunk = self._get(batch, self.chunk)
+        if self.convert_state_to_9d and chunk.shape[-1] == STATE_QUAT_DIM:
+            return state_quat_to_9d(chunk)
+        return chunk
+
     def _frame_tokens(self, batch: Any) -> Tensor:  # noqa: PLR0914
         """Per-frame token blocks `(b, T, 3P + 1, d)` -- everything below the trunk.
 
@@ -289,7 +336,7 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
         `PatchPolicyDecoderStep` equivalent) can run the identical pipeline on a
         single frame; nothing here is temporal.
         """
-        state = self._get(batch, self.state)  # (b, T, 2, A_state)
+        state = self._state(batch)  # (b, T, 2, 60)
         valid = self._get(batch, self.side_valid)  # (b, 2) bool
         cond = self._get(batch, self.camera_cond)  # (b, n_cam, 13)
         b, t = state.shape[0], state.shape[1]
@@ -396,7 +443,7 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
     def _compute_metrics(self, batch: Any) -> TensorDict:  # noqa: PLR0914
         tokenizer = self.tokenizer
         features = self._features(batch)  # (b, T, d)
-        chunk = self._get(batch, self.chunk)  # (b, T, H, 2, A)
+        chunk = self._chunk(batch)  # (b, T, H, 2, 60)
         valid = self._get(batch, self.side_valid)  # (b, 2)
 
         b, t = features.shape[0], features.shape[1]

--- a/src/rmind/models/nero_patch_policy.py
+++ b/src/rmind/models/nero_patch_policy.py
@@ -154,7 +154,14 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
         # boundary -- set False if a loader ever hands over 60 directly.
         convert_state_to_9d: bool = True,
         goal_dropout: float = 0.15,
-        sample_codes: bool = True,
+        # Argmax by default, not sampling. No loss depends on this while
+        # `teacher_force_offset` is True (the default): the code losses are
+        # cross-entropy against tokenizer-encoded `target_codes`, and the offset
+        # loss is teacher-forced from those same codes. So sampling only feeds
+        # the reported `offset_sampled_recon` / pose-error metrics -- and those
+        # are more useful computed the way SERVING decodes, which is argmax.
+        # It also makes inference deterministic; see docs/nero_serving_handover.md.
+        sample_codes: bool = False,
         teacher_force_offset: bool = True,
         offset_scale: float | None = None,
         optimizer: HydraConfig[Optimizer] | None = None,

--- a/src/rmind/models/nero_pose_tokenizer.py
+++ b/src/rmind/models/nero_pose_tokenizer.py
@@ -49,7 +49,13 @@ from torch.optim import Optimizer
 from rmind.components import optimizers
 from rmind.components.vq import ResidualVQ
 from rmind.config import HydraConfig, init_hydra_param
-from rmind.data.nero import SIDE_DIM, PoseStandardizer, pose_error_metrics
+from rmind.data.nero import (
+    SIDE_DIM,
+    STATE_QUAT_DIM,
+    PoseStandardizer,
+    pose_error_metrics,
+    state_quat_to_9d,
+)
 from rmind.models.action_tokenizer import LRSchedulerHydraConfig
 from rmind.utils._wandb import LoadableFromArtifact
 
@@ -203,6 +209,10 @@ class NeroPoseTokenizer(pl.LightningModule, LoadableFromArtifact):
         for key in self.side_valid:
             valid = valid[key]
 
+        # rbyte emits the §5.2 STORAGE form (46 per side); expand at the
+        # boundary, exactly as the policy does, so both see the same space.
+        if self.has_pose_layout and action.shape[-1] == STATE_QUAT_DIM:
+            action = state_quat_to_9d(action)
         b, t, h, s, f = action.shape
         chunks = action.permute(0, 1, 3, 2, 4).reshape(b * t * s, h, f)
         mask = valid[:, None, :].expand(b, t, s).reshape(-1)

--- a/src/rmind/models/nero_pose_tokenizer.py
+++ b/src/rmind/models/nero_pose_tokenizer.py
@@ -1,0 +1,332 @@
+"""VQ-BeT residual-VQ tokenizer for the nero-arms SE(3) action space.
+
+Same recipe as `rmind.models.waypoints_tokenizer.WaypointsTokenizer` and
+`rmind.models.action_tokenizer.ActionTokenizer` (encoder -> `ResidualVQ` ->
+decoder, straight-through, codebook + commitment losses), adapted to the
+contract's action space:
+
+* the token is **one side's action chunk**: `(action_horizon, action_features)`
+  in the contract's 9D form (default `6 x 60`). Because `action(t)` is *future
+  state* (§6.2), state and action live in the same space -- so **this one
+  tokenizer serves both** current-state encoding and action prediction;
+* the tokenizer is **per side, weight-shared**. A right-only dataset (the dummy)
+  therefore trains a tokenizer that is immediately valid for the left hand, and
+  the `side_valid` mask simply drops invalid rows from the fit rather than
+  teaching a codebook that "left == zeros";
+* inputs are **per-channel standardised** with train-split statistics
+  (`PoseStandardizer`, §5.4). Translations are ~0.06-0.7 m while 6D rotation
+  components are ~1; unstandardised, rotation error swamps translation error in
+  any L1/L2 objective;
+* reconstruction error is reported **separately for translation (mm) and
+  rotation (degrees, geodesic)** (§5.5). A single scalar recon loss is the single
+  most likely silent failure in this task.
+
+Configuration seam (contract §11)
+---------------------------------
+`action_features` and `action_horizon` are constructor arguments, not constants.
+Swapping to the BrainCo Revo2 joint-angle action space of §11 option (B) --
+~12 dims per side instead of 60 -- is `action_features: 12` plus a new
+checkpoint; no code change. When `action_features != 60` the pose-layout
+physical metrics are skipped automatically (there is no translation/rotation
+split in a joint-angle vector) and only the standardised recon loss is reported.
+"""
+
+from typing import Any, Self, final, override
+
+import pytorch_lightning as pl
+import torch
+from lightning_fabric.utilities.types import _MAP_LOCATION_TYPE, _PATH
+from pydantic import ConfigDict, InstanceOf, validate_call
+from pytorch_lightning.utilities.model_helpers import (
+    _restricted_classmethod,  # noqa: PLC2701
+)
+from pytorch_lightning.utilities.types import STEP_OUTPUT, OptimizerLRScheduler
+from torch import Tensor
+from torch.nn import Module
+from torch.nn import functional as F
+from torch.optim import Optimizer
+
+from rmind.components import optimizers
+from rmind.components.vq import ResidualVQ
+from rmind.config import HydraConfig, init_hydra_param
+from rmind.data.nero import SIDE_DIM, PoseStandardizer, pose_error_metrics
+from rmind.models.action_tokenizer import LRSchedulerHydraConfig
+from rmind.utils._wandb import LoadableFromArtifact
+
+__all__ = ["NeroPoseTokenizer"]
+
+
+class NeroPoseTokenizer(pl.LightningModule, LoadableFromArtifact):
+    """Residual-VQ autoencoder over one side's `(horizon, features)` pose chunk."""
+
+    @validate_call
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        encoder: HydraConfig[Module] | InstanceOf[Module],
+        quantizer: HydraConfig[ResidualVQ] | InstanceOf[ResidualVQ],
+        decoder: HydraConfig[Module] | InstanceOf[Module],
+        standardizer: HydraConfig[Module] | InstanceOf[Module] | None = None,
+        action_features: int = SIDE_DIM,
+        action_horizon: int = 6,
+        commitment_weight: float = 1.0,
+        vq_weight: float = 5.0,
+        action: tuple[str, ...] = ("action", "future_state"),
+        side_valid: tuple[str, ...] = ("side_valid",),
+        optimizer: HydraConfig[Optimizer] | None = None,
+        lr_scheduler: LRSchedulerHydraConfig | None = None,
+        **_legacy_hparams: Any,
+    ) -> None:
+        super().__init__()
+
+        hparams: dict[str, Any] = {}
+
+        self.encoder = init_hydra_param(hparams, "encoder", encoder)
+        self.quantizer: ResidualVQ = init_hydra_param(hparams, "quantizer", quantizer)
+        self.decoder = init_hydra_param(hparams, "decoder", decoder)
+        standardizer_module = init_hydra_param(hparams, "standardizer", standardizer)
+        self.standardizer: Module = (
+            PoseStandardizer(dim=action_features)
+            if standardizer_module is None
+            else standardizer_module
+        )
+
+        self.action_features = action_features
+        self.action_horizon = action_horizon
+        self.commitment_weight = commitment_weight
+        self.vq_weight = vq_weight
+        self.action = action
+        self.side_valid = side_valid
+        hparams |= {
+            "action_features": action_features,
+            "action_horizon": action_horizon,
+            "commitment_weight": commitment_weight,
+            "vq_weight": vq_weight,
+            "action": action,
+            "side_valid": side_valid,
+        }
+
+        if optimizer is not None:
+            hparams["optimizer"] = optimizer.model_dump()
+        self.optimizer: HydraConfig[Optimizer] | None = optimizer
+
+        if lr_scheduler is not None:
+            hparams["lr_scheduler"] = lr_scheduler.model_dump()
+        self.lr_scheduler: LRSchedulerHydraConfig | None = lr_scheduler
+
+        self.save_hyperparameters(hparams)
+
+    @override
+    @_restricted_classmethod
+    @validate_call(config=ConfigDict(arbitrary_types_allowed=True))
+    def load_from_checkpoint(
+        cls,  # noqa: N805
+        checkpoint_path: _PATH,
+        *,
+        map_location: _MAP_LOCATION_TYPE = None,
+        strict: bool | None = False,
+        weights_only: bool | None = False,
+        **kwargs: Any,
+    ) -> Self:  # ty:ignore[invalid-method-override]
+        return super().load_from_checkpoint(
+            checkpoint_path,
+            map_location=map_location,
+            strict=strict,
+            weights_only=weights_only,
+            **kwargs,
+        )
+
+    # ------------------------------------------------------------- geometry
+
+    @property
+    def _action_features(self) -> int:
+        """Name kept for parity with `ActionTokenizer` (the policy reads it)."""
+        return self.action_features
+
+    @property
+    def action_dim(self) -> int:
+        return self.action_horizon * self.action_features
+
+    @property
+    def has_pose_layout(self) -> bool:
+        """Whether the per-side vector is the contract §6.1 60-dim pose layout.
+
+        False for the §11 option-(B) Revo2 joint-angle variant, where a
+        translation/rotation split is meaningless.
+        """
+        return self.action_features == SIDE_DIM
+
+    def _normalize(self, action: Tensor) -> Tensor:
+        """Standardise a FLAT `(*b, horizon * features)` chunk. Mirrors `ActionTokenizer`."""
+        *batch, _ = action.shape
+        chunk = action.reshape(*batch, self.action_horizon, self.action_features)
+        return self.standardizer(chunk).reshape(*batch, self.action_dim)
+
+    def _denormalize(self, action: Tensor) -> Tensor:
+        *batch, _ = action.shape
+        chunk = action.reshape(*batch, self.action_horizon, self.action_features)
+        return self.standardizer.unstandardize(chunk).reshape(  # ty:ignore[call-non-callable]
+            *batch, self.action_dim
+        )
+
+    # ---------------------------------------------------------------- codec
+
+    @override
+    def forward(self, action: Tensor) -> Tensor:
+        """`(*b, horizon, features)` raw chunk -> `(*b, num_quantizers)` codes."""
+        action = action.flatten(-2, -1)
+        *batch, action_dim = action.shape
+        z = self.encoder(self._normalize(action).reshape(-1, action_dim))
+        codes, _, _ = self.quantizer(z)
+        return codes.reshape(*batch, self.quantizer.num_quantizers)
+
+    def invert(self, codes: Tensor) -> Tensor:
+        """`(*b, num_quantizers)` -> flat STANDARDISED `(*b, horizon * features)`."""
+        *batch, num_quantizers = codes.shape
+        z_q = self.quantizer.lookup(codes.reshape(-1, num_quantizers))
+        return self.decoder(z_q).reshape(*batch, self.action_dim)
+
+    # ---------------------------------------------------------------- train
+
+    def _gather(self, batch: Any) -> tuple[Tensor, Tensor]:
+        """`(n, horizon, features)` chunks and their `(n,)` validity mask.
+
+        Contract §8 emits `action.future_state` as `(b, T, H, 2, 60)` and
+        `side_valid` as `(b, 2)`. Every (batch, frame, side) triple is one
+        training example; invalid sides are dropped entirely rather than fed as
+        zeros -- see the class docstring.
+        """
+        action = batch
+        for key in self.action:
+            action = action[key]
+        valid = batch
+        for key in self.side_valid:
+            valid = valid[key]
+
+        b, t, h, s, f = action.shape
+        chunks = action.permute(0, 1, 3, 2, 4).reshape(b * t * s, h, f)
+        mask = valid[:, None, :].expand(b, t, s).reshape(-1)
+        return chunks, mask
+
+    def _step(self, batch: Any) -> tuple[Tensor, dict[str, Tensor]]:
+        chunks, mask = self._gather(batch)
+        chunks = chunks[mask]
+        if chunks.numel() == 0:
+            msg = "no valid sides in batch -- side_valid is all False"
+            raise ValueError(msg)
+
+        raw = chunks.flatten(-2, -1)  # (n, horizon * features)
+        a = self._normalize(raw)
+
+        z = self.encoder(a)
+        codes, z_q, vq = self.quantizer(z)
+        a_hat = self.decoder(z + (z_q - z).detach())  # straight-through
+
+        recon = F.l1_loss(a_hat, a)
+        total = recon + self.vq_weight * (
+            vq["codebook"] + self.commitment_weight * vq["commit"]
+        )
+
+        metrics = {
+            "recon": recon,
+            "codebook": vq["codebook"],
+            "commit": vq["commit"],
+            "total": total,
+        }
+        perplexity = self.quantizer.perplexity(codes)
+        for q in range(self.quantizer.num_quantizers):
+            metrics[f"perplexity/q{q}"] = perplexity[q]
+
+        # ⚠️ contract §5.5: NEVER report a single scalar recon for this space.
+        with torch.no_grad():
+            metrics |= self.reconstruction_metrics(a_hat, raw)
+
+        return total, metrics
+
+    def reconstruction_metrics(
+        self, predicted: Tensor, target_raw: Tensor
+    ) -> dict[str, Tensor]:
+        """Split reconstruction error, in physical units where the layout allows it.
+
+        Args:
+            predicted: STANDARDISED flat reconstruction `(n, horizon * features)`.
+            target_raw: RAW (unstandardised) flat target, same shape.
+        """
+        target = self._normalize(target_raw)
+        out = {
+            "recon_std_l1": F.l1_loss(predicted, target),
+            "recon_std_l2": F.mse_loss(predicted, target).sqrt(),
+        }
+        if not self.has_pose_layout:
+            return out
+
+        n = predicted.shape[0]
+        shape = (n, self.action_horizon, self.action_features)
+        pred_raw = self._denormalize(predicted).reshape(shape)
+        gt = target_raw.reshape(shape)
+        out |= pose_error_metrics(pred_raw, gt)
+
+        # the same split in standardised units, so the training objective itself
+        # can be audited channel-group-wise
+        from rmind.data.nero import translation_rotation_split  # noqa: PLC0415
+
+        p_t, p_r = translation_rotation_split(predicted.reshape(shape))
+        g_t, g_r = translation_rotation_split(target.reshape(shape))
+        out |= {
+            "recon_std_l1/translation": F.l1_loss(p_t, g_t),
+            "recon_std_l1/rotation": F.l1_loss(p_r, g_r),
+        }
+        return out
+
+    @override
+    def training_step(self, batch: Any, _batch_idx: int) -> STEP_OUTPUT:
+        total, metrics = self._step(batch)
+        self.log_dict({f"train/{k}": v for k, v in metrics.items()}, sync_dist=True)
+        return {"loss": total}
+
+    @override
+    def validation_step(self, batch: Any, _batch_idx: int) -> STEP_OUTPUT:
+        total, metrics = self._step(batch)
+        if not self.trainer.sanity_checking:
+            self.log_dict({f"val/{k}": v for k, v in metrics.items()}, sync_dist=True)
+        return {"loss": total}
+
+    @override
+    def configure_optimizers(self) -> OptimizerLRScheduler:
+        if self.optimizer is None:
+            msg = "optimizer not specified"
+            raise ValueError(msg)
+
+        match self.optimizer.target:
+            case optimizers.SelectiveAdamW:
+                optimizer = self.optimizer.instantiate(module=self)
+            case _:
+                optimizer = self.optimizer.instantiate(params=self.parameters())
+
+        if self.lr_scheduler is not None:
+            scheduler = self.lr_scheduler.scheduler.instantiate(optimizer=optimizer)
+            lr_scheduler = {"scheduler": scheduler} | self.lr_scheduler.model_dump(
+                exclude={"scheduler"}
+            )
+            return {"optimizer": optimizer, "lr_scheduler": lr_scheduler}
+
+        return {"optimizer": optimizer}
+
+
+@final
+class NeroGoalXYZTokenizer(NeroPoseTokenizer):
+    """Optional second RVQ over the normalised goal xyz 3-vector (contract §9).
+
+    Same recipe, defaulted to a single 3-vector instead of a pose chunk, so
+    `has_pose_layout` is False and only the standardised metrics are reported.
+    This is the config seam for "predict the goal rather than merely condition on
+    it" (§9). Scaffolding: NOT trained or evaluated in this work.
+    """
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**{
+            "action_horizon": 1,
+            "action_features": 3,
+            "action": ("goal", "xyz"),
+            **kwargs,
+        })

--- a/src/rmind/scripts/nero_serving_stub.py
+++ b/src/rmind/scripts/nero_serving_stub.py
@@ -1,0 +1,86 @@
+"""Emit a random-weight nero policy checkpoint and print its serving I/O contract.
+
+For building a serving app **before any model is trained**. The weights are
+random and the outputs are meaningless -- what is real, and what a serving app
+needs to be written against, is the *shape* of the interface: which tensors go
+in, at what dtypes and sizes, and what comes back.
+
+    uv run python -m rmind.scripts.nero_serving_stub --out /tmp/nero-serving
+
+Writes `policy_random.ckpt` (loadable with `torch.load(..., weights_only=False)`)
+and `io_contract.json` next to it.
+
+Nothing here trains, and nothing here should be benchmarked for accuracy. It is
+a shape and plumbing fixture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import torch
+from hydra.utils import instantiate
+
+from rmind.datamodules.nero_random import nero_random_batch
+from rmind.scripts.nero_smoke import _cfg
+
+
+def _describe(obj: Any, prefix: str = "") -> dict[str, Any]:
+    """Recursively map a nested batch/output to `{key: {shape, dtype}}`."""
+    out: dict[str, Any] = {}
+    items = obj.items() if hasattr(obj, "items") else []
+    for key, value in items:
+        name = f"{prefix}{key}"
+        if hasattr(value, "items"):
+            out.update(_describe(value, prefix=f"{name}."))
+        elif isinstance(value, torch.Tensor):
+            out[name] = {"shape": list(value.shape), "dtype": str(value.dtype)}
+        else:
+            out[name] = {"type": type(value).__name__}
+    return out
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    _ = parser.add_argument("--experiment", default="yaak/nero_arms/causal")
+    _ = parser.add_argument("--out", default="/tmp/nero-serving")  # noqa: S108
+    _ = parser.add_argument("--batch-size", type=int, default=1)
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+
+    torch.manual_seed(0)
+    cfg = _cfg(args.experiment)
+    model = instantiate(cfg.model).eval()
+
+    total = sum(p.numel() for p in model.parameters())
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+
+    batch = nero_random_batch(batch_size=args.batch_size)
+    with torch.no_grad():
+        output = model(batch)
+
+    contract = {
+        "note": "RANDOM WEIGHTS. Shapes are real; values are meaningless.",
+        "experiment": args.experiment,
+        "batch_size": args.batch_size,
+        "parameters": {"total": total, "trainable": trainable},
+        "inputs": _describe(batch),
+        "outputs": _describe(output),
+    }
+
+    ckpt = out / "policy_random.ckpt"
+    torch.save({"state_dict": model.state_dict(), "experiment": args.experiment}, ckpt)
+    (out / "io_contract.json").write_text(json.dumps(contract, indent=2))
+
+    print(json.dumps(contract, indent=2))  # noqa: T201
+    print(f"\ncheckpoint: {ckpt}")  # noqa: T201
+    print(f"contract:   {out / 'io_contract.json'}")  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rmind/scripts/nero_smoke.py
+++ b/src/rmind/scripts/nero_smoke.py
@@ -1,0 +1,436 @@
+"""Smoke harness for the nero-arms causal patch policy and its action tokenizer.
+
+Runs three stages, all on structured synthetic data at the **real** contract §8
+shapes (3 cameras, 120-dim bimanual action, camera-conditioning, goal images):
+
+``budget``
+    Compute the flattened sequence length, check `head_dim % 8 == 0`, and probe
+    which SDPA backend the trunk actually gets. This is the pre-flight from
+    PR #265: at head_dim 20 the fused kernels are inadmissible and the math
+    fallback materialises the full `(B, H, L, L)` score matrix and OOMs.
+``tokenizer``
+    Fit the VQ-BeT `NeroPoseTokenizer`, reporting translation error in **mm** and
+    rotation error in **degrees**, separately (contract §5.5). Writes the
+    checkpoint and the versioned standardisation artifact.
+``policy``
+    Train `NeroPatchPolicy` for a few hundred steps against that tokenizer;
+    report the loss curve, step time and peak memory.
+
+Usage::
+
+    uv run python -m rmind.scripts.nero_smoke --stage all --out /tmp/nero-smoke
+"""
+
+import argparse
+import json
+import statistics
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+from hydra import compose, initialize_config_dir
+from hydra.utils import instantiate
+from omegaconf import OmegaConf
+from torch.nn.attention import SDPBackend, sdpa_kernel
+
+from rmind.data.nero import PoseStandardizer
+from rmind.datamodules.nero_random import nero_random_batch
+
+CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
+#: steps discarded before the peak-memory counter is reset (allocator warmup)
+WARMUP_STEPS = 4
+
+
+def _cfg(experiment: str, overrides: list[str] | None = None) -> Any:
+    with initialize_config_dir(config_dir=str(CONFIG_DIR), version_base=None):
+        return compose(
+            config_name="train",
+            overrides=[f"experiment={experiment}", *(overrides or [])],
+        )
+
+
+def _to(batch: dict[str, Any], device: torch.device) -> dict[str, Any]:
+    return {k: v.to(device, non_blocking=True) for k, v in batch.items()}
+
+
+# --------------------------------------------------------------------- budget
+
+
+def stage_budget(cfg: Any) -> dict[str, Any]:
+    tokens_per_frame = cfg.num_cameras * cfg.num_patches + 1
+    sequence_length = cfg.episode_length * tokens_per_frame
+    head_dim = cfg.policy_embedding_dim // cfg.num_heads
+
+    report = {
+        "tokens_per_frame": tokens_per_frame,
+        "sequence_length": sequence_length,
+        "head_dim": head_dim,
+        "head_dim_div8": head_dim % 8 == 0,
+        "head_dim_even_for_rope": head_dim % 2 == 0,
+        # what the dense score matrix WOULD cost if a math fallback is taken
+        "dense_scores_gib_per_sample_bf16": (
+            cfg.num_heads * sequence_length**2 * 2 / 1024**3
+        ),
+    }
+    if not report["head_dim_div8"]:
+        msg = (
+            f"head_dim {head_dim} is not divisible by 8: fused SDPA is inadmissible and "
+            "the math fallback materialises the full (B, H, L, L) matrix (PR #265)"
+        )
+        raise ValueError(msg)
+
+    # empirical: is the memory-efficient backend actually admissible for the
+    # mask this trunk passes? Reasoning about it is not enough.
+    if torch.cuda.is_available():
+        q = torch.randn(
+            1, cfg.num_heads, 512, head_dim, device="cuda", dtype=torch.bfloat16
+        )
+        mask = torch.zeros(512, 512, device="cuda", dtype=torch.bool)
+        try:
+            with sdpa_kernel([SDPBackend.EFFICIENT_ATTENTION]):
+                _ = torch.nn.functional.scaled_dot_product_attention(
+                    q, q, q, attn_mask=~mask
+                )
+            report["efficient_attention_admissible"] = True
+        except RuntimeError as error:  # pragma: no cover - backend-dependent
+            report["efficient_attention_admissible"] = False
+            report["efficient_attention_error"] = str(error)[:200]
+    return report
+
+
+# ------------------------------------------------------------------ tokenizer
+
+
+def _chunk_pool(cfg: Any, *, batches: int, device: torch.device) -> torch.Tensor:
+    """`(n, H, features)` valid per-side chunks drawn from the synthetic stream."""
+    pool: list[torch.Tensor] = []
+    for i in range(batches):
+        batch = nero_random_batch(
+            batch_size=cfg.batch_size,
+            episode_length=cfg.episode_length,
+            action_horizon=cfg.action_horizon,
+            image_size=8,  # images unused here; keep them tiny
+            both_sides=cfg.both_sides,
+            seed=i,
+        )
+        action = batch["action.future_state"]  # (b, T, H, 2, F)
+        valid = batch["side_valid"]
+        b, t, h, s, f = action.shape
+        chunks = action.permute(0, 1, 3, 2, 4).reshape(-1, h, f)
+        mask = valid[:, None, :].expand(b, t, s).reshape(-1)
+        pool.append(chunks[mask])
+    return torch.cat(pool).to(device)
+
+
+def stage_tokenizer(  # noqa: PLR0914
+    cfg: Any, out: Path, *, steps: int, device: torch.device
+) -> dict[str, Any]:
+    torch.manual_seed(0)
+    model = instantiate(cfg.model)
+
+    train_pool = _chunk_pool(cfg, batches=256, device=device)
+    val_pool = _chunk_pool(cfg, batches=8, device=device)
+
+    # ⚠️ contract §5.4: statistics from the TRAIN split only.
+    standardizer = PoseStandardizer.from_samples(
+        train_pool.cpu(), source="smoke-train-split"
+    )
+    artifact = standardizer.save(out / "pose_standardizer.json")
+    model.standardizer = standardizer
+    model = model.to(device).train()
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=cfg.lr)
+    curve: list[dict[str, float]] = []
+    batch_size = 256
+
+    for step in range(steps):
+        index = torch.randint(0, train_pool.shape[0], (batch_size,), device=device)
+        chunks = train_pool[index]
+        raw = chunks.flatten(-2, -1)
+        a = model._normalize(raw)  # noqa: SLF001
+        z = model.encoder(a)
+        _codes, z_q, vq = model.quantizer(z)
+        a_hat = model.decoder(z + (z_q - z).detach())
+        recon = torch.nn.functional.l1_loss(a_hat, a)
+        loss = recon + model.vq_weight * (
+            vq["codebook"] + model.commitment_weight * vq["commit"]
+        )
+
+        optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        _ = torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+        optimizer.step()
+
+        if step % max(1, steps // 20) == 0 or step == steps - 1:
+            with torch.no_grad():
+                metrics = model.reconstruction_metrics(a_hat.detach(), raw)
+            curve.append({
+                "step": step,
+                "loss": loss.item(),
+                "recon": recon.item(),
+                **{k: v.item() for k, v in metrics.items()},
+            })
+            print(  # noqa: T201
+                f"[tokenizer] step {step:5d} loss {loss.item():.4f} "
+                f"recon {recon.item():.4f} "
+                f"trans {metrics['translation_mm'].item():.2f} mm "
+                f"rot {metrics['rotation_deg'].item():.2f} deg"
+            )
+
+    model.eval()
+    with torch.no_grad():
+        raw = val_pool.flatten(-2, -1)
+        codes = model(val_pool)
+        # round-trip exactly as the policy does it: codes -> chunk (no offset)
+        reconstruction = model.invert(codes)
+        held_out = {
+            k: v.item()
+            for k, v in model.reconstruction_metrics(reconstruction, raw).items()
+        }
+        # the UNQUANTIZED autoencoder, i.e. the ceiling the code path is measured
+        # against: the gap between the two is the cost of the codebook, and the
+        # gap between this and the mean baseline is what the encoder learned
+        a = model._normalize(raw)  # noqa: SLF001
+        z = model.encoder(a)
+        ae = {
+            k: v.item()
+            for k, v in model.reconstruction_metrics(model.decoder(z), raw).items()
+        }
+        # baseline: predicting the train-split MEAN chunk, so the numbers above
+        # are falsifiable rather than merely small
+        mean_chunk = model._normalize(train_pool.flatten(-2, -1)).mean(0, keepdim=True)  # noqa: SLF001
+        baseline = {
+            k: v.item()
+            for k, v in model.reconstruction_metrics(
+                mean_chunk.expand_as(a), raw
+            ).items()
+        }
+
+    torch.save(
+        {"state_dict": model.state_dict(), "hyper_parameters": dict(model.hparams)},
+        out / "pose_tokenizer.ckpt",
+    )
+    return {
+        "curve": curve,
+        "held_out_code_only": held_out,
+        "held_out_autoencoder": ae,
+        "held_out_mean_baseline": baseline,
+        "standardizer_artifact": str(artifact),
+        "num_train_chunks": int(train_pool.shape[0]),
+    }
+
+
+# --------------------------------------------------------------------- policy
+
+
+def stage_policy(  # noqa: C901, PLR0913, PLR0914, PLR0915
+    cfg: Any,
+    out: Path,
+    *,
+    steps: int,
+    device: torch.device,
+    tokenizer_ckpt: Path | None,
+    batch_size: int,
+    both_sides: bool = True,
+    overfit_one_batch: bool = False,
+) -> dict[str, Any]:
+    torch.manual_seed(0)
+    model = instantiate(cfg.model)
+
+    if tokenizer_ckpt is not None and tokenizer_ckpt.exists():
+        payload = torch.load(tokenizer_ckpt, map_location="cpu", weights_only=False)
+        missing = model.tokenizer.load_state_dict(payload["state_dict"], strict=False)
+        print(f"[policy] tokenizer loaded ({missing})")  # noqa: T201
+    model.tokenizer.requires_grad_(False).eval()  # noqa: FBT003
+    model = model.to(device)
+    model.train()
+
+    trainable = sum(p.numel() for p in model.parameters() if p.requires_grad)
+    total = sum(p.numel() for p in model.parameters())
+
+    optimizer = torch.optim.AdamW(
+        [p for p in model.parameters() if p.requires_grad], lr=cfg.lr, betas=(0.9, 0.95)
+    )
+
+    curve: list[dict[str, float]] = []
+    step_times: list[float] = []
+    if device.type == "cuda":
+        torch.cuda.reset_peak_memory_stats()
+
+    fixed = (
+        _to(
+            nero_random_batch(
+                batch_size=batch_size,
+                episode_length=cfg.episode_length,
+                action_horizon=cfg.action_horizon,
+                image_size=cfg.image_size,
+                both_sides=both_sides,
+                seed=0,
+            ),
+            device,
+        )
+        if overfit_one_batch
+        else None
+    )
+
+    for step in range(steps):
+        batch = fixed or _to(
+            nero_random_batch(
+                batch_size=batch_size,
+                episode_length=cfg.episode_length,
+                action_horizon=cfg.action_horizon,
+                image_size=cfg.image_size,
+                both_sides=both_sides,
+                seed=step,
+            ),
+            device,
+        )
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        started = time.perf_counter()
+
+        with torch.autocast(
+            device_type=device.type, dtype=torch.bfloat16, enabled=device.type == "cuda"
+        ):
+            metrics = model._compute_metrics(batch)  # noqa: SLF001
+            loss = metrics["policy", "loss"].sum(reduce=True)
+
+        optimizer.zero_grad(set_to_none=True)
+        loss.backward()
+        _ = torch.nn.utils.clip_grad_norm_(
+            [p for p in model.parameters() if p.requires_grad], 1.0
+        )
+        optimizer.step()
+
+        if device.type == "cuda":
+            torch.cuda.synchronize()
+        step_times.append(time.perf_counter() - started)
+
+        if step == WARMUP_STEPS and device.type == "cuda":  # discard warmup allocations
+            torch.cuda.reset_peak_memory_stats()
+
+        flat = {
+            "/".join(k): v.item()
+            for k, v in metrics.detach().items(include_nested=True, leaves_only=True)
+        }
+        curve.append({"step": step, "loss": loss.item(), **flat})
+        if step % max(1, steps // 20) == 0 or step == steps - 1:
+            extra = ""
+            if "policy/metric/translation_mm" in flat:
+                extra = (
+                    f" trans {flat['policy/metric/translation_mm']:.1f} mm "
+                    f"rot {flat['policy/metric/rotation_deg']:.1f} deg"
+                )
+            print(  # noqa: T201
+                f"[policy] step {step:4d} loss {loss.item():.4f} "
+                f"offset {flat['policy/loss/offset']:.4f}{extra}"
+            )
+
+    peak = torch.cuda.max_memory_allocated() / 1024**3 if device.type == "cuda" else 0.0
+    tokens_per_frame = cfg.num_cameras * cfg.num_patches + 1
+
+    def _mean(key: str, lo: int, hi: int) -> float:
+        return statistics.fmean(c[key] for c in curve[lo:hi])
+
+    window = max(1, steps // 10)
+    summary = {
+        "batch_size": batch_size,
+        "both_sides": both_sides,
+        "overfit_one_batch": overfit_one_batch,
+        # ⚠️ the trunk gradient-CHECKPOINTS while training
+        # (rmind.components.transformer.utils.run_layer_stack), so peak memory
+        # is a checkpointed figure -- memory traded for recompute.
+        "gradient_checkpointing": True,
+        "sequence_length": cfg.episode_length * tokens_per_frame,
+        "trainable_params_m": trainable / 1e6,
+        "total_params_m": total / 1e6,
+        "peak_memory_gib": peak,
+        "median_step_s": (
+            statistics.median(step_times[WARMUP_STEPS + 1 :])
+            if len(step_times) > WARMUP_STEPS + 1
+            else None
+        ),
+        "loss_first_window": _mean("loss", 0, window),
+        "loss_last_window": _mean("loss", -window, len(curve)),
+        "offset_first_window": _mean("policy/loss/offset", 0, window),
+        "offset_last_window": _mean("policy/loss/offset", -window, len(curve)),
+        "curve": curve,
+    }
+    name = "policy_curve"
+    if overfit_one_batch:
+        name += "_overfit"
+    if not both_sides:
+        name += "_right_only"
+    _ = (out / f"{name}.json").write_text(json.dumps(summary, indent=2))
+    return summary
+
+
+# ----------------------------------------------------------------------- main
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    _ = parser.add_argument(
+        "--stage", default="all", choices=["all", "budget", "tokenizer", "policy"]
+    )
+    _ = parser.add_argument("--out", default="/tmp/nero-smoke")  # noqa: S108
+    _ = parser.add_argument("--tokenizer-steps", type=int, default=3000)
+    _ = parser.add_argument("--policy-steps", type=int, default=300)
+    _ = parser.add_argument("--batch-size", type=int, default=8)
+    _ = parser.add_argument("--lr", type=float, default=None)
+    # right-only, i.e. the dummy recording's `side_valid = [False, True]`
+    _ = parser.add_argument("--right-only", action="store_true")
+    # train on ONE fixed batch: the discriminating check that the whole path
+    # (readout -> per-side embedding -> shared head -> tokenizer targets ->
+    # gradients) can learn at all, independently of whether fresh noise images
+    # carry any signal
+    _ = parser.add_argument("--overfit-one-batch", action="store_true")
+    _ = parser.add_argument(
+        "--device", default="cuda" if torch.cuda.is_available() else "cpu"
+    )
+    args = parser.parse_args()
+
+    out = Path(args.out)
+    out.mkdir(parents=True, exist_ok=True)
+    device = torch.device(args.device)
+    torch.set_float32_matmul_precision("high")
+
+    overrides = [] if args.lr is None else [f"lr={args.lr}"]
+    report: dict[str, Any] = {}
+    policy_cfg = _cfg("yaak/nero_arms/causal", overrides)
+
+    if args.stage in {"all", "budget"}:
+        report["budget"] = stage_budget(policy_cfg)
+        print(json.dumps(report["budget"], indent=2))  # noqa: T201
+
+    if args.stage in {"all", "tokenizer"}:
+        report["tokenizer"] = stage_tokenizer(
+            _cfg("yaak/nero_arms/tokenizer"),
+            out,
+            steps=args.tokenizer_steps,
+            device=device,
+        )
+
+    if args.stage in {"all", "policy"}:
+        report["policy"] = stage_policy(
+            policy_cfg,
+            out,
+            steps=args.policy_steps,
+            device=device,
+            tokenizer_ckpt=out / "pose_tokenizer.ckpt",
+            batch_size=args.batch_size,
+            both_sides=not args.right_only,
+            overfit_one_batch=args.overfit_one_batch,
+        )
+
+    _ = (out / "report.json").write_text(
+        json.dumps(
+            report, indent=2, default=lambda o: OmegaConf.to_container(o, resolve=True)
+        )
+    )
+    print(f"\nwrote {out / 'report.json'}")  # noqa: T201
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rmind/scripts/nero_smoke.py
+++ b/src/rmind/scripts/nero_smoke.py
@@ -34,7 +34,7 @@ from hydra.utils import instantiate
 from omegaconf import OmegaConf
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from rmind.data.nero import PoseStandardizer
+from rmind.data.nero import PoseStandardizer, state_quat_to_9d
 from rmind.datamodules.nero_random import CAMERA_NAMES, nero_random_batch
 
 CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
@@ -123,7 +123,9 @@ def _chunk_pool(cfg: Any, *, batches: int, device: torch.device) -> torch.Tensor
             both_sides=cfg.both_sides,
             seed=i,
         )
-        action = batch["action.future_state"]  # (b, T, H, 2, F)
+        # storage form (46/side) -> model-facing 9D (60/side), the same
+        # conversion the policy and the tokenizer do at their input boundary
+        action = state_quat_to_9d(batch["action.future_state"])  # (b, T, H, 2, 60)
         valid = batch["side_valid"]
         b, t, h, s, f = action.shape
         chunks = action.permute(0, 1, 3, 2, 4).reshape(-1, h, f)

--- a/src/rmind/scripts/nero_smoke.py
+++ b/src/rmind/scripts/nero_smoke.py
@@ -35,7 +35,7 @@ from omegaconf import OmegaConf
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from rmind.data.nero import PoseStandardizer
-from rmind.datamodules.nero_random import nero_random_batch
+from rmind.datamodules.nero_random import CAMERA_NAMES, nero_random_batch
 
 CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
 #: steps discarded before the peak-memory counter is reset (allocator warmup)
@@ -61,8 +61,17 @@ def stage_budget(cfg: Any) -> dict[str, Any]:
     tokens_per_frame = cfg.num_cameras * cfg.num_patches + 1
     sequence_length = cfg.episode_length * tokens_per_frame
     head_dim = cfg.policy_embedding_dim // cfg.num_heads
+    patch = 14
+    grid = (cfg.image_height // patch, cfg.image_width // patch)
+    if grid[0] * grid[1] != cfg.num_patches:
+        msg = (
+            f"num_patches {cfg.num_patches} != the {grid} grid implied by "
+            f"{cfg.image_height}x{cfg.image_width} at patch {patch}"
+        )
+        raise ValueError(msg)
 
     report = {
+        "patch_grid": list(grid),
         "tokens_per_frame": tokens_per_frame,
         "sequence_length": sequence_length,
         "head_dim": head_dim,
@@ -110,7 +119,7 @@ def _chunk_pool(cfg: Any, *, batches: int, device: torch.device) -> torch.Tensor
             batch_size=cfg.batch_size,
             episode_length=cfg.episode_length,
             action_horizon=cfg.action_horizon,
-            image_size=8,  # images unused here; keep them tiny
+            grids=dict.fromkeys(CAMERA_NAMES, (8, 8)),  # images unused here
             both_sides=cfg.both_sides,
             seed=i,
         )
@@ -264,7 +273,6 @@ def stage_policy(  # noqa: C901, PLR0913, PLR0914, PLR0915
                 batch_size=batch_size,
                 episode_length=cfg.episode_length,
                 action_horizon=cfg.action_horizon,
-                image_size=cfg.image_size,
                 both_sides=both_sides,
                 seed=0,
             ),
@@ -280,7 +288,6 @@ def stage_policy(  # noqa: C901, PLR0913, PLR0914, PLR0915
                 batch_size=batch_size,
                 episode_length=cfg.episode_length,
                 action_horizon=cfg.action_horizon,
-                image_size=cfg.image_size,
                 both_sides=both_sides,
                 seed=step,
             ),

--- a/tests/test_nero_patch_policy.py
+++ b/tests/test_nero_patch_policy.py
@@ -22,16 +22,21 @@ import torch
 from torch import Tensor, nn
 
 from rmind.components.containers import ModuleDict
+from rmind.components.image import LetterboxResize
 from rmind.components.loss import FocalLoss
 from rmind.components.transformer.causal_frame import CausalFrameTransformer
 from rmind.components.vq import ResidualVQ
-from rmind.data.nero import CAMERA_COND_DIM, NUM_SIDES, SIDE_DIM
+from rmind.data.nero import CAMERA_COND_DIM, NUM_SIDES, SIDE_DIM, STATE_QUAT_DIM
 from rmind.datamodules.nero_random import CAMERA_NAMES, nero_random_batch
 from rmind.models.nero_patch_policy import NeroPatchPolicy
 from rmind.models.nero_pose_tokenizer import NeroPoseTokenizer
 
-PATCH_GRID = 2  # 2x2 = 4 patches per camera, stands in for 16x16 = 256
-NUM_PATCHES = PATCH_GRID**2
+PATCH_GRID = (2, 3)  # 6 patches per camera, standing in for the real 10x16 = 160
+NUM_PATCHES = PATCH_GRID[0] * PATCH_GRID[1]
+# the three cameras arrive on DIFFERENT grids (rbyte isotropic downscale); the
+# model's LetterboxResize is what unifies them, so the test uses one too
+TEST_GRIDS = {"base": (9, 16), "side_left": (10, 16), "side_right": (10, 16)}
+UNIFIED = (10, 16)
 IMAGE_DIM = 8
 POLICY_DIM = 16
 NUM_HEADS = 2  # head_dim = 8: divisible by 8 (fused SDPA) and even (RoPE)
@@ -42,12 +47,21 @@ CODEBOOK_SIZE = 4
 NUM_QUANTIZERS = 2
 
 
-class _ToFloat(nn.Module):
-    """Stand-in for the real `LetterboxResize -> ToDtype -> Normalize` pipeline."""
+class _Unify(nn.Module):
+    """The real pipeline minus the ImageNet normalisation: letterbox, then scale.
+
+    The letterbox is not decoration here -- `base` and `side_*` arrive on
+    different grids, so without it the per-camera patch tensors cannot be
+    concatenated at all.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.letterbox = LetterboxResize(size=UNIFIED)
 
     @override
     def forward(self, x: Tensor) -> Tensor:
-        return x.float() / 255.0
+        return self.letterbox(x).float() / 255.0
 
 
 class _TinyImageEncoder(nn.Module):
@@ -60,9 +74,7 @@ class _TinyImageEncoder(nn.Module):
     @override
     def forward(self, x: Tensor) -> Tensor:
         *batch, c, h, w = x.shape
-        pooled = nn.functional.adaptive_avg_pool2d(
-            x.reshape(-1, c, h, w), (PATCH_GRID, PATCH_GRID)
-        )
+        pooled = nn.functional.adaptive_avg_pool2d(x.reshape(-1, c, h, w), PATCH_GRID)
         pooled = pooled.flatten(-2, -1).transpose(-2, -1)  # (n, P, 3)
         return self.projection(pooled).reshape(*batch, NUM_PATCHES, IMAGE_DIM)
 
@@ -89,7 +101,7 @@ def _policy(**kwargs: Any) -> NeroPatchPolicy:
     torch.manual_seed(0)
     action_dim = HORIZON * SIDE_DIM
     policy = NeroPatchPolicy(
-        image_transform=_ToFloat(),
+        image_transform=_Unify(),
         image_encoder=_TinyImageEncoder(),
         patch_projection=nn.Linear(2 * IMAGE_DIM + CAMERA_COND_DIM, POLICY_DIM),
         state_embedding=nn.Linear(NUM_SIDES * SIDE_DIM + NUM_SIDES, POLICY_DIM),
@@ -112,14 +124,12 @@ def _policy(**kwargs: Any) -> NeroPatchPolicy:
     return policy.eval()  # no dropout, no goal dropout
 
 
-def _batch(
-    *, both_sides: bool = True, seed: int = 0, image_size: int = 16
-) -> dict[str, Any]:
+def _batch(*, both_sides: bool = True, seed: int = 0) -> dict[str, Any]:
     return nero_random_batch(
         batch_size=2,
         episode_length=EPISODE_LENGTH,
         action_horizon=HORIZON,
-        image_size=image_size,
+        grids=TEST_GRIDS,
         both_sides=both_sides,
         seed=seed,
     )
@@ -146,24 +156,50 @@ def test_token_layout_and_readout_shapes() -> None:
     assert out.shape == (2, NUM_SIDES, HORIZON, SIDE_DIM)
 
 
-def test_contract_batch_shapes_are_what_section_8_specifies() -> None:
-    batch = _batch(image_size=24)
-    assert batch["state.pose"].shape == (2, EPISODE_LENGTH, NUM_SIDES, SIDE_DIM)
+def test_loader_shapes_are_what_rbyte_actually_emits() -> None:
+    """Storage form (46/side), per-camera grids, per-camera goal keys."""
+    batch = _batch()
+    assert batch["state.pose"].shape == (2, EPISODE_LENGTH, NUM_SIDES, STATE_QUAT_DIM)
     assert batch["action.future_state"].shape == (
         2,
         EPISODE_LENGTH,
         HORIZON,
         NUM_SIDES,
-        SIDE_DIM,
+        STATE_QUAT_DIM,
     )
     assert batch["camera_cond"].shape == (2, len(CAMERA_NAMES), CAMERA_COND_DIM)
-    assert batch["goal.image"].shape == (2, len(CAMERA_NAMES), 3, 24, 24)
     assert batch["side_valid"].shape == (2, NUM_SIDES)
     for camera in CAMERA_NAMES:
-        assert batch[f"image.{camera}"].shape == (2, EPISODE_LENGTH, 3, 24, 24)
+        h, w = TEST_GRIDS[camera]
+        assert batch[f"image.{camera}"].shape == (2, EPISODE_LENGTH, 3, h, w)
+        # three SEPARATE goal keys, each on its own grid
+        assert batch[f"goal.image.{camera}"].shape == (2, 3, h, w)
+    # the cameras really are on different grids -- otherwise the letterbox path
+    # this test exercises would be vacuous
+    assert len({TEST_GRIDS[c] for c in CAMERA_NAMES}) > 1
     # §6.2: action(t) really is the future state chunk [t+1 .. t+H]
     assert torch.allclose(
         batch["action.future_state"][:, 0, 0], batch["state.pose"][:, 1], atol=1e-6
+    )
+    # §6.2 alias, materialised by rbyte as a byte-identical duplicate
+    assert torch.equal(batch["action.commanded"], batch["action.future_state"])
+
+
+def test_storage_form_is_expanded_to_the_model_facing_9d_form() -> None:
+    policy = _policy()
+    batch = _batch()
+    assert policy._state(batch).shape == (  # noqa: SLF001
+        2,
+        EPISODE_LENGTH,
+        NUM_SIDES,
+        SIDE_DIM,
+    )
+    assert policy._chunk(batch).shape == (  # noqa: SLF001
+        2,
+        EPISODE_LENGTH,
+        HORIZON,
+        NUM_SIDES,
+        SIDE_DIM,
     )
 
 
@@ -292,7 +328,9 @@ def test_goal_image_reaches_the_trunk_and_can_be_disabled() -> None:
     baseline = policy._features(batch)  # noqa: SLF001
 
     perturbed = dict(batch)
-    perturbed["goal.image"] = torch.randint_like(batch["goal.image"], 0, 256)
+    for camera in CAMERA_NAMES:
+        key = f"goal.image.{camera}"
+        perturbed[key] = torch.randint_like(batch[key], 0, 256)
     assert not torch.allclose(policy._features(perturbed), baseline, atol=1e-4)  # noqa: SLF001
 
 
@@ -314,7 +352,9 @@ def test_goal_dropout_replaces_the_goal_with_a_learned_embedding() -> None:
     policy.train()
     policy.image_encoder.eval()
     other = dict(batch)
-    other["goal.image"] = torch.randint_like(batch["goal.image"], 0, 256)
+    for camera in CAMERA_NAMES:
+        key = f"goal.image.{camera}"
+        other[key] = torch.randint_like(batch[key], 0, 256)
     assert torch.allclose(policy._frame_tokens(other), dropped, atol=1e-6)  # noqa: SLF001
 
 

--- a/tests/test_nero_patch_policy.py
+++ b/tests/test_nero_patch_policy.py
@@ -1,0 +1,366 @@
+"""Causality, `side_valid` masking and conditioning flow for `NeroPatchPolicy`.
+
+The three properties that a shape test would pass vacuously, and that this file
+makes falsifiable:
+
+* **causality of the NEW token layout** -- a frame's readout must not move when a
+  LATER frame's pixels change. The layout differs from PR #265's (769 tokens per
+  frame across 3 cameras, state token first instead of a speed token), so the
+  trunk's guarantee has to be re-checked against this packing, not assumed.
+* **`side_valid`** -- perturbing an invalid side's state must leave the output
+  BIT-IDENTICAL, and the invalid side must contribute no loss rows. Note the
+  converse is deliberately NOT asserted: the state token is shared, so a valid
+  side's prediction legitimately depends on both sides' inputs.
+* **camera conditioning** -- `camera_cond` must actually reach the trunk. A
+  shape-only test passes even if the tensor is dropped on the floor.
+"""
+
+from typing import Any, override
+
+import pytest
+import torch
+from torch import Tensor, nn
+
+from rmind.components.containers import ModuleDict
+from rmind.components.loss import FocalLoss
+from rmind.components.transformer.causal_frame import CausalFrameTransformer
+from rmind.components.vq import ResidualVQ
+from rmind.data.nero import CAMERA_COND_DIM, NUM_SIDES, SIDE_DIM
+from rmind.datamodules.nero_random import CAMERA_NAMES, nero_random_batch
+from rmind.models.nero_patch_policy import NeroPatchPolicy
+from rmind.models.nero_pose_tokenizer import NeroPoseTokenizer
+
+PATCH_GRID = 2  # 2x2 = 4 patches per camera, stands in for 16x16 = 256
+NUM_PATCHES = PATCH_GRID**2
+IMAGE_DIM = 8
+POLICY_DIM = 16
+NUM_HEADS = 2  # head_dim = 8: divisible by 8 (fused SDPA) and even (RoPE)
+NUM_LAYERS = 2
+HORIZON = 2
+EPISODE_LENGTH = 3
+CODEBOOK_SIZE = 4
+NUM_QUANTIZERS = 2
+
+
+class _ToFloat(nn.Module):
+    """Stand-in for the real `LetterboxResize -> ToDtype -> Normalize` pipeline."""
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        return x.float() / 255.0
+
+
+class _TinyImageEncoder(nn.Module):
+    """Deterministic stand-in for the frozen ViT: `(..., 3, H, W)` -> `(..., P, D)`."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.projection = nn.Linear(3, IMAGE_DIM)
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        *batch, c, h, w = x.shape
+        pooled = nn.functional.adaptive_avg_pool2d(
+            x.reshape(-1, c, h, w), (PATCH_GRID, PATCH_GRID)
+        )
+        pooled = pooled.flatten(-2, -1).transpose(-2, -1)  # (n, P, 3)
+        return self.projection(pooled).reshape(*batch, NUM_PATCHES, IMAGE_DIM)
+
+
+def _tokenizer() -> NeroPoseTokenizer:
+    action_dim = HORIZON * SIDE_DIM
+    return NeroPoseTokenizer(
+        encoder=nn.Sequential(nn.Linear(action_dim, 32), nn.GELU(), nn.Linear(32, 16)),
+        # kmeans_init=False so the codebook is meaningfully initialised without a
+        # data-dependent first forward (the repo guards that on `training`)
+        quantizer=ResidualVQ(
+            dim=16,
+            codebook_size=CODEBOOK_SIZE,
+            num_quantizers=NUM_QUANTIZERS,
+            kmeans_init=False,
+        ),
+        decoder=nn.Sequential(nn.Linear(16, 32), nn.GELU(), nn.Linear(32, action_dim)),
+        action_features=SIDE_DIM,
+        action_horizon=HORIZON,
+    )
+
+
+def _policy(**kwargs: Any) -> NeroPatchPolicy:
+    torch.manual_seed(0)
+    action_dim = HORIZON * SIDE_DIM
+    policy = NeroPatchPolicy(
+        image_transform=_ToFloat(),
+        image_encoder=_TinyImageEncoder(),
+        patch_projection=nn.Linear(2 * IMAGE_DIM + CAMERA_COND_DIM, POLICY_DIM),
+        state_embedding=nn.Linear(NUM_SIDES * SIDE_DIM + NUM_SIDES, POLICY_DIM),
+        encoder=CausalFrameTransformer(
+            dim_model=POLICY_DIM,
+            num_layers=NUM_LAYERS,
+            num_heads=NUM_HEADS,
+            tokens_per_frame=len(CAMERA_NAMES) * NUM_PATCHES + 1,
+            window=EPISODE_LENGTH,
+        ),
+        tokenizer=_tokenizer(),
+        code_head=nn.Linear(POLICY_DIM, NUM_QUANTIZERS * CODEBOOK_SIZE),
+        offset_head=nn.Linear(POLICY_DIM, NUM_QUANTIZERS * CODEBOOK_SIZE * action_dim),
+        losses=ModuleDict(modules={"code": FocalLoss(), "offset": nn.L1Loss()}),
+        image_embedding_dim=IMAGE_DIM,
+        policy_embedding_dim=POLICY_DIM,
+        sample_codes=False,  # determinism
+        **({"goal_dropout": 0.0} | kwargs),
+    )
+    return policy.eval()  # no dropout, no goal dropout
+
+
+def _batch(
+    *, both_sides: bool = True, seed: int = 0, image_size: int = 16
+) -> dict[str, Any]:
+    return nero_random_batch(
+        batch_size=2,
+        episode_length=EPISODE_LENGTH,
+        action_horizon=HORIZON,
+        image_size=image_size,
+        both_sides=both_sides,
+        seed=seed,
+    )
+
+
+# ---------------------------------------------------------------- shape flow
+
+
+def test_token_layout_and_readout_shapes() -> None:
+    policy = _policy()
+    batch = _batch()
+    tokens = policy._frame_tokens(batch)  # noqa: SLF001
+    assert tokens.shape == (
+        2,
+        EPISODE_LENGTH,
+        len(CAMERA_NAMES) * NUM_PATCHES + 1,
+        POLICY_DIM,
+    )
+
+    features = policy._features(batch)  # noqa: SLF001
+    assert features.shape == (2, EPISODE_LENGTH, POLICY_DIM)
+
+    out = policy(batch)["policy", "action"]
+    assert out.shape == (2, NUM_SIDES, HORIZON, SIDE_DIM)
+
+
+def test_contract_batch_shapes_are_what_section_8_specifies() -> None:
+    batch = _batch(image_size=24)
+    assert batch["state.pose"].shape == (2, EPISODE_LENGTH, NUM_SIDES, SIDE_DIM)
+    assert batch["action.future_state"].shape == (
+        2,
+        EPISODE_LENGTH,
+        HORIZON,
+        NUM_SIDES,
+        SIDE_DIM,
+    )
+    assert batch["camera_cond"].shape == (2, len(CAMERA_NAMES), CAMERA_COND_DIM)
+    assert batch["goal.image"].shape == (2, len(CAMERA_NAMES), 3, 24, 24)
+    assert batch["side_valid"].shape == (2, NUM_SIDES)
+    for camera in CAMERA_NAMES:
+        assert batch[f"image.{camera}"].shape == (2, EPISODE_LENGTH, 3, 24, 24)
+    # §6.2: action(t) really is the future state chunk [t+1 .. t+H]
+    assert torch.allclose(
+        batch["action.future_state"][:, 0, 0], batch["state.pose"][:, 1], atol=1e-6
+    )
+
+
+# ----------------------------------------------------------------- causality
+
+
+def test_future_frames_do_not_change_earlier_readouts() -> None:
+    """Causality of the NEW 3-camera / state-token layout, not the trunk's alone."""
+    policy = _policy()
+    batch = _batch()
+    baseline = policy._features(batch)  # noqa: SLF001
+
+    perturbed = dict(batch)
+    images = batch["image.side_right"].clone()
+    images[:, -1] = torch.randint_like(images[:, -1], 0, 256)  # newest frame only
+    perturbed["image.side_right"] = images
+    after = policy._features(perturbed)  # noqa: SLF001
+
+    assert torch.allclose(baseline[:, :-1], after[:, :-1], atol=1e-6)
+    # falsifiability: the perturbation must actually matter SOMEWHERE
+    assert not torch.allclose(baseline[:, -1], after[:, -1], atol=1e-4)
+
+
+def test_state_of_a_future_frame_does_not_change_earlier_readouts() -> None:
+    policy = _policy()
+    batch = _batch()
+    baseline = policy._features(batch)  # noqa: SLF001
+
+    perturbed = dict(batch)
+    state = batch["state.pose"].clone()
+    state[:, -1] += 1.0
+    perturbed["state.pose"] = state
+    after = policy._features(perturbed)  # noqa: SLF001
+
+    assert torch.allclose(baseline[:, :-1], after[:, :-1], atol=1e-6)
+    assert not torch.allclose(baseline[:, -1], after[:, -1], atol=1e-4)
+
+
+# ---------------------------------------------------------------- side_valid
+
+
+def test_invalid_side_state_cannot_influence_the_output() -> None:
+    """The discriminating `side_valid` test: bit-identical, not merely 'it runs'."""
+    policy = _policy()
+    batch = _batch(both_sides=False)  # left absent, as in the dummy recording
+    assert not bool(batch["side_valid"][0, 0])
+
+    baseline = policy._features(batch)  # noqa: SLF001
+
+    perturbed = dict(batch)
+    state = batch["state.pose"].clone()
+    state[:, :, 0] = torch.randn_like(state[:, :, 0]) * 10  # the INVALID side
+    perturbed["state.pose"] = state
+    assert torch.equal(policy._features(perturbed), baseline)  # noqa: SLF001
+
+    # falsifiable control: the VALID side does influence the output
+    control = dict(batch)
+    state = batch["state.pose"].clone()
+    state[:, :, 1] = torch.randn_like(state[:, :, 1]) * 10
+    control["state.pose"] = state
+    assert not torch.allclose(policy._features(control), baseline, atol=1e-4)  # noqa: SLF001
+
+
+def test_invalid_side_contributes_no_loss_rows() -> None:
+    policy = _policy()
+    batch = _batch(both_sides=False)
+    metrics = policy._compute_metrics(batch)  # noqa: SLF001
+    # 2 samples x 3 frames x 1 valid side
+    assert metrics["policy", "metric", "valid_rows"].item() == 2 * EPISODE_LENGTH * 1
+
+    both = policy._compute_metrics(_batch(both_sides=True))  # noqa: SLF001
+    assert (
+        both["policy", "metric", "valid_rows"].item() == 2 * EPISODE_LENGTH * NUM_SIDES
+    )
+
+
+def test_invalid_side_action_values_do_not_move_the_loss() -> None:
+    """`sum/count` normalisation: garbage in the masked-out rows must be inert."""
+    policy = _policy()
+    batch = _batch(both_sides=False)
+    baseline = policy._compute_metrics(batch)["policy", "loss"].sum(reduce=True)  # noqa: SLF001
+
+    poisoned = dict(batch)
+    action = batch["action.future_state"].clone()
+    action[:, :, :, 0] = 1e3  # the invalid side's target
+    poisoned["action.future_state"] = action
+    assert torch.allclose(
+        policy._compute_metrics(poisoned)["policy", "loss"].sum(reduce=True),  # noqa: SLF001
+        baseline,
+        atol=1e-6,
+    )
+
+
+# ------------------------------------------------------ conditioning reaches
+
+
+def test_camera_conditioning_reaches_the_trunk() -> None:
+    policy = _policy()
+    batch = _batch()
+    baseline = policy._features(batch)  # noqa: SLF001
+
+    perturbed = dict(batch)
+    perturbed["camera_cond"] = batch["camera_cond"] + 1.0
+    assert not torch.allclose(policy._features(perturbed), baseline, atol=1e-4)  # noqa: SLF001
+
+
+def test_per_camera_conditioning_is_bound_to_that_camera() -> None:
+    """Conditioning is concatenated PER CAMERA, so swapping two cameras' vectors
+    must change the output -- an implementation that broadcast one shared vector
+    to all patches would pass a naive 'it changes something' test.
+    """
+    policy = _policy()
+    batch = _batch()
+    baseline = policy._features(batch)  # noqa: SLF001
+
+    swapped = dict(batch)
+    cond = batch["camera_cond"].clone()
+    cond[:, [1, 2]] = cond[:, [2, 1]]
+    swapped["camera_cond"] = cond
+    assert not torch.allclose(policy._features(swapped), baseline, atol=1e-4)  # noqa: SLF001
+
+
+def test_goal_image_reaches_the_trunk_and_can_be_disabled() -> None:
+    policy = _policy()
+    batch = _batch()
+    baseline = policy._features(batch)  # noqa: SLF001
+
+    perturbed = dict(batch)
+    perturbed["goal.image"] = torch.randint_like(batch["goal.image"], 0, 256)
+    assert not torch.allclose(policy._features(perturbed), baseline, atol=1e-4)  # noqa: SLF001
+
+
+def test_goal_dropout_replaces_the_goal_with_a_learned_embedding() -> None:
+    """Dropout must be TRAIN-only and must use `no_goal`, not zeros."""
+    policy = _policy(goal_dropout=1.0)
+    batch = _batch()
+
+    policy.train()
+    policy.image_encoder.eval()
+    dropped = policy._frame_tokens(batch)  # noqa: SLF001
+
+    policy.eval()
+    kept = policy._frame_tokens(batch)  # noqa: SLF001
+    assert not torch.allclose(dropped, kept, atol=1e-4)
+
+    # with every goal dropped the goal slice is the same learned vector for all
+    # cameras and patches, so two different goal images give the SAME tokens
+    policy.train()
+    policy.image_encoder.eval()
+    other = dict(batch)
+    other["goal.image"] = torch.randint_like(batch["goal.image"], 0, 256)
+    assert torch.allclose(policy._frame_tokens(other), dropped, atol=1e-6)  # noqa: SLF001
+
+
+# ------------------------------------------------------------------ training
+
+
+def test_gradients_flow_to_the_trunk_and_not_to_frozen_modules() -> None:
+    policy = _policy()
+    policy.train()
+    policy.image_encoder.eval()
+    loss = policy._compute_metrics(_batch())["policy", "loss"].sum(reduce=True)  # noqa: SLF001
+    loss.backward()
+
+    assert policy.encoder.layers[0].attn.in_proj_weight.grad is not None
+    assert policy.patch_projection.weight.grad is not None
+    assert policy.side_embedding.weight.grad is not None
+    assert all(p.grad is None for p in policy.tokenizer.parameters())
+    assert all(p.grad is None for p in policy.image_encoder.parameters())
+
+
+def test_head_is_weight_shared_but_side_distinguishing() -> None:
+    policy = _policy()
+    features = torch.randn(2, EPISODE_LENGTH, POLICY_DIM)
+    per_side = policy._per_side_features(features)  # noqa: SLF001
+    assert per_side.shape == (2, EPISODE_LENGTH, NUM_SIDES, POLICY_DIM)
+    assert not torch.allclose(per_side[..., 0, :], per_side[..., 1, :])
+
+
+@pytest.mark.parametrize("action_features", [SIDE_DIM, 12])
+def test_action_dimensionality_is_a_config_seam(action_features: int) -> None:
+    """Contract §11: swapping to the Revo2 joint-angle space must be config-only."""
+    tokenizer = NeroPoseTokenizer(
+        encoder=nn.Linear(HORIZON * action_features, 16),
+        quantizer=ResidualVQ(
+            dim=16,
+            codebook_size=CODEBOOK_SIZE,
+            num_quantizers=NUM_QUANTIZERS,
+            kmeans_init=False,
+        ),
+        decoder=nn.Linear(16, HORIZON * action_features),
+        action_features=action_features,
+        action_horizon=HORIZON,
+    ).eval()
+    assert tokenizer.has_pose_layout == (action_features == SIDE_DIM)
+
+    chunk = torch.randn(5, HORIZON, action_features)
+    codes = tokenizer(chunk)
+    assert codes.shape == (5, NUM_QUANTIZERS)
+    assert tokenizer.invert(codes).shape == (5, HORIZON * action_features)

--- a/tests/test_nero_patch_policy.py
+++ b/tests/test_nero_patch_policy.py
@@ -15,6 +15,7 @@ makes falsifiable:
   shape-only test passes even if the tensor is dropped on the floor.
 """
 
+from pathlib import Path
 from typing import Any, override
 
 import pytest
@@ -404,3 +405,114 @@ def test_action_dimensionality_is_a_config_seam(action_features: int) -> None:
     codes = tokenizer(chunk)
     assert codes.shape == (5, NUM_QUANTIZERS)
     assert tokenizer.invert(codes).shape == (5, HORIZON * action_features)
+
+
+# ------------------------------------------------------- action-space seam
+
+
+def _joint_policy(*, action_features: int, state_features: int) -> NeroPatchPolicy:
+    """The §13.3 option-A configuration: robot joint commands, ~12 dims per side."""
+    torch.manual_seed(0)
+    action_dim = HORIZON * action_features
+    tokenizer = NeroPoseTokenizer(
+        encoder=nn.Linear(action_dim, 16),
+        quantizer=ResidualVQ(
+            dim=16,
+            codebook_size=CODEBOOK_SIZE,
+            num_quantizers=NUM_QUANTIZERS,
+            kmeans_init=False,
+        ),
+        decoder=nn.Linear(16, action_dim),
+        action_features=action_features,
+        action_horizon=HORIZON,
+    )
+    return NeroPatchPolicy(
+        image_transform=_Unify(),
+        image_encoder=_TinyImageEncoder(),
+        patch_projection=nn.Linear(2 * IMAGE_DIM + CAMERA_COND_DIM, POLICY_DIM),
+        state_embedding=nn.Linear(NUM_SIDES * state_features + NUM_SIDES, POLICY_DIM),
+        encoder=CausalFrameTransformer(
+            dim_model=POLICY_DIM,
+            num_layers=NUM_LAYERS,
+            num_heads=NUM_HEADS,
+            tokens_per_frame=len(CAMERA_NAMES) * NUM_PATCHES + 1,
+            window=EPISODE_LENGTH,
+        ),
+        tokenizer=tokenizer,
+        code_head=nn.Linear(POLICY_DIM, NUM_QUANTIZERS * CODEBOOK_SIZE),
+        offset_head=nn.Linear(POLICY_DIM, NUM_QUANTIZERS * CODEBOOK_SIZE * action_dim),
+        losses=ModuleDict(modules={"code": FocalLoss(), "offset": nn.L1Loss()}),
+        image_embedding_dim=IMAGE_DIM,
+        policy_embedding_dim=POLICY_DIM,
+        sample_codes=False,
+        goal_dropout=0.0,
+    )
+
+
+def test_joint_angle_action_space_needs_no_code_change() -> None:
+    """Contract §10 A1 / §13.3 option A -- LOAD-BEARING, not precautionary.
+
+    The glove SE(3) parameterisation is a stand-in; iteration-1 teleop records
+    robot joint values (~12 per side, 24 bimanual). Swapping to that must be a
+    config change plus a new tokenizer checkpoint, so this exercises a full
+    forward AND backward in the joint-angle space with the SAME model code.
+    """
+    action_features, state_features = 12, 24
+    policy = _joint_policy(
+        action_features=action_features, state_features=state_features
+    )
+    policy.train()
+    policy.image_encoder.eval()
+
+    generator = torch.Generator().manual_seed(7)
+    batch = dict(_batch())
+    batch["state.pose"] = torch.randn(
+        2, EPISODE_LENGTH, NUM_SIDES, state_features, generator=generator
+    )
+    batch["action.future_state"] = torch.randn(
+        2, EPISODE_LENGTH, HORIZON, NUM_SIDES, action_features, generator=generator
+    )
+
+    # the storage-form conversion must NOT fire for a non-46-dim space
+    assert policy._state(batch).shape[-1] == state_features  # noqa: SLF001
+    assert policy._chunk(batch).shape[-1] == action_features  # noqa: SLF001
+    # ... and the pose-layout metrics must switch themselves off
+    assert not policy.tokenizer.has_pose_layout
+
+    loss = policy._compute_metrics(batch)["policy", "loss"].sum(reduce=True)  # noqa: SLF001
+    loss.backward()
+    assert policy.encoder.layers[0].attn.in_proj_weight.grad is not None
+    assert policy.offset_head.weight.grad is not None
+
+    policy.eval()
+    out = policy(batch)["policy", "action"]
+    assert out.shape == (2, NUM_SIDES, HORIZON, action_features)
+
+
+def test_head_widths_derive_from_the_action_space_in_config() -> None:
+    """The seam is only real if the CONFIG derives the head widths from it."""
+    from hydra import compose, initialize_config_dir  # noqa: PLC0415
+
+    config_dir = str(Path(__file__).resolve().parents[1] / "config")
+    widths: dict[int, tuple[int, int]] = {}
+    for action_features in (60, 12):
+        with initialize_config_dir(config_dir=config_dir, version_base=None):
+            cfg = compose(
+                config_name="train",
+                overrides=[
+                    "experiment=yaak/nero_arms/causal",
+                    f"action_features={action_features}",
+                ],
+            )
+        widths[action_features] = (
+            cfg.model.offset_head.hidden_channels[-1],
+            cfg.model.tokenizer.decoder.hidden_channels[-1],
+        )
+        assert widths[action_features] == (
+            cfg.num_quantizers
+            * cfg.codebook_size
+            * cfg.action_horizon
+            * action_features,
+            cfg.action_horizon * action_features,
+        )
+    assert widths[60] != widths[12]  # the override actually propagates

--- a/tests/test_nero_patch_policy.py
+++ b/tests/test_nero_patch_policy.py
@@ -516,3 +516,70 @@ def test_head_widths_derive_from_the_action_space_in_config() -> None:
             cfg.action_horizon * action_features,
         )
     assert widths[60] != widths[12]  # the override actually propagates
+
+
+# --------------------------------------------------------------- goal_valid
+
+
+def test_goal_valid_absent_is_backward_compatible() -> None:
+    """An existing batch with no `goal_valid` must behave exactly as before."""
+    policy = _policy()
+    batch = _batch()
+    policy.eval()
+    with torch.no_grad():
+        base = policy(batch)["policy"]["action"]
+        explicit = policy(
+            dict(batch) | {"goal_valid": torch.ones(2, 3, dtype=torch.bool)}
+        )["policy"]["action"]
+    assert torch.equal(base, explicit)
+
+
+def test_no_goal_is_reachable_at_inference() -> None:
+    """§22.8: the learned `no_goal` embedding must be usable at serving.
+
+    Before `goal_valid`, the only routes were training-time dropout and a
+    model-wide config switch, so a serving app could never say "no goal" -- and
+    omitting the frames raised KeyError while a black image was read as a real
+    goal.
+    """
+    policy = _policy()
+    batch = _batch()
+    policy.eval()
+    lean = {k: v for k, v in batch.items() if not k.startswith("goal.image")}
+    lean["goal_valid"] = torch.zeros(2, 3, dtype=torch.bool)
+    with torch.no_grad():
+        goal_free = policy(lean)["policy"]["action"]
+        goal_on = policy(batch)["policy"]["action"]
+    assert goal_free.shape == goal_on.shape
+    assert not torch.equal(goal_free, goal_on)
+
+
+def test_missing_goal_frames_still_raise_when_claimed() -> None:
+    """A missing key with `goal_valid` TRUE is an error, not an implicit no-goal."""
+    policy = _policy()
+    batch = _batch()
+    policy.eval()
+    broken = {k: v for k, v in batch.items() if k != "goal.image.base"}
+    broken["goal_valid"] = torch.ones(2, 3, dtype=torch.bool)
+    with pytest.raises(KeyError), torch.no_grad():
+        policy(broken)
+
+
+def test_goal_dropout_does_not_mutate_the_loader_flag() -> None:
+    """Regression: `present &= keep` would alias and corrupt `batch["goal_valid"]`.
+
+    `.to()` returns *self* when dtype and device already match, so an in-place op
+    permanently zeroes the loader's tensor -- and with a cached TensorDict the
+    corruption outlives the step. A ruff PLR6104 autofix introduced exactly this
+    bug in the depth path.
+    """
+    policy = _policy()
+    batch = _batch()
+    policy.train()
+    flag = torch.ones(2, 3, dtype=torch.bool)
+    batch = dict(batch) | {"goal_valid": flag}
+    for _ in range(5):
+        _ = policy._goal_features(  # noqa: SLF001
+            batch, batch_size=2, device=torch.device("cpu")
+        )
+    assert bool(flag.all()), "goal dropout mutated the caller's goal_valid tensor"

--- a/tests/test_nero_pose.py
+++ b/tests/test_nero_pose.py
@@ -15,6 +15,7 @@ from rmind.data.nero import (
     POSE_BLOCK_LAYOUT,
     ROTATION_INDICES,
     SIDE_DIM,
+    STATE_QUAT_DIM,
     TRANSLATION_INDICES,
     PoseStandardizer,
     canonicalize_quat,
@@ -28,6 +29,8 @@ from rmind.data.nero import (
     rot6d_to_quat,
     rot6d_to_rotmat,
     rotmat_to_quat,
+    state_9d_to_quat,
+    state_quat_to_9d,
     translation_rotation_split,
 )
 
@@ -245,3 +248,61 @@ def test_letterbox_camera_cond_rewrites_intrinsics_consistently() -> None:
     # ... and fy/S shrinks by the letterbox ratio
     assert out[0, 0, 1].item() == pytest.approx(0.9 * (1080 / 1920), abs=1e-6)
     assert out[0, 1, 1].item() == pytest.approx(0.9 * (800 / 1280), abs=1e-6)
+
+
+# ------------------------------------------------- storage <-> model-facing
+
+
+def test_state_quat_9d_round_trip_is_identity() -> None:
+    """46 (contract §5.2 storage) <-> 60 (model-facing 9D), the rbyte boundary."""
+    generator = torch.Generator().manual_seed(5)
+    poses = _random_poses(64 * 6, seed=6).reshape(64, 6 * 7)
+    hub = torch.randn(64, 4, generator=generator, dtype=torch.float64)
+    hub = canonicalize_quat(hub / hub.norm(dim=-1, keepdim=True))
+    state = torch.cat([poses, hub], dim=-1)
+    assert state.shape[-1] == STATE_QUAT_DIM
+
+    expanded = state_quat_to_9d(state)
+    assert expanded.shape[-1] == SIDE_DIM
+    assert torch.allclose(state_9d_to_quat(expanded), state, atol=TOL)
+
+
+def test_state_conversion_preserves_the_block_layout() -> None:
+    """The arm translation must land at indices 0..2, not somewhere else."""
+    state = torch.zeros(1, STATE_QUAT_DIM)
+    state[0, :3] = torch.tensor([0.3, 0.1, 0.05])  # arm translation
+    state[0, 6] = 1.0  # arm qw
+    for pose in range(1, 6):  # remaining poses: identity rotation
+        state[0, pose * 7 + 6] = 1.0
+    state[0, -1] = 1.0  # hub qw
+    expanded = state_quat_to_9d(state)
+    assert torch.allclose(expanded[0, :3], torch.tensor([0.3, 0.1, 0.05]), atol=TOL)
+    # identity rotation in 6D is the first two columns of I
+    assert torch.allclose(
+        expanded[0, 3:9], torch.tensor([1.0, 0, 0, 0, 1.0, 0]), atol=TOL
+    )
+
+
+def test_letterbox_to_a_rectangular_target_unifies_different_camera_grids() -> None:
+    """rbyte's per-camera isotropic downscale leaves base 270x480 and side_*
+    300x480; the model must land them on ONE grid without anisotropy.
+    """
+    transform = LetterboxResize(size=(140, 224))
+    outputs = {}
+    for camera, (h, w) in (("base", (270, 480)), ("side_left", (300, 480))):
+        outputs[camera] = transform(torch.zeros(2, 3, 3, h, w))
+        assert outputs[camera].shape == (2, 3, 3, 140, 224)
+    # 300x480 -> 140x224 is exactly isotropic, so the side cameras are NOT padded
+    # while base is (270/480 is a wider aspect than 140/224)
+    cond = torch.zeros(1, 2, 13)
+    cond[..., 0], cond[..., 1] = 0.5, 0.5
+    cond[..., 2], cond[..., 3] = 0.5, 0.5
+    size = torch.tensor([[[480.0, 270.0], [480.0, 300.0]]])
+    out = letterbox_camera_cond(cond, source_size=size, target_size=(140, 224))
+    # side camera: untouched (no padding, isotropic resize)
+    assert out[0, 1, 1].item() == pytest.approx(0.5, abs=1e-6)
+    # base camera: fy shrinks by 270/300 = 0.9, principal point re-centred
+    assert out[0, 0, 1].item() == pytest.approx(0.5 * 0.9, abs=1e-6)
+    assert out[0, 0, 3].item() == pytest.approx(0.5, abs=1e-6)
+    # widths are the limiting dimension for both, so fx is untouched
+    assert torch.allclose(out[..., 0], cond[..., 0])

--- a/tests/test_nero_pose.py
+++ b/tests/test_nero_pose.py
@@ -1,0 +1,247 @@
+"""Contract §5 / §7 primitives: rotation representations, standardisation, letterbox.
+
+The round-trip direction matters. `quat -> 9D -> quat` from a CANONICALISED unit
+quaternion is an identity and is tested to 1e-6. The reverse from an arbitrary
+9-vector is NOT an identity -- Gram-Schmidt is a projection -- so that direction
+is tested for the property that actually holds: the result is a valid rotation.
+"""
+
+import pytest
+import torch
+
+from rmind.components.image import LetterboxResize
+from rmind.data.nero import (
+    BIMANUAL_DIM,
+    POSE_BLOCK_LAYOUT,
+    ROTATION_INDICES,
+    SIDE_DIM,
+    TRANSLATION_INDICES,
+    PoseStandardizer,
+    canonicalize_quat,
+    geodesic_angle_error,
+    letterbox_camera_cond,
+    pose_9d_to_quat,
+    pose_error_metrics,
+    pose_quat_to_9d,
+    quat_to_rot6d,
+    quat_to_rotmat,
+    rot6d_to_quat,
+    rot6d_to_rotmat,
+    rotmat_to_quat,
+    translation_rotation_split,
+)
+
+TOL = 1e-6
+
+
+def _random_poses(n: int = 512, *, seed: int = 0) -> torch.Tensor:
+    generator = torch.Generator().manual_seed(seed)
+    q = torch.randn(n, 4, generator=generator, dtype=torch.float64)
+    q = canonicalize_quat(q / q.norm(dim=-1, keepdim=True))
+    t = torch.randn(n, 3, generator=generator, dtype=torch.float64) * 0.3
+    return torch.cat([t, q], dim=-1)
+
+
+# ------------------------------------------------------------------- layout
+
+
+def test_layout_partitions_the_60_dims() -> None:
+    assert SIDE_DIM == 60  # noqa: PLR2004
+    assert BIMANUAL_DIM == 120  # noqa: PLR2004
+    assert len(TRANSLATION_INDICES) == 18  # noqa: PLR2004
+    assert len(ROTATION_INDICES) == 42  # noqa: PLR2004
+    assert set(TRANSLATION_INDICES).isdisjoint(ROTATION_INDICES)
+    assert set(TRANSLATION_INDICES) | set(ROTATION_INDICES) == set(range(SIDE_DIM))
+    # exactly one rotation-only block (the hub orientation, contract §6.1)
+    assert sum(not b.has_translation for b in POSE_BLOCK_LAYOUT) == 1
+
+
+def test_translation_rotation_split_selects_the_right_columns() -> None:
+    x = torch.arange(SIDE_DIM, dtype=torch.float32)
+    t, r = translation_rotation_split(x)
+    assert t.tolist() == list(TRANSLATION_INDICES)
+    assert r.tolist() == list(ROTATION_INDICES)
+
+
+# ---------------------------------------------------------------- rotations
+
+
+def test_pose_quat_9d_round_trip_is_identity() -> None:
+    poses = _random_poses()
+    assert torch.allclose(pose_9d_to_quat(pose_quat_to_9d(poses)), poses, atol=TOL)
+
+
+def test_quaternion_double_cover_is_removed() -> None:
+    """`q` and `-q` are the same rotation and MUST map to the same 9D vector."""
+    poses = _random_poses()
+    flipped = poses.clone()
+    flipped[:, 3:] *= -1
+    assert torch.allclose(pose_quat_to_9d(poses), pose_quat_to_9d(flipped), atol=TOL)
+    assert (canonicalize_quat(flipped[:, 3:])[:, 3] >= 0).all()
+
+
+def test_rot6d_projects_arbitrary_vectors_onto_so3() -> None:
+    """The reverse direction is a PROJECTION, so assert the invariant, not identity."""
+    generator = torch.Generator().manual_seed(1)
+    perturbed = quat_to_rot6d(_random_poses()[:, 3:]) + 0.3 * torch.randn(
+        512, 6, generator=generator, dtype=torch.float64
+    )
+    r = rot6d_to_rotmat(perturbed)
+    eye = torch.eye(3, dtype=r.dtype).expand_as(r)
+    assert torch.allclose(r.transpose(-2, -1) @ r, eye, atol=1e-10)
+    assert torch.allclose(
+        torch.linalg.det(r), torch.ones(512, dtype=r.dtype), atol=1e-10
+    )
+
+
+def test_rotmat_quat_round_trip_including_near_zero_w() -> None:
+    """Shepperd's method must stay stable for 180-degree rotations (`qw ~ 0`)."""
+    axis = torch.tensor(
+        [[1.0, 0, 0], [0, 1.0, 0], [0, 0, 1.0], [1.0, 1.0, 1.0]], dtype=torch.float64
+    )
+    axis /= axis.norm(dim=-1, keepdim=True)
+    q = torch.cat([axis, torch.zeros(4, 1, dtype=torch.float64)], dim=-1)  # 180 deg
+    assert torch.allclose(rotmat_to_quat(quat_to_rotmat(q)).abs(), q.abs(), atol=1e-8)
+
+
+def test_rot6d_quat_round_trip_for_the_hub_block() -> None:
+    """Contract GAP: §5 names only the 7<->9 pair; the hub block needs 4<->6."""
+    q = _random_poses()[:, 3:]
+    assert torch.allclose(rot6d_to_quat(quat_to_rot6d(q)), q, atol=TOL)
+
+
+def test_geodesic_angle_error_matches_a_known_rotation() -> None:
+    identity = torch.tensor([0.0, 0.0, 0.0, 1.0], dtype=torch.float64)
+    angle = torch.tensor(0.5, dtype=torch.float64)  # 0.5 rad about z
+    rotated = torch.stack([
+        torch.tensor(0.0, dtype=torch.float64),
+        torch.tensor(0.0, dtype=torch.float64),
+        torch.sin(angle / 2),
+        torch.cos(angle / 2),
+    ])
+    error = geodesic_angle_error(quat_to_rot6d(identity), quat_to_rot6d(rotated))
+    assert error.item() == pytest.approx(torch.rad2deg(angle).item(), abs=1e-6)
+
+
+# --------------------------------------------------------------- error split
+
+
+def test_pose_error_metrics_separates_translation_from_rotation() -> None:
+    """The §5.5 requirement, made falsifiable: a translation-only error must not
+    show up as rotation error, and vice versa.
+    """
+    generator = torch.Generator().manual_seed(2)
+    target = torch.zeros(64, SIDE_DIM, dtype=torch.float64)
+    for block in POSE_BLOCK_LAYOUT:
+        target[..., block.rotation_slice] = quat_to_rot6d(
+            canonicalize_quat(
+                torch.nn.functional.normalize(
+                    torch.randn(64, 4, generator=generator, dtype=torch.float64), dim=-1
+                )
+            )
+        )
+        if block.has_translation:
+            target[..., block.translation_slice] = torch.randn(
+                64, 3, generator=generator, dtype=torch.float64
+            )
+
+    translated = target.clone()
+    translated[..., list(TRANSLATION_INDICES)] += 0.01  # 10 mm per axis
+    metrics = pose_error_metrics(translated, target)
+    assert metrics["translation_mm"].item() == pytest.approx(10 * 3**0.5, abs=1e-3)
+    assert metrics["rotation_deg"].item() == pytest.approx(0.0, abs=1e-6)
+
+    rotated = target.clone()
+    for block in POSE_BLOCK_LAYOUT:
+        angle = torch.tensor(0.2, dtype=torch.float64)
+        delta = torch.stack([
+            torch.zeros((), dtype=torch.float64),
+            torch.zeros((), dtype=torch.float64),
+            torch.sin(angle / 2),
+            torch.cos(angle / 2),
+        ])
+        r = quat_to_rotmat(delta) @ rot6d_to_rotmat(target[..., block.rotation_slice])
+        rotated[..., block.rotation_slice] = (
+            r[..., :, :2].transpose(-2, -1).reshape(64, 6)
+        )
+    metrics = pose_error_metrics(rotated, target)
+    assert metrics["translation_mm"].item() == pytest.approx(0.0, abs=1e-6)
+    assert metrics["rotation_deg"].item() == pytest.approx(
+        torch.rad2deg(torch.tensor(0.2)).item(), abs=1e-4
+    )
+
+
+# ------------------------------------------------------------ standardisation
+
+
+def test_standardizer_round_trip_and_channel_scaling() -> None:
+    generator = torch.Generator().manual_seed(3)
+    samples = torch.randn(4096, SIDE_DIM, generator=generator)
+    samples[:, list(TRANSLATION_INDICES)] *= 0.05  # metres-scale translations
+    standardizer = PoseStandardizer.from_samples(samples)
+
+    standardized = standardizer(samples)
+    assert torch.allclose(standardizer.unstandardize(standardized), samples, atol=1e-4)
+    # the point of §5.4: after standardisation the two channel groups have
+    # comparable scale, so an L1 objective weights them comparably
+    t, r = translation_rotation_split(standardized)
+    assert t.std().item() == pytest.approx(r.std().item(), rel=0.05)
+
+
+def test_standardizer_artifact_round_trip_and_version_gate(tmp_path) -> None:  # noqa: ANN001
+    generator = torch.Generator().manual_seed(4)
+    standardizer = PoseStandardizer.from_samples(
+        torch.randn(256, SIDE_DIM, generator=generator), source="unit-test"
+    )
+    path = standardizer.save(tmp_path / "stats.json")
+    loaded = PoseStandardizer.load(path)
+    assert torch.allclose(loaded.mean, standardizer.mean)
+    assert torch.allclose(loaded.std, standardizer.std)
+    assert loaded.source == "unit-test"
+
+    import json  # noqa: PLC0415
+
+    payload = json.loads(path.read_text())
+    payload["version"] = 999
+    _ = path.write_text(json.dumps(payload))
+    with pytest.raises(ValueError, match="version"):
+        _ = PoseStandardizer.load(path)
+
+
+# ------------------------------------------------------- camera conditioning
+
+
+def test_letterbox_resize_preserves_aspect_ratio() -> None:
+    """Contract §7.2: base is 16:9 and side_* are 16:10 -- an anisotropic resize
+    would make the same object a different shape in different cameras.
+    """
+    transform = LetterboxResize(size=224)
+    for w, h in ((1920, 1080), (1280, 800)):
+        x = torch.zeros(2, 3, 3, h, w)
+        x[..., h // 4 : 3 * h // 4, w // 4 : 3 * w // 4] = 1.0
+        out = transform(x)
+        assert out.shape == (2, 3, 3, 224, 224)
+        # the padded rows/cols are exactly the letterbox bars
+        scale = min(224 / w, 224 / h)
+        pad = 224 - max(1, round(h * scale))
+        if pad:
+            assert out[..., : pad // 2, :].abs().max().item() == pytest.approx(0.0)
+
+
+def test_letterbox_camera_cond_rewrites_intrinsics_consistently() -> None:
+    """A point at the image centre must stay at the letterboxed image centre."""
+    cond = torch.zeros(1, 2, 13)
+    cond[..., 0], cond[..., 1] = 0.5, 0.9  # fx/W, fy/H
+    cond[..., 2], cond[..., 3] = 0.5, 0.5  # principal point at the centre
+    cond[..., 4:] = torch.arange(9, dtype=torch.float32)  # extrinsics
+    size = torch.tensor([[[1920.0, 1080.0], [1280.0, 800.0]]])
+
+    out = letterbox_camera_cond(cond, source_size=size, target_size=224)
+    assert torch.allclose(out[..., 2], torch.full((1, 2), 0.5))  # centre stays centred
+    assert torch.allclose(out[..., 3], torch.full((1, 2), 0.5))
+    assert torch.allclose(out[..., 4:], cond[..., 4:])  # extrinsics untouched
+    # width is the limiting dimension for both cameras -> fx/S is unchanged
+    assert torch.allclose(out[..., 0], cond[..., 0])
+    # ... and fy/S shrinks by the letterbox ratio
+    assert out[0, 0, 1].item() == pytest.approx(0.9 * (1080 / 1920), abs=1e-6)
+    assert out[0, 1, 1].item() == pytest.approx(0.9 * (800 / 1280), abs=1e-6)


### PR DESCRIPTION
Causal patch policy for **nero-arms** — a new bimanual robot-manipulation dataset — plus a VQ-BeT SE(3) action tokenizer and a smoke run at real contract shapes.

![nero-arms architecture](https://raw.githubusercontent.com/yaak-ai/rmind/ab3d2028871acdac428f747c1fa506d7e78b8047/docs/nero_arms_architecture.svg)

<sub>blue = frozen · orange = trained · dashed cyan = the optional depth arm, off by default. Every figure is measured, not estimated; also committed as `docs/nero_arms_architecture.svg`.</sub>

> **Stacked PR.** Base is `feat/patch-policy-decoder-only`, which is itself unmerged and ahead of #265 (their merge-base `3398f3d` is #265's tip). Review that first; this only adds on top. The `CausalFrameTransformer` trunk is reused **unchanged**.

Both sides of this work code against a shared contract at `nero-arms/DATA_CONTRACT.md`, derived empirically from the recordings. The matching rbyte ingestion is on `feat/nero-arms` there.

## What's here

| file | what |
|---|---|
| `src/rmind/data/nero.py` | the §5 shared boundary — `pose_quat_to_9d`/`pose_9d_to_quat`, `state_quat_to_9d` (46↔60), the 60-dim channel layout, a versioned `PoseStandardizer`, mm/degree error split |
| `src/rmind/models/nero_patch_policy.py` | `NeroPatchPolicy` |
| `src/rmind/models/nero_pose_tokenizer.py` | `NeroPoseTokenizer` (VQ-BeT) |
| `src/rmind/components/image.py` | `LetterboxResize` |
| `src/rmind/datamodules/nero_random.py`, `src/rmind/scripts/nero_smoke.py` | synthetic data at real shapes, smoke harness |
| `docs/nero_arms_causal_patch_policy.md` | design record |
| `tests/test_nero_pose.py`, `tests/test_nero_patch_policy.py` | 34 new tests |

## Architecture decisions

**Camera conditioning is concatenated per patch**, not added as extra tokens and not FiLM. Zero sequence cost, binds each camera's geometry to its own patches, and doubles as camera identity — tested by swapping two cameras' vectors.

**Goal is a same-index concat of the goal image's patch features.** Goal patch `(c,p)` and observation patch `(c,p)` are the same ray, so index alignment preserves the "where did the object end up" signal that mean-pooling destroys. Goal dropout 0.15 to a **learned** `no_goal` embedding rather than zeros.

**`side_valid` is consumed twice** — state zeroed pre-token (bit-identity asserted) and loss **row-selected** with `sum/count`, never `mean` over zero-padding. The tokenizer and head are per-side weight-shared with a learned side embedding, so right-only data still trains something valid for the left hand. This matters because the dummy recordings are right-hand-only while the real rig is bimanual.

## Numbers

**Sequence 2886** — 481 tokens/frame on a 10×16 grid at 140×224, the cameras' own 5:8 aspect. A square 224² would have been 4614 for identical image content, with 6 of 16 patch rows pure padding — roughly 2.6× the attention cost. `head_dim` 64 (divisible by 8), memory-efficient SDPA confirmed admissible by probe rather than assumed; #265 hit exactly this and OOMed.

**Peak 1.74 GiB at batch 8, 0.21 s/step — with the trunk's gradient checkpointing on.** That qualifier is load-bearing for anyone sizing a real run.

**Tokenizer reconstruction, held out**, reported split as the contract requires:

| | translation | rotation |
|---|---|---|
| mean baseline | 14.24 mm | 10.94° |
| **codes only** | **9.76 mm** | **4.89°** |
| unquantized ceiling | 9.22 mm | 4.12° |

Codebook perplexity 15.5–15.8 of 16. Rotation is the real win, most of the way to its ceiling; translation moves much less. A single scalar loss would have hidden that asymmetry entirely — which is why the split is mandatory here.

**The smoke loss is flat, and that is the correct result.** The four code losses sit at 2.4368 = `(1−1/16)²·ln16`, exactly the uniform-prior floor: synthetic noise images carry no signal, so 480 of 481 tokens per frame are distractors. The path is proven by controls instead — one fixed batch reaches **0.57 mm / 1.41°** (code losses 0.000), and a right-only batch reaches **1.12 mm / 1.31°** with `valid_rows` pinned at 48, exercising the bimanual mask through a real backward pass.

## Verified, not asserted

`pose_quat_to_9d` is **bit-identical** to `rbyte.io.nero.rotation.pose_quat_to_9d` on random poses (independently re-checked: max difference exactly 0.0), block order agrees, and rbyte's `[t+1 … t+H]` action shift matches this side exactly. An off-by-one there would have read as a suspiciously good loss curve rather than a failure.

The action-space seam is proven by a real forward+backward at `action_features=12`, plus config composition at both 60 and 12 — not by assertion. That matters because the glove parameterisation is only a stand-in: iteration-1 teleop data will be robot joint values (NERO 7 DOF + Revo2 6 actuated DOF ≈ 13/side, 26 bimanual, against 120 here).

## Tests

Baseline on the untouched base branch: 134 passed, 1 skipped, 3 pre-existing `test_models.py` fixture errors. After: **168 passed, 1 skipped, same 3 errors** — no new failures.

Those 3 errors were independently confirmed pre-existing by running `test_models.py` on a detached worktree of the base branch and getting the identical three — worth checking because this PR touches `timm_backbone.py`, which the driving models share.

`test_compile_benchmark.py` is a pre-existing `torch.compile` benchmark that crawls on a loaded box; it is unaffected by these changes.

## Contract contradictions found

Documented in the design doc; the two consequential ones:

1. **§8's `(T,2,60)` contradicted §5.2's 46-dim quaternion storage.** rbyte implemented §5.2; this expands at the model boundary. The contract has been corrected.
2. **§8 implied a common image H/W across cameras; there is none** (base 270×480, sides 300×480). An anisotropic resize there fails **silently** and invalidates `camera_cond`. Hence `LetterboxResize`.

Also: the 60-dim channel order was undefined and therefore unimplementable for per-channel standardisation — now pinned on both sides; §5 named only the 7↔9 conversion, but the hub block is rotation-only and needs 4↔6.

## Caveats for the reviewer

- **The synthetic tokenizer numbers are not a forecast.** The generator's compressibility was deliberately built in, and the real data will not even be this action space.
- `lr_warmup_steps`/`lr_total_steps` are placeholders. 15,047 real samples ≈ 1.9k steps/epoch at batch 8 — re-derive before a real run, and note `get_cosine_schedule_with_warmup` rises again past `num_training_steps` (this bit the FT baseline).
- **The goal-xyz RVQ is not delivered** — `NeroGoalXYZTokenizer` is a named seam only; its inherited `_gather` doesn't handle a `(b,2,3)` tensor.
- One deliberate deviation: `offset_head` penultimate width 512 rather than the driving config's 1024 (23040 outputs would otherwise be 23.6M params).
- Two non-nero files touched: `timm_backbone.py` (non-square patch grids; identical behaviour for square inputs) and a whitespace-only `ruff format` of a code sample in `docs/decoder_only_kv_cache.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Since this PR was opened

- **`sample_codes` now defaults to `False`** (argmax). Inference is deterministic, and the reported reconstruction metrics measure what the serving path actually produces — the export config already forced argmax, so only the default disagreed. Safe because no loss depends on it while `teacher_force_offset` is true: verified, all five losses bit-identical under both settings.
- **`goal_valid` added** (§22.8). The learned `no_goal` embedding was unreachable at inference — omitting the goal frames raised `KeyError`, and a black image was read as a *real* goal while being out of distribution. Now `(b, n_cam)` bool, per camera; where false the frames may be omitted entirely. Absent ⇒ all-true, so existing batches are bit-identical.
- **Serving stub + handover** — `rmind.scripts.nero_serving_stub` emits a random-weight checkpoint and `io_contract.json` so a serving app can be built before training; `docs/nero_serving_handover.md` is the one-pager.
- **Architecture pictogram**, above.

One implementation note worth carrying: the goal-dropout composition is written `present = present & keep`, deliberately **not** `present &= keep`. `present` may alias `batch["goal_valid"]` — `.to()` returns *self* when dtype and device already match — so the in-place form permanently corrupts the loader's tensor, invisibly, and worse with a cached TensorDict. A ruff `PLR6104` autofix introduced exactly that bug in the depth path; there is a regression test pinning it here.
