### PR TITLE
chore(skills): add the trt-export Claude Code skill

### DIFF
--- a/.claude/skills/trt-export/SKILL.md
+++ b/.claude/skills/trt-export/SKILL.md
@@ -1,0 +1,477 @@
+---
+name: trt-export
+description: Build, validate and deploy TensorRT engines from rmind ONNX exports for the yaak test car — fp16 / fp16-strict / fp32, ONNX-Runtime parity verification, Orin latency benchmarking, and the two-hop transfer to the car. Use whenever asked to export/convert an ONNX to TRT, build engines for serving, benchmark model latency on Orin, or ship a model to the car.
+---
+
+# TRT export for the drivr car
+
+Turn an rmind ONNX export into a TRT engine that is **verified equivalent to the ONNX**,
+benchmarked against the control-loop budget, and deployed to the car.
+
+Building the engine is the easy part. Every expensive failure here was silent: an engine
+that loads, runs fast, and decodes **different actions**; an engine built under CPU load
+that is needlessly slow; a runtime that feeds the wrong image size without complaining.
+Each rule below exists because one of those happened.
+
+## 1. Hosts
+
+| Host | Role | Notes |
+| --- | --- | --- |
+| `sisyphos.ml`, `tresor.ml` | ONNX source | `/nasa/...` shared NAS (same files on both) |
+| `max@delta-dev1.kit` | preferred build host | **IP moves** — was `172.30.0.62`; if the alias fails, ask |
+| `max@delta-emc1.kit` | the car, serving target | `172.30.0.40` |
+
+**Routing — verified 4 Aug, and only the car needs a relay:**
+
+- **sisyphos ↔ dev1 is direct**, over ZeroTier, using dev1's `172.30.0.62` (its ZeroTier
+  address) — *not* `192.168.144.35`, which has no route from sisyphos. So push ONNX
+  straight from the NAS to the build host; no hop through your machine.
+  **Use `ConnectTimeout=30`.** A cold ZeroTier path starts out in `RELAY` state and takes
+  many seconds to establish; `ConnectTimeout=8` fails and looks exactly like "no route".
+  That false negative is why this doc previously claimed no route existed.
+- **The car is reachable only from your machine**, via the AWS Client VPN (`utun5`,
+  `172.30.0.0/24`). Both sisyphos and dev1 get "No route to host" for `172.30.0.40`
+  despite sharing the ZeroTier network with it. So the *engine* leg does need two
+  `rsync` hops through your machine — `md5sum` both ends.
+- Cloudflare WARP carries `192.168.207.0/24` and `192.168.144.0/24` for enrolled
+  **clients** only; sisyphos and dev1 have no `warp-cli`, so it is not a host-to-host
+  path. (`ProxyJump 10.19.17.255` in sisyphos's ssh_config is stale — it times out.)
+- The car link is flaky: expect rsync to die mid-transfer on large engines. Use
+  `--partial --append-verify` plus a retry loop, and treat `md5sum` as the acceptance
+  gate — an interrupted `--partial` run leaves a **truncated file under the final
+  engine name**, which is worse than no file.
+
+Use `/home/max/Code/drivr/.venv` on dev1 and the car — it has `tensorrt`, `onnxruntime`,
+`torch`, `structlog`. `/home/nvidia/workspace/drivr/.venv` on dev1 has none of them; a
+build that "fails" in **0 seconds** is this, not a real build error.
+
+## 2. Inspect the graph — do not trust the manifest
+
+```
+scripts/inspect_onnx.py MODEL.onnx [MODEL2.onnx ...]
+```
+
+Exports ship a `MANIFEST.md`; trust it for intent, not facts (names get flattened at
+export, so `data.cam_front_left` becomes `batch_data_cam_front_left` and the manifest may
+predate that). Four things decide everything downstream:
+
+- **Input image size, and the `Resize` count.** Zero `Resize` nodes means the graph does
+  **not** rescale — the host must deliver the exact size. PatchPolicy: DINOv2 = 224×224,
+  DINOv3 = 256×256.
+- **First ops.** `Sub`/`Div` at the top = ImageNet normalization is **in-graph**, so the
+  host feeds `[0,1]` (`--image-norm unit`). Normalizing host-side too double-normalizes
+  every pixel and degrades the model silently.
+- **`ArgMax` count.** Non-zero = codebook/VQ decoding in-graph. **This is the model class
+  where fp16 is dangerous** (§4) — a tiny numeric error flips a discrete code, so the
+  action changes by a *step*, not a nudge.
+- **`Sin`/`Cos`.** Indicates RoPE. DINOv3 has them, DINOv2 does not, and DINOv3 is by far
+  the most fp16-fragile of the family.
+
+## 3. Build — only on an idle host
+
+```
+/home/max/Code/drivr/.venv/bin/python \
+  /home/max/Code/drivr/scripts/build_trt_engine.py \
+  --onnx MODEL.onnx --precision {fp32|fp16|fp16-strict} --workspace-gb 6
+```
+
+Suffixes: `fp32` → `.trt`, `fp16` → `.fp16.trt`, `fp16-strict` → `.fp16strict.trt`.
+`fp16-strict` = FP16 with computation layers pinned to FP32 via
+`OBEY_PRECISION_CONSTRAINTS`.
+
+**TRT selects kernels by timing them**, so building on a loaded machine bakes in slower
+tactics. `scripts/build_and_bench.sh` gates on sustained low load (3 checks under 3.0,
+45 s apart) and **exits without building** if it never settles — that is deliberate;
+a mistimed engine is worse than no engine.
+
+Engines are tied to **TRT version + GPU arch**. Building on dev1 and serving on the car
+is only valid because both are Orin on the same TRT. Check before shipping:
+
+```
+dpkg -l | grep -m1 libnvinfer-bin                                    # must match
+cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_max_freq            # and clocks,
+cat /sys/devices/platform/bus@0/17000000.gpu/devfreq/*/max_freq      # or latency
+grep -m1 PM_CONFIG /etc/nvpmodel.conf                                # won't transfer
+```
+
+## 4. Pick precision by measurement, never by default
+
+Measured on PatchPolicy (ViT-S encoder, 6 frames, Orin @ GPU 918 MHz):
+
+Full Pareto curve, **all at n=200 with an fp32 control**, on `zt39kjn4-v1` (the
+widest-margin checkpoint in a 16-model screen — so these are best-case numbers):
+
+| config | fp32-pinned layers | latency | decisions |
+| --- | --- | --- | --- |
+| **fp32** (TF32 flag *cleared*) | all | **420 ms** | **0/200 — the only decision-exact option** |
+| `tf32` (TRT's default fp32 path) | all | 226 ms | 1/200 |
+| fp16-strict | ~all compute | 232 ms | 1/200 |
+| bf16 everywhere + fp32 decode | decode | 182 ms | 19/200 |
+| fp32 encoder + **bf16** trunk | encoder + decode | 98 ms | 12/200 |
+| **fp32 encoder + fp16 trunk** | encoder + decode | **98 ms** | **1/200 ← best non-fp32** |
+| AMP-faithful + fp32 encoder | 86 + encoder + decode | 97 ms | 2/200 |
+| fp32 encoder + int8 trunk | encoder + decode | 96 ms | 1/200 |
+| **AMP-faithful** (norms/softmax/reduce) | **86 layers** + decode | **74 ms** | 5/200 |
+| int8 everywhere but decode | decode | 72 ms | 7/200 |
+| pure fp16 | none | 72 ms | ~16/200 |
+
+**What to take from this, in order of how much time it saves you:**
+
+1. **`fp16-strict` is dominated — stop reaching for it as the "safe middle".** It is
+   232 ms at 1/200, while **fp32-encoder + fp16-trunk is 98 ms at the same 1/200** — 2.4×
+   faster for identical parity. fp16-strict's design is *backwards* relative to how these
+   models train: it pins the **compute** (GEMMs) to FP32 and leaves data movement in fp16,
+   whereas AMP does the opposite. That is why it is both slow (the GEMMs are the cost) and
+   not actually safer.
+2. **Pin the image encoder, not the tail.** Error is created in the encoder (relative error
+   9e-4 → 3.2e-3) and is flat through the temporal trunk (2.46e-3 → 2.63e-3). Every attempt
+   to pin the tail — TopK, ArgMax, constants, decode head — produced engines **bit-identical**
+   to the unpinned build, because the readout feature was already corrupted. The encoder is
+   only ~18 % of runtime, so protecting it is cheap.
+3. **bf16 is strictly worse here, despite being the training precision.** 12/200 vs 1/200 on
+   the trunk *at identical latency*, and 19/200 network-wide at 182 ms. bf16 has 8 mantissa
+   bits vs fp16's 11 (~8× coarser ULP), and this failure is mantissa-limited. Do not
+   "match training precision" reflexively.
+4. **Trunk precision barely matters** once the encoder is fp32 — fp16, int8 and bf16 all land
+   within a few ms, because the trunk is bandwidth-bound. Choose fp16 (best parity).
+5. **A cheap partial:** pinning just the 86 `NORMALIZATION`/`SOFTMAX`/`REDUCE` layers to fp32
+   gives 5/200 at **74 ms** — 3× better than pure fp16 for 2.7 ms. Good if you need ~74 ms
+   and can accept ~2.5 %.
+6. **naive int8 PTQ (logits quantized) = 82 % wrong.** Never ship it.
+7. **`tf32` — TRT's *default* — is also dominated, and worth understanding.** Our `fp32`
+   build calls `config.clear_flag(trt.BuilderFlag.TF32)`, i.e. it disables the tensor-core
+   path to get *true* fp32. That is the entire reason fp32 costs 420 ms; leave TF32 on and
+   the same network is **226 ms**. But it scores **1/200**, so it buys nothing over the
+   98 ms mixed engine and is 2.3× slower. Build it only to reason about *why* fp16 fails:
+   TF32 rounds matmul **inputs** to a 10-bit mantissa (same as fp16) while accumulating in
+   fp32 and keeping fp32 storage between ops, so it isolates input-mantissa loss from
+   intermediate rounding. Keep using the TF32-*cleared* build as the reference — it is the
+   only 0/200 config, and a reference must be exact.
+
+### Read `max|d|` PER CHANNEL — the single scalar is misleading
+
+`parity_matrix.py` reports one `max|d|` over the whole `(horizon x action_features)` chunk.
+For PatchPolicy the channels are **`[gas_pedal, brake_pedal, steering_angle, turn_signal]`**
+(the tokenizer's continuous normalizer is `Identity`, so gas/brake/steering are already in
+their `*_normalized` units). `turn_signal` has a much larger dynamic range than the pedals and
+**dominates the headline number**.
+
+Measured on `zt39kjn4-v5`, `encfp32-fp16trunk` vs native, n=200
+(`scripts/per_channel_parity.py`):
+
+| channel | max \|d\| | mean \|d\| |
+| --- | --- | --- |
+| gas_pedal | 0.0843 | 4.5e-04 |
+| brake_pedal | 0.0355 | 1.9e-04 |
+| steering_angle | 0.0541 | 2.5e-04 |
+| **turn_signal** | **0.5461** | 2.6e-03 |
+
+The engine's headline `max|d| = 0.546` is entirely the **turn signal** — an indicator state
+change, not a trajectory change. Reporting it as a "coarse mode change" was wrong.
+
+Do **not** over-correct the other way either: both flagged trials also exceed tol on a
+*control* channel (`decision changes CONTROL only: 2/200`). The defensible statement is
+"worst case 8.4 % throttle / 5.4 % steering / 3.6 % brake on 1 % of plans, on a harness ~7x
+harsher than the road", not "only the indicator changed".
+
+**Always run `per_channel_parity.py` before quoting a magnitude to anyone.**
+
+### The ONNX fp32 reference is validated against rmind native — don't re-litigate it
+
+Every parity number here is scored against ORT fp32 on the exported ONNX. That baseline was
+checked directly against **rmind PyTorch native** (`PatchPolicy.load_for_export` — the same
+callable the graph is traced from, `sample_codes=False`), same harness inputs, same seed:
+
+| | decisions | max \|d\| | mean \|d\| |
+| --- | --- | --- | --- |
+| native vs ONNX fp32 (`zt39kjn4-v5`, n=200) | **0/200** | 7.75e-07 | 5.10e-08 |
+
+Float32 round-off, not a modelling difference. Re-scoring the engines against a **native**
+reference cache instead of the ORT one reproduced the TRT numbers *exactly* — 0/200 for fp32,
+and 2/200 at `max|d| = 0.546103`, `mean = 8.72e-04` for the mixed engine, identical to six
+digits and on the identical trials. So the ORT reference is sound and results hold
+transitively. `scripts/native_vs_ort.py` re-runs this and emits a native ref-cache in
+`parity_matrix.py`'s npz format (feed it via `--ref-cache`) if you ever need to re-check a
+new arm.
+
+### The residual `1/200` is a boundary tie, not precision damage
+
+Worth knowing before you spend anything trying to reach 0/200 on a fast engine. Four
+different numeric paths — `tf32`, `encfp32-fp16trunk`, and the derived-range rebuild — all
+flip **the same trial (t82)** by the **same magnitude** (0.0952 / 0.0950 / 0.0950). And
+`tf32` is measurably *more* accurate than the fp16 trunk (mean |d| 1.23e-4 vs 1.39e-4) yet
+flips the identical decision. An input that flips under every perturbation regardless of the
+perturbation's size is sitting **on** an `ArgMax` boundary — it is a tie, not damage.
+
+Its consequence is small *by construction*: a tight margin means the two codes are
+near-equivalent, so the decode barely moves. Measured, that flip is 0.095 in normalized
+action units, matching the ~0.105 mean consequence of tie states from the code-bimodality
+study (decisive decisions carry ~0.50). Real-data ULP-risk rate is **0.136 %**, ~7× rarer
+than this synthetic harness suggests.
+
+So: **read the serving engine's `1/200` as "clean apart from one degenerate input", not as a
+0.5 % defect rate**, and do not conclude a training change is needed to widen margins — at
+this configuration there is almost nothing left for it to fix. (Bounded honestly: n=200 over
+3 real frames with synthetic speed/waypoints. This rules out *additional* precision-driven
+flips at that sample size, not all of them. Re-check per checkpoint with §4a — margins are
+per-checkpoint, and 2 of 7 checkpoints genuinely do flip ~4 %.)
+
+⚠️ **Only the TF32-cleared fp32 build has ever reached 0/200.** Do not conclude parity from
+n=50: `2/50` and `4/50` are indistinguishable and both are consistent with 3.5 %. Every
+low-precision config that looked acceptable at n=50 failed at n=200.
+
+⚠️ **Caveat on the reference.** These models train *and validate* under `torch.autocast(bf16)`
+(`patch_policy_eval.py`), while `export_onnx.py` exports in plain fp32. So the fp32 ONNX we
+score against is a precision the model was never trained or evaluated at. At a top1−top2 gap
+of 0.35 fp16 ULP the model never learned a preference at that resolution, so a 1/200
+disagreement with fp32 is not self-evidently a defect. If you need to settle this, build a
+bf16-faithful engine (export under autocast + `trtexec --stronglyTyped`) and score it against
+a **bf16** reference.
+
+⚠️ **At n=200, fp32 is the only config that has ever passed.** Do not conclude from an
+n=50 run that a low-precision engine is at parity: `2/50` and `4/50` are indistinguishable,
+and both are consistent with a true rate of 3.5 %. Every low-precision config that looked
+acceptable at n=50 failed when re-measured at n=200.
+
+**Two things to take from this table.**
+
+**(1) fp16-strict is per-checkpoint, not per-architecture.** 2 of 7 checkpoints flip ~4 % of
+actions, and failure does **not** follow the arm — `b2itoon8-v3` passes while its own parent
+`wxyp0bzq-v9` fails on the same head. **You cannot inherit a verdict from a sibling.** Root
+cause is `code_head` ArgMax margin geometry: a top1−top2 gap under ~1 fp16 ULP is not
+resolvable in fp16 at all. Error accumulates in the *encoder* (9e-4 → 3.2e-3) and is flat
+through the head, so **no mixed-precision layer pinning fixes it** — pinning TopK/ArgMax/
+constants to FP32 produced engines *bit-identical* to the unpinned one.
+
+**(2) int8 is not usable on this model family, even with the decode head protected.**
+Quantizing the logits too is catastrophic (82 % wrong). Pinning the code-head MLP, codebook
+gather, offset table and `tokenizer.decoder` to FP32 (`build_mixed.py --precision int8-mixed
+--fp32-index-ranges …`) rescues it to *look* fine at n=50 — but at **n=200 it flips 3.5 %
+even on the checkpoint with the widest margins in the whole fleet** (13.7 fp16 ULP), and
+7.0 % on a tight one. int8 also buys nothing over pure fp16 on speed (both ~70 ms — the
+model is bandwidth-bound), so there is no reason to prefer it.
+
+**The margin screen predicts fp16 safety, NOT int8 safety.** ULPs are an fp16 unit; int8
+activation quantization error is far larger than one fp16 ULP, so a 13.7-fp16-ULP margin is
+not remotely a guarantee under int8. If you want int8, the margin requirement must be
+re-derived in int8 quantization steps — expect it to be orders of magnitude larger.
+
+**Also measured, so don't re-derive:** DLA is a dead end for a transformer (201 layers on
+DLA vs 1024 on GPU, all LayerNorms and Softmaxes falling back, DLA subgraphs only 6.3 % of
+runtime, and **19 % slower** overall from DLA↔GPU reformat overhead).
+
+### 4a. Screen the margins BEFORE building — it predicts the failure
+
+`scripts/margin_screen.py` probes every `ArgMax`'s input, measures `top1 − top2`, and
+expresses it in fp16 ULPs at that magnitude. 25 trials, ONNX-Runtime only, **no GPU, ~40 s**.
+
+Validated on 16 checkpoints: **`min ULP < 1` predicted every measured fp16-strict failure,
+and no checkpoint with `min ULP ≥ 4` has ever failed.** `<4 ULP` is *not* the discriminator —
+a checkpoint can carry 1 % of decisions under 4 ULP and still score 0/50.
+
+```
+scripts/margin_screen.py --onnx A.onnx,B.onnx --labels a,b --trials 25 --frames f1,f2,f3
+```
+
+| min ULP | meaning |
+| --- | --- |
+| **< 1** | fp16-strict **will** flip actions. Serve fp32, or pick another checkpoint. |
+| 1–4 | marginal; verify parity at ≥200 trials before serving low precision |
+| **≥ 4** | fp16-strict has always been clean here |
+
+Frozen sub-codebooks give identical margins across checkpoints — if several ArgMax probes
+report byte-identical numbers for different models, that part of the graph is frozen and is
+not your problem. Only the trained head varies.
+
+**The real fix is upstream**, not in TRT: near-tied code logits mean the model is genuinely
+torn between actions that decode ~0.08 apart (max 0.82), and fp16 turns that into a coin
+flip. That is a training-side robustness bug. Note the ties are an *overfitting* symptom —
+train `p_gt ≈ 0.6` vs val `≈ 0.13` — so a margin loss computed on training batches may not
+move val margins at all.
+
+Benchmark median GPU compute:
+
+```
+/usr/src/tensorrt/bin/trtexec --loadEngine=ENGINE.trt \
+  --iterations=60 --avgRuns=20 --useSpinWait --warmUp=1000
+```
+
+**Budget** — measured on the car from `reports/*_predictions.jsonl`, 31 Jul, not assumed:
+
+- Inference runs **once per ~2 s plan**, not once per 333 ms step (a 6-step joint-actions
+  plan dispatches between inferences). So "does the model fit in a step?" is the wrong
+  question; the cost lands on one tick in six.
+- The control loop *blocks* during inference, and the tick carrying one costs exactly
+  `333 ms (frame wait) + inference_ms`: 610 ms at fp32 (268 ms), 512 ms at fp16-strict
+  (172 ms). 95 ms less GPU time bought 96 ms of tick — it pays back **1:1**, with no
+  hidden overhead. Plain ticks hold 332–333 ms.
+- Consequence of the overrun: ~35 % of plan cycles dispatch only 5 of their 6 steps at
+  fp32, ~27 % at fp16-strict. Real, but a weaker effect than the latency gap suggests.
+- **Idle `trtexec` is a floor, by ~+55 to +60 ms.** Attributed on dev1 (4 Aug) by running
+  real drivr and bracketing the *same* launch with `torch.cuda.Event`, across 15
+  configurations. Two independent GPU-side mechanisms, and they are **not additive**
+  (both together measured +88 ms, not +107):
+
+  1. **GPU DVFS — ~+55 ms, the dominant term.** `nvhost_podgov` really does drop to
+     **306 MHz** between inferences: during a realistic 2 s-gap run, **70.9 %** of 20 ms
+     samples sat at 306 MHz and only **10.8 %** at 918 MHz.
+     `corr(mean clock during inference, inference_ms) = −0.971`. Inferences starting at
+     918 MHz took ~229 ms; starting at 306 MHz, 269–318 ms. Pinning the clock with a CUDA
+     keep-alive dropped latency 280.9 → 247.1 ms.
+     **Fix: pin the clock** — `jetson_clocks`, or devfreq `governor=performance` /
+     `min_freq=918000000`. Needs root. Recovers ~55 ms for free, no code change.
+     ⚠️ **An earlier version of this doc claimed the clock stays pinned at 918 MHz and told
+     you not to re-derive it. That was WRONG.** It came from sampling `cur_freq` only
+     *after* each inference, when the clock has already ramped, and from a synthetic
+     duty-cycle test that kept the GPU warmer than drivr does. Sample `cur_freq`
+     continuously *through* the idle gap, or join a clock trace to individual inferences.
+  2. **The 8 secondary mp4 recorders — ~+52 ms, independent of the clock.** Present even
+     with the clock at 918 MHz for every measured inference. Each `_SecondaryRecorder`
+     opens its own **1080p** V4L2 stream and encodes with cv2 `mp4v`, a **CPU** encoder;
+     a bandwidth-bound model loses ~23 %. **Fix: NVENC instead of `mp4v`, and/or fewer /
+     lower-resolution recorders while AI control is engaged.**
+     Beware the measurement trap: feeding pre-made small frames from memory shows only
+     +0.8 ms. You must include real capture at real resolution.
+- **Refuted suspects, so nobody re-spends the time:** rerun logging costs **0 ms**
+  (229.0 ms active vs 229.5 ms absent — and check `rerun-sdk` is actually installed, it was
+  silently missing from dev1's venv). GIL / thread count: +0.2 ms with 12 extra threads at
+  50/30/10 Hz. Flask: invisible. The whole camera path — defish 1080p, pageable H2D, CUDA
+  `preprocess_image` — is only **+4.8 ms**, so preprocessing offload is a minor lever.
+- **It is GPU time, not CPU scheduling.** `inference_ms − gpu_ms` (CUDA events around the
+  identical launch) stayed **≤1.21 ms in all 15 configs** while `inference_ms` ranged
+  225→314 ms. Don't chase descheduling or the GIL.
+- `inference_ms` in the logs brackets only `execute_async_v3` + `synchronize()`, so it is
+  directly comparable to `trtexec` GPU-compute, and does **not** include capture,
+  preprocessing or the H2D/D2H copies.
+
+## 5. Validate parity — not optional
+
+```
+scripts/verify_trt_parity.py --onnx M.onnx --engine M.fp16strict.trt \
+  --trials 50 --frames /tmp/a.png,/tmp/b.jpg,/tmp/c.jpg
+```
+
+Compares TRT against ONNX Runtime (CPU fp32) and counts **decision changes** — samples
+where any action channel moves more than `--code-tol` (default 0.02). Float noise is
+~1e-4 and a code flip is ~0.1, so the threshold is not delicate. Non-zero exit on failure.
+
+`scripts/parity_matrix.py` does the same across several engines against **one shared** ORT
+reference (`--ref-cache`), which is how you compare precisions without paying for the
+reference N times.
+
+Four rules, each learned by getting it wrong:
+
+- **Real camera frames, several of them.** Noise understated one failure (4/10 vs 8/10)
+  and produced a false failure elsewhere. Vary speed and waypoints too, but the image
+  must be real. Grab frames off the car (`/tmp/video*.jpg`) or from an rrd.
+- **≥50 trials to detect, ≥200 to decide.** 10 trials passed engines that flip 6–8 %.
+  And **2/50 vs 4/50 is not a distinguishable difference** — if a ship decision turns on
+  which of two configs is better, 50 trials cannot support it. n=200 bounds a clean run
+  near ~1.5 %; n=50 only bounds it near 7 %.
+- **Always run an fp32 control.** Without it you cannot distinguish precision loss from
+  `ArgMax` boundary ties — inputs near a decision boundary flip under *any* numeric
+  difference, so a nonzero rate is not automatically a defect. When we ran it, fp32 scored
+  0/50 **bit-exact** (max abs diff `0.000000`), proving the flips were precision, not ties.
+- **Quarantine by renaming, and record why.** Rename to
+  `QUARANTINE-FAILED-PARITY.<name>.trt` and drop a `PARITY-NOTES.md` beside the engines
+  with the measured numbers. A failed engine under a plausible name will eventually be
+  served by someone.
+
+## 6. Deploy
+
+ONNX to the build host goes **direct** (§1); only the engine leg to the car needs a relay:
+
+```
+# NAS -> build host, no hop through your machine
+ssh max@sisyphos.ml 'rsync -a --partial \
+  -e "ssh -o ConnectTimeout=30" /nasa/max/models/<family>/MODEL.onnx \
+  max@172.30.0.62:onnx_exports/<family>/'
+
+# engine -> car, two hops via your machine, retried, md5-gated
+rsync -a --partial --append-verify --timeout=120 max@172.30.0.62:onnx_exports/<family>/ENGINE.trt ./
+rsync -a --partial --append-verify --timeout=120 \
+  -e 'ssh -o ServerAliveInterval=10 -o ServerAliveCountMax=3' \
+  ./ENGINE.trt max@delta-emc1.kit:onnx_exports/<family>/
+# then md5sum on BOTH ends and compare - this is the acceptance gate, not optional
+```
+
+Wrap the car leg in a retry loop; it dies mid-transfer regularly. **A killed `--partial`
+transfer leaves a truncated file under the final engine name** — verify or delete it, never
+leave it. Same for engines that failed parity: delete or clearly quarantine, or someone
+will serve one.
+
+## 7. Tell the user how to serve it — both failure modes are silent
+
+- **`--image-norm unit`** when normalization is in-graph (§2).
+- **Input size must match the engine.** `TRTEngine.run` binds via `set_tensor_address`,
+  which takes a raw pointer with **no size validation**, so a 256×256 tensor handed to a
+  224×224 binding is *not* an error: TRT reinterprets the buffer as 224-wide rows,
+  producing a diagonally sheared, partially truncated image. The model runs and merely
+  looks weak. Branch `feat/engine-derived-image-size` (PR #27) reads the size from the
+  engine; without it only models matching drivr's hardcoded 256×256 are evaluated fairly.
+
+## 8. Host quirks
+
+- **Bare PATH over non-interactive ssh.** `uv`/`just` live in `~/.nix-profile/bin` on
+  sisyphos/tresor — prefix `export PATH=$HOME/.nix-profile/bin:$PATH` or use `bash -lc`.
+- **Background jobs die on disconnect.** `( … ) &` inside ssh takes SIGHUP. Use
+  `setsid nohup script.sh > log 2>&1 < /dev/null &`.
+- **`git diff` may go through an external differ** (difftastic-style) and produce output
+  `git apply` rejects with "unrecognized input". Use `git --no-pager diff --no-ext-diff`.
+- **Heredocs over ssh get mangled.** Write the script locally, `scp`, then run it.
+
+## 9. Recommended workflow — build the SERVING PAIR, nothing else
+
+**Every model gets exactly two engines. This is the standard; do not deviate without a
+measurement that justifies it.**
+
+| # | engine | build | role |
+| --- | --- | --- | --- |
+| 1 | `MODEL.trt` | `--precision fp32` | **the reference.** Bit-exact (0/200). Serve it wherever it fits the tick — for a ViT-S arm that is ~195–200 ms, so it fits. |
+| 2 | `MODEL.encfp32-fp16trunk.trt` | `--precision mixed --fp32-index-ranges <encoder>,<decode>` | **the fast one.** ~4.3× faster at the *same* measured parity as fp16-strict. Serve it when fp32 does not fit the tick. |
+
+```
+scripts/build_serving_pair.sh MODEL.onnx        # does all of 1-5 below
+```
+
+**Do NOT build these** — each was measured and each is dominated:
+
+- **`fp16-strict`** — 232 ms at 1/200, versus 98 ms at 1/200 for engine #2. It pins the
+  GEMMs to FP32 and leaves data movement in fp16, the *inverse* of how these models train
+  (`bf16-mixed` autocast: GEMMs low, softmax/layernorm/reductions fp32). Hence slow *and*
+  not safer. **If you find one being served, replace it with the pair.**
+- **`tf32`** — 226 ms at 1/200, so it is dominated by engine #2 on both axes (2.3× slower,
+  same parity). Note this is TRT's **default**: engine #1 is only decision-exact because
+  `--precision fp32` explicitly *clears* `BuilderFlag.TF32`. Diagnostic value only (§4).
+- **`int8` / `int8-mixed`** — no speed gain over fp16 (both ~72 ms; the model is
+  bandwidth-bound) and worse parity (7/200). With the logits quantized: 82 % wrong.
+- **`bf16` anything** — 12–19× more flips than fp16 at *identical* latency (8 mantissa bits
+  vs 11), despite being the training precision. Training precision was chosen for
+  throughput on a 4090/5090, not fidelity on an Orin; it has no claim as a reference.
+  Confirmed by pairwise scoring: bf16 sits 20–23/200 from *every* other config while fp32
+  and the whole fp16 family cluster at 2–11.
+
+### Steps
+
+1. `inspect_onnx.py` → input size, norm contract, `ArgMax`/RoPE risk.
+2. **`margin_screen.py` — 40 s, no GPU, before you build anything.** `min ULP < 1` ⇒ low
+   precision will flip actions; serve fp32 or pick another checkpoint. Predicted every
+   measured failure across 16 checkpoints, including one nobody had tested.
+3. Check TRT version on build host vs car, confirm the build host is idle, and **pin the GPU
+   clock** (§4) or your numbers are ~55 ms pessimistic.
+4. **`precision_ranges.py` to derive the fp32 ranges for *this* architecture.** Never
+   hardcode them — a dinov2 224² arm and a dinov3 256² arm have entirely different layer
+   counts, and a wrong range silently mispins.
+5. `parity_matrix.py --trials 200` across both engines off one shared reference. **fp32 must
+   be 0/200**; if not, the harness is broken, stop.
+6. Two-hop rsync the passing engines; md5 both ends; quarantine failures by renaming to
+   `QUARANTINE-FAILED-PARITY.*` and leave a `PARITY-NOTES.md`.
+7. Report a **latency × parity** table with a recommendation. State sample sizes, and
+   **compare against what is actually served, not against fp32** — quoting a speedup versus
+   a config nobody runs overstates the win.
+
+⚠️ **The harness is ~7× harsher than reality.** It feeds real frames but *synthetic* speed
+and waypoints. On 2,210 real validation states the within-1-fp16-ULP rate is **0.136 %**, not
+the ~1 % measured synthetically, and the flips concentrate in fine residual levels whose
+consequence is small. Good conservatism for a gate; do not quote harness rates as deployment
+rates.

--- a/.claude/skills/trt-export/scripts/build_and_bench.sh
+++ b/.claude/skills/trt-export/scripts/build_and_bench.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+# Build TRT engines for every *.onnx in a directory, at one or more precisions,
+# and benchmark each with trtexec.
+#
+# Waits for the host to be genuinely idle first: TRT picks kernels by TIMING them,
+# so building under load bakes in slower tactics. If the load never settles this
+# exits WITHOUT building rather than producing a mistimed engine.
+#
+# Usage:
+#   build_and_bench.sh ONNX_DIR ["fp32 fp16-strict"] [DRIVR_DIR]
+# Example:
+#   build_and_bench.sh ~/onnx_exports/patch_policy "fp32 fp16-strict fp16"
+set -u
+PP="${1:?usage: build_and_bench.sh ONNX_DIR [PRECISIONS] [DRIVR_DIR]}"
+PRECS="${2:-fp32 fp16-strict}"
+D="${3:-/home/max/Code/drivr}"
+PY="$D/.venv/bin/python"
+TRTEXEC=/usr/src/tensorrt/bin/trtexec
+
+suffix_for () {  # precision -> engine filename suffix
+    case "$1" in
+        fp32)        echo ".trt" ;;
+        fp16)        echo ".fp16.trt" ;;
+        fp16-strict) echo ".fp16strict.trt" ;;
+        *)           echo ".$1.trt" ;;
+    esac
+}
+
+echo "=== waiting for sustained low load (3 x <3.0, 45s apart, up to 2h) ==="
+settled=0
+for i in $(seq 1 160); do
+    L=$(awk '{print $1}' /proc/loadavg)
+    if [ "$(echo "$L < 3.0" | bc -l)" = "1" ]; then
+        settled=$((settled + 1)); echo "  load $L — quiet ($settled/3)"
+        [ $settled -ge 3 ] && break
+    else
+        [ $settled -gt 0 ] && echo "  load $L — busy again, resetting"
+        settled=0; [ $((i % 8)) -eq 0 ] && echo "  load $L, still waiting ..."
+    fi
+    sleep 45
+done
+[ $settled -ge 3 ] || { echo "GAVE UP: load never settled — not building"; exit 3; }
+echo "proceeding — load settled"; free -g | head -2
+
+for f in "$PP"/*.onnx; do
+    [ -e "$f" ] || { echo "no *.onnx in $PP"; exit 2; }
+    name=$(basename "$f" .onnx)
+    for prec in $PRECS; do
+        eng="$PP/${name}$(suffix_for "$prec")"
+        echo ""; echo "=== $name [$prec]"
+        if [ -s "$eng" ]; then
+            echo "BUILT (cached): $(basename "$eng")"
+        else
+            start=$(date +%s)
+            "$PY" "$D/scripts/build_trt_engine.py" --onnx "$f" --precision "$prec" \
+                --workspace-gb 6 > "/tmp/build_${name}_${prec}.log" 2>&1 || {
+                    echo "BUILD FAILED: $name $prec"; tail -8 "/tmp/build_${name}_${prec}.log"
+                    continue; }
+            [ -s "$eng" ] || { echo "BUILD ODD: exit 0 but $eng missing"; continue; }
+            echo "BUILT: $(basename "$eng") ($(du -h "$eng" | cut -f1), $(( $(date +%s) - start ))s)"
+        fi
+        "$TRTEXEC" --loadEngine="$eng" --iterations=60 --avgRuns=20 --useSpinWait \
+            --warmUp=1000 > "/tmp/bench_$(basename "$eng").log" 2>&1
+        gpu=$(grep -m1 "GPU Compute Time" "/tmp/bench_$(basename "$eng").log" \
+              | sed -E 's/.*median = ([0-9.]+) ms.*/\1/')
+        e2e=$(grep -m1 "\] \[I\] Latency:" "/tmp/bench_$(basename "$eng").log" \
+              | sed -E 's/.*median = ([0-9.]+) ms.*/\1/')
+        echo "LATENCY $(basename "$eng"): compute_median=${gpu:-?}ms end_to_end=${e2e:-?}ms"
+    done
+done
+
+echo ""; echo "=== engines ==="; ls -la "$PP"/*.trt 2>/dev/null
+echo "ALL DONE — now verify parity (scripts/verify_trt_parity.py), including an fp32 control"

--- a/.claude/skills/trt-export/scripts/build_mixed.py
+++ b/.claude/skills/trt-export/scripts/build_mixed.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python
+"""TRT builder with per-layer-name precision pinning, int8 PTQ, and a dry-run
+layer dump.  Superset of scripts/build_trt_engine.py.
+
+Modes:
+  --list-layers                  parse ONNX -> print every network layer (no build)
+  --precision fp32|fp16|fp16-strict|mixed|int8|int8-mixed
+  --fp32-regex RE                for 'mixed'/'int8-mixed': layers whose name matches
+                                 are pinned to FP32 (with OBEY_PRECISION_CONSTRAINTS)
+  --calib-frames ...             int8 calibration frames (real camera images)
+"""
+from __future__ import annotations
+import argparse, re, sys, time
+from pathlib import Path
+import numpy as np
+import tensorrt as trt
+
+TRT_LOGGER = trt.Logger(trt.Logger.WARNING)
+
+_FP16_ONLY_LAYERS = frozenset({
+    trt.LayerType.CONSTANT, trt.LayerType.SHUFFLE, trt.LayerType.CAST,
+    trt.LayerType.SLICE, trt.LayerType.GATHER, trt.LayerType.CONCATENATION,
+    trt.LayerType.TOPK, trt.LayerType.SELECT,
+})
+
+
+
+_FLOAT_DT = None
+
+
+def _float_dts():
+    global _FLOAT_DT
+    if _FLOAT_DT is None:
+        dts = [trt.DataType.FLOAT, trt.DataType.HALF]
+        for extra in ("BF16",):
+            if hasattr(trt.DataType, extra):
+                dts.append(getattr(trt.DataType, extra))
+        _FLOAT_DT = tuple(dts)
+    return _FLOAT_DT
+
+
+def pin_fp32(L) -> bool:
+    """Force a layer to FP32 compute, skipping layers that produce no float tensor.
+
+    Integer producers (index Constants, Cast-to-int, TopK's indices output, Gather
+    on indices) cannot be given precision Float -- TRT raises API Usage Error 3.
+    """
+    outs = []
+    for j in range(L.num_outputs):
+        try:
+            outs.append((j, L.get_output(j)))
+        except Exception:
+            pass
+    if not outs or not any(o.dtype in _float_dts() for _, o in outs):
+        return False
+    try:
+        L.precision = trt.float32
+    except Exception:
+        return False
+    for j, o in outs:
+        if o.dtype in _float_dts():
+            try:
+                L.set_output_type(j, trt.float32)
+            except Exception:
+                pass
+    return True
+
+
+def make_network(onnx_path: Path):
+    builder = trt.Builder(TRT_LOGGER)
+    network = builder.create_network(1 << int(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH))
+    parser = trt.OnnxParser(network, TRT_LOGGER)
+    if not parser.parse_from_file(str(onnx_path)):
+        for i in range(parser.num_errors):
+            print("ONNX parse error:", parser.get_error(i), file=sys.stderr)
+        raise SystemExit("failed to parse ONNX")
+    return builder, network
+
+
+def build_feed_shapes(network):
+    out = {}
+    for i in range(network.num_inputs):
+        inp = network.get_input(i)
+        out[inp.name] = (tuple(int(d) for d in inp.shape), trt.nptype(inp.dtype))
+    return out
+
+
+class FrameCalibrator(trt.IInt8EntropyCalibrator2):
+    """Feeds realistic batches built from real camera frames."""
+
+    def __init__(self, shapes, frames, n_batches, cache):
+        super().__init__()
+        import torch
+        self.torch = torch
+        self.shapes, self.frames, self.n = shapes, frames, n_batches
+        self.cache = Path(cache)
+        self.idx = 0
+        self.rng = np.random.default_rng(7)
+        self.keep = {}
+
+    def get_batch_size(self):
+        return 1
+
+    def _make(self):
+        import cv2
+        feed = {}
+        for nm, (sh, dt) in self.shapes.items():
+            low = nm.lower()
+            if "cam" in low:
+                h, w = sh[-2], sh[-1]
+                img = self.frames[self.idx % len(self.frames)]
+                img = cv2.resize(img, (w, h), interpolation=cv2.INTER_AREA)
+                chw = img.transpose(2, 0, 1)
+                seq = np.stack([np.clip(chw * (0.90 + 0.04 * k), 0, 1) for k in range(sh[1])], 0)
+                feed[nm] = seq[None].astype(np.float32)
+            elif "speed" in low:
+                feed[nm] = np.full(sh, self.rng.uniform(0, 40), np.float32)
+            elif "waypoint" in low:
+                spacing = self.rng.uniform(2, 25) / 100.0
+                y = (np.arange(sh[2], dtype=np.float32) + 1) * spacing
+                x = self.rng.normal(0, 0.02, sh[2]).astype(np.float32)
+                wp = np.stack([x, y], 1)
+                feed[nm] = np.tile(wp, (sh[0], sh[1], 1, 1)).astype(np.float32)
+            else:
+                feed[nm] = self.rng.uniform(0, 1, sh).astype(np.float32)
+        return feed
+
+    def get_batch(self, names):
+        if self.idx >= self.n:
+            return None
+        feed = self._make()
+        ptrs = []
+        for nm in names:
+            t = self.torch.from_numpy(np.ascontiguousarray(feed[nm].ravel())).cuda()
+            self.keep[nm] = t
+            ptrs.append(int(t.data_ptr()))
+        self.idx += 1
+        print(f"  calibration batch {self.idx}/{self.n}", flush=True)
+        return ptrs
+
+    def read_calibration_cache(self):
+        return self.cache.read_bytes() if self.cache.exists() else None
+
+    def write_calibration_cache(self, cache):
+        self.cache.write_bytes(cache)
+
+
+def load_frames(spec):
+    import cv2
+    frames = []
+    for p in [x for x in spec.split(",") if x.strip()]:
+        img = cv2.imread(p)
+        if img is None:
+            continue
+        h = img.shape[0]
+        side = min(h, 320)
+        top = max((h - side) // 2, 0)
+        frames.append(cv2.cvtColor(img[top:top+side, :], cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0)
+    if not frames:
+        raise SystemExit("no calibration frames loaded")
+    return frames
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--onnx", type=Path, required=True)
+    ap.add_argument("--engine", type=Path, default=None)
+    ap.add_argument("--precision", default="fp16",
+                    choices=["fp32", "fp16", "fp16-strict", "mixed", "int8", "int8-mixed",
+                               "bf16", "bf16-mixed", "tf32"])
+    ap.add_argument("--fp32-regex", default=None)
+    ap.add_argument("--bf16-index-ranges", default=None,
+                    help="layer indices to pin to BF16 (per-layer, needs a mixed precision)")
+    ap.add_argument("--fp32-index-ranges", default=None,
+                    help="e.g. '1737-1875,2853-2961' -- pin these network layer indices to FP32")
+    ap.add_argument("--workspace-gb", type=int, default=6)
+    ap.add_argument("--list-layers", action="store_true")
+    ap.add_argument("--calib-frames",
+                    default="/tmp/native_raw.png,/tmp/frame_video1.jpg,/tmp/frame_video0_.jpg")
+    ap.add_argument("--calib-batches", type=int, default=24)
+    ap.add_argument("--calib-cache", default=None)
+    ap.add_argument("--strict-exempt", default=None,
+                    help="fp16-strict: comma list of LayerType names left in FP16. "
+                         "Default reproduces scripts/build_trt_engine.py: "
+                         "CONSTANT,SHUFFLE,CAST,SLICE,GATHER,CONCATENATION,TOPK,SELECT")
+    a = ap.parse_args()
+
+    builder, network = make_network(a.onnx)
+    print(f"network: {network.num_layers} layers, {network.num_inputs} inputs, "
+          f"{network.num_outputs} outputs", flush=True)
+
+    if a.list_layers:
+        for i in range(network.num_layers):
+            L = network.get_layer(i)
+            outs = []
+            for j in range(L.num_outputs):
+                try:
+                    outs.append(f"{tuple(L.get_output(j).shape)}")
+                except Exception:
+                    pass
+            print(f"{i:5d} {str(L.type).replace('LayerType.',''):16s} "
+                  f"{L.name[:100]:100s} {';'.join(outs)[:60]}")
+        return
+
+    config = builder.create_builder_config()
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, a.workspace_gb * (1 << 30))
+    profile = builder.create_optimization_profile()
+    for i in range(network.num_inputs):
+        inp = network.get_input(i)
+        sh = tuple(int(d) for d in inp.shape)
+        profile.set_shape(inp.name, sh, sh, sh)
+    config.add_optimization_profile(profile)
+
+    p = a.precision
+    if p == "fp32":
+        config.clear_flag(trt.BuilderFlag.TF32)
+    elif p == "tf32":
+        # set NOTHING: TF32 is on by default, so this is the tensor-core fp32 path --
+        # 10-bit mantissa matmul inputs, fp32 accumulate, fp32 storage between ops.
+        # 226 ms at 1/200 on dinowm_big => dominated by encfp32-fp16trunk (98 ms, 1/200).
+        # Diagnostic only; the REFERENCE must keep TF32 cleared to stay 0/200.
+        print("tf32: TRT defaults (TF32 tensor cores on, no other precision flags)")
+    elif p == "fp16":
+        config.set_flag(trt.BuilderFlag.FP16)
+    elif p == "bf16":
+        config.set_flag(trt.BuilderFlag.BF16)
+        print("bf16: BF16 flag set, TRT picks per layer")
+    elif p == "fp16-strict":
+        config.set_flag(trt.BuilderFlag.FP16)
+        config.set_flag(trt.BuilderFlag.OBEY_PRECISION_CONSTRAINTS)
+        exempt = _FP16_ONLY_LAYERS
+        if a.strict_exempt is not None:
+            exempt = frozenset(getattr(trt.LayerType, t.strip().upper())
+                               for t in a.strict_exempt.split(",") if t.strip())
+        print(f"fp16-strict exempt set: {sorted(str(e).replace('LayerType.','') for e in exempt)}")
+        n32 = n16 = 0
+        for i in range(network.num_layers):
+            L = network.get_layer(i)
+            if L.type in exempt:
+                n16 += 1
+                continue
+            if pin_fp32(L):
+                n32 += 1
+            else:
+                n16 += 1
+        print(f"fp16-strict: fp32-pinned={n32} fp16-kept={n16}")
+    elif p in ("mixed", "int8-mixed", "bf16-mixed"):
+        if not (a.fp32_regex or a.fp32_index_ranges):
+            raise SystemExit("--fp32-regex or --fp32-index-ranges required for mixed")
+        rx = re.compile(a.fp32_regex) if a.fp32_regex else None
+        idxset = set()
+        for part in (a.fp32_index_ranges or "").split(","):
+            part = part.strip()
+            if not part:
+                continue
+            if "-" in part:
+                lo, hi = part.split("-")
+                idxset.update(range(int(lo), int(hi) + 1))
+            else:
+                idxset.add(int(part))
+        if p == "bf16-mixed":
+            config.set_flag(trt.BuilderFlag.BF16)
+        else:
+            config.set_flag(trt.BuilderFlag.FP16)
+            if a.bf16_index_ranges:
+                config.set_flag(trt.BuilderFlag.BF16)
+        config.set_flag(trt.BuilderFlag.OBEY_PRECISION_CONSTRAINTS)
+        hits, skipped = [], []
+        for i in range(network.num_layers):
+            L = network.get_layer(i)
+            if (rx is not None and rx.search(L.name)) or (i in idxset):
+                if pin_fp32(L):
+                    hits.append(f"{i}:{str(L.type).replace('LayerType.','')}:{L.name[:70]}")
+                else:
+                    skipped.append(f"{i}:{str(L.type).replace('LayerType.','')}:{L.name[:60]}")
+        print(f"mixed: skipped {len(skipped)} non-float (integer/index) layers")
+        print(f"mixed: pinned {len(hits)} layers to FP32 "
+              f"(regex={a.fp32_regex!r} ranges={a.fp32_index_ranges!r})")
+        if a.bf16_index_ranges:
+            bset = set()
+            for part in a.bf16_index_ranges.split(","):
+                part = part.strip()
+                if not part:
+                    continue
+                if "-" in part:
+                    lo, hi = part.split("-")
+                    bset.update(range(int(lo), int(hi) + 1))
+                else:
+                    bset.add(int(part))
+            bset -= idxset          # FP32 pins win
+            nb = 0
+            for i in sorted(bset):
+                L = network.get_layer(i)
+                try:
+                    if L.get_output(0).dtype in (trt.DataType.INT32, trt.DataType.INT64,
+                                                 trt.DataType.BOOL):
+                        continue
+                    L.precision = trt.DataType.BF16
+                    nb += 1
+                except Exception:
+                    pass
+            print(f"mixed: pinned {nb} layers to BF16 (ranges={a.bf16_index_ranges!r})")
+            if nb == 0:
+                raise SystemExit("bf16 ranges matched no float layers -- refusing to build")
+        for h in hits:
+            print("   ", h)
+        if not hits:
+            raise SystemExit("regex matched no layers -- refusing to build a mislabelled engine")
+    if p in ("int8", "int8-mixed"):
+        config.set_flag(trt.BuilderFlag.INT8)
+        cache = a.calib_cache or str(a.onnx.with_suffix(".calib"))
+        frames = load_frames(a.calib_frames)
+        config.int8_calibrator = FrameCalibrator(build_feed_shapes(network), frames,
+                                                 a.calib_batches, cache)
+        print(f"int8: entropy-calibrator2, {a.calib_batches} batches from "
+              f"{len(frames)} real frames, cache={cache}", flush=True)
+
+    suffix = {"fp32": ".trt", "tf32": ".tf32.trt", "fp16": ".fp16.trt", "fp16-strict": ".fp16strict.trt",
+              "bf16": ".bf16.trt", "bf16-mixed": ".bf16mixed.trt",
+              "mixed": ".mixed.trt", "int8": ".int8.trt", "int8-mixed": ".int8mixed.trt"}[p]
+    engine_path = a.engine or a.onnx.with_name(a.onnx.stem + suffix)
+    print(f"building -> {engine_path}", flush=True)
+    t0 = time.time()
+    ser = builder.build_serialized_network(network, config)
+    if ser is None:
+        raise SystemExit("BUILD FAILED")
+    engine_path.write_bytes(bytes(ser))
+    print(f"built in {time.time()-t0:.0f}s, {engine_path.stat().st_size/1e6:.1f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/trt-export/scripts/build_serving_pair.sh
+++ b/.claude/skills/trt-export/scripts/build_serving_pair.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# Build the SERVING PAIR for one ONNX, and verify it at n=200.
+#
+#   1. fp32                                     -- the reference. Bit-exact. Always build it.
+#   2. fp32 encoder + fp16 trunk + fp32 decode  -- ~4.3x faster at the same measured parity.
+#
+# These two are the standard. Do NOT build fp16-strict: it is dominated (232 ms at 1/200 vs
+# 98 ms at 1/200 for the pair's second engine) because it pins the GEMMs to FP32 and leaves
+# data movement in fp16 -- the inverse of how these models train. Do not build int8 either:
+# no speed gain over fp16 (both bandwidth-bound) and worse parity. Do not build bf16: 12-19x
+# more flips than fp16 at identical latency, despite being the training precision.
+#
+# Layer ranges are derived per model by precision_ranges.py -- never hardcode them, they are
+# architecture-specific (a dinov2 224x224 arm and a dinov3 256x256 arm differ entirely).
+#
+# Usage: build_serving_pair.sh MODEL.onnx [DRIVR_DIR] [TRIALS]
+set -u
+ONNX="${1:?usage: build_serving_pair.sh MODEL.onnx [DRIVR_DIR] [TRIALS]}"
+D="${2:-/home/max/Code/drivr}"
+TRIALS="${3:-200}"
+PY="$D/.venv/bin/python"
+HERE="$(cd "$(dirname "$0")" && pwd)"
+TRTEXEC=/usr/src/tensorrt/bin/trtexec
+FRAMES="${FRAMES:-/tmp/native_raw.png,/tmp/frame_video1.jpg,/tmp/frame_video0_.jpg}"
+
+base="${ONNX%.onnx}"
+FP32="$base.trt"
+MIX="$base.encfp32-fp16trunk.trt"
+
+echo "######## 0. graph inspection"
+"$PY" "$HERE/inspect_onnx.py" "$ONNX" 2>&1 | grep -vE "Warning|pkg_resources"
+
+echo ""
+echo "######## 1. margin pre-flight (40 s, no GPU) — min ULP < 1 predicts fp16 flips"
+"$PY" "$HERE/margin_screen.py" --onnx "$ONNX" --trials 25 --frames "$FRAMES" 2>&1 \
+    | grep -vE "Warning|pkg_resources|^  [0-9]+/" | sed 's/^/  /'
+
+echo ""
+echo "######## 2. derive the fp32 layer ranges for this architecture"
+RANGES=$("$PY" "$HERE/precision_ranges.py" "$ONNX" --drivr-dir "$D" 2>&1 | tee /dev/stderr \
+         | awk '/^fp32 ranges/{print $NF}')
+[ -n "$RANGES" ] || { echo "FATAL: could not derive ranges — inspect with --list-layers"; exit 1; }
+echo "  using: $RANGES"
+
+echo ""
+echo "######## 3. build both engines"
+for spec in "fp32|$FP32|" "mixed|$MIX|$RANGES"; do
+    IFS='|' read -r prec eng rng <<<"$spec"
+    if [ -s "$eng" ]; then echo "  BUILT (cached): $(basename "$eng")"; continue; fi
+    start=$(date +%s)
+    if [ -n "$rng" ]; then
+        "$PY" "$HERE/build_mixed.py" --onnx "$ONNX" --precision "$prec" \
+            --fp32-index-ranges "$rng" --engine "$eng" --workspace-gb 6 \
+            > "/tmp/bsp_$(basename "$eng").log" 2>&1
+    else
+        "$PY" "$HERE/build_mixed.py" --onnx "$ONNX" --precision "$prec" \
+            --engine "$eng" --workspace-gb 6 > "/tmp/bsp_$(basename "$eng").log" 2>&1
+    fi
+    [ -s "$eng" ] || { echo "  BUILD FAILED: $prec"; tail -8 "/tmp/bsp_$(basename "$eng").log"; exit 1; }
+    echo "  BUILT: $(basename "$eng") ($(du -h "$eng"|cut -f1), $(( $(date +%s) - start ))s)"
+done
+
+echo ""
+echo "######## 4. latency"
+for eng in "$FP32" "$MIX"; do
+    "$TRTEXEC" --loadEngine="$eng" --iterations=60 --avgRuns=20 --useSpinWait --warmUp=1000 \
+        > "/tmp/bspb_$(basename "$eng").log" 2>&1
+    ms=$(grep -m1 "GPU Compute Time" "/tmp/bspb_$(basename "$eng").log" \
+         | sed -E 's/.*median = ([0-9.]+) ms.*/\1/')
+    echo "  $(basename "$eng"): ${ms:-?} ms"
+done
+
+echo ""
+echo "######## 5. parity, $TRIALS trials, fp32 first as the control"
+"$PY" "$HERE/parity_matrix.py" --onnx "$ONNX" --engines "$FP32,$MIX" --trials "$TRIALS" \
+    --frames "$FRAMES" --out "$base.parity.json" 2>&1 \
+    | grep -vE "Warning|pkg_resources|onnxruntime|^\[|ORT [0-9]|\.\.\. [0-9]" | sed 's/^/  /'
+
+echo ""
+echo "fp32 MUST be 0/$TRIALS. If it is not, the harness or the reference is broken — stop."
+echo "The mixed engine is expected ~1/200 on this input distribution (which is ~7x harsher"
+echo "than real driving states: synthetic speed/waypoints tighten margins). Quarantine by"
+echo "renaming to QUARANTINE-FAILED-PARITY.* if it is materially worse."
+echo "SERVING PAIR DONE"

--- a/.claude/skills/trt-export/scripts/inspect_onnx.py
+++ b/.claude/skills/trt-export/scripts/inspect_onnx.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+"""Report the four things about an ONNX export that decide the whole TRT pipeline.
+
+  input size + Resize count -> does the HOST have to deliver the exact size?
+  first ops (Sub/Div)       -> is ImageNet normalization already in the graph?
+                               (yes => serve with --image-norm unit)
+  ArgMax count              -> codebook/VQ decoding in-graph => fp16 is dangerous
+  Sin/Cos                   -> RoPE => strongly fp16-fragile (DINOv3 has it, v2 doesn't)
+
+Usage:  inspect_onnx.py MODEL.onnx [MODEL2.onnx ...]
+Needs:  onnx   (e.g. `uv run --with onnx python inspect_onnx.py ...`)
+"""
+from __future__ import annotations
+
+import sys
+from collections import Counter
+from pathlib import Path
+
+import onnx
+
+WATCH = ("Resize", "ArgMax", "Sin", "Cos", "Softmax", "LayerNormalization")
+
+
+def dims(t) -> list:
+    return [d.dim_value or d.dim_param or "?" for d in t.type.tensor_type.shape.dim]
+
+
+def report(path: Path) -> None:
+    m = onnx.load(str(path), load_external_data=False)
+    g = m.graph
+    ops = [n.op_type for n in g.node]
+    c = Counter(ops)
+
+    print(f"\n=== {path.name}")
+    for i in g.input:
+        print(f"  IN   {i.name:44s} {dims(i)}")
+    for o in g.output:
+        print(f"  OUT  {o.name:44s} {dims(o)}")
+    print(f"  nodes {len(ops)}   " + "  ".join(f"{k}={c.get(k, 0)}" for k in WATCH))
+    print(f"  first ops: {ops[:10]}")
+
+    # the actionable reading of the above
+    notes = []
+    cam = next((i for i in g.input if "cam" in i.name.lower()), None)
+    if cam is not None:
+        d = dims(cam)
+        if len(d) >= 2 and all(isinstance(x, int) for x in d[-2:]):
+            hw = f"{d[-2]}x{d[-1]}"
+            notes.append(f"image input {hw}" + ("; NO Resize in graph -> host must "
+                         f"deliver exactly {hw}" if not c.get("Resize") else ""))
+    if ops[:2] == ["Sub", "Div"]:
+        notes.append("Sub/Div first -> ImageNet norm IS in-graph -> serve --image-norm unit")
+    if c.get("ArgMax"):
+        notes.append(f"{c['ArgMax']} ArgMax -> codebook decode in-graph -> verify parity by "
+                     "DECISION changes, prefer fp32")
+    if c.get("Sin") or c.get("Cos"):
+        notes.append("Sin/Cos present -> RoPE -> strongly fp16-fragile")
+    for n in notes:
+        print(f"  ** {n}")
+
+
+def main() -> int:
+    paths = [Path(p) for p in sys.argv[1:]]
+    if not paths:
+        print(__doc__)
+        return 2
+    for p in paths:
+        if p.exists():
+            report(p)
+        else:
+            print(f"\n=== {p}  MISSING")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/trt-export/scripts/margin_screen.py
+++ b/.claude/skills/trt-export/scripts/margin_screen.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+"""Decision-margin analysis: how close is each ArgMax to flipping, in fp16 units?
+
+For every ArgMax in the graph we expose its input tensor and measure
+    margin = top1 - top2
+and compare it to the fp16 representation spacing at that magnitude.  A margin
+below ~1 fp16 ULP means the decision is not resolvable in fp16 at all; a margin
+of a few ULPs means accumulated fp16 error can flip it.
+
+Run on a FAILING and a PASSING checkpoint of the same architecture to test
+whether checkpoint-dependent fp16 failures are explained by margin geometry.
+"""
+from __future__ import annotations
+import argparse, json, sys
+from pathlib import Path
+import numpy as np
+import onnx
+from onnx import helper, TensorProto
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+
+def make_probe(src: Path, dst: Path):
+    m = onnx.load(str(src))
+    g = m.graph
+    have = {o.name for o in g.output}
+    probes = []
+    for n in g.node:
+        if n.op_type != "ArgMax":
+            continue
+        t = n.input[0]
+        if t not in have:
+            g.output.append(helper.make_tensor_value_info(t, TensorProto.FLOAT, None))
+            probes.append((n.name, t))
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    onnx.save(m, str(dst), save_as_external_data=True, all_tensors_to_one_file=True,
+              location=dst.name + ".w", size_threshold=1024)
+    return probes
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--onnx", required=True, help="comma-separated models to compare")
+    ap.add_argument("--labels", default=None, help="comma-separated labels")
+    ap.add_argument("--trials", type=int, default=25)
+    ap.add_argument("--frames",
+                    default="/tmp/native_raw.png,/tmp/frame_video1.jpg,/tmp/frame_video0_.jpg")
+    ap.add_argument("--workdir", default="/tmp/marginprobe")
+    ap.add_argument("--out", default=None)
+    a = ap.parse_args()
+
+    import cv2, onnxruntime as ort
+    from verify_trt_parity import build_inputs
+
+    frames = []
+    for fp in [Path(x) for x in a.frames.split(",") if x.strip()]:
+        img = cv2.imread(str(fp)) if fp.exists() else None
+        if img is None:
+            continue
+        h = img.shape[0]
+        side = min(h, 320)
+        top = max((h - side) // 2, 0)
+        frames.append(cv2.cvtColor(img[top:top+side, :], cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0)
+    print(f"{len(frames)} real frames")
+
+    models = [Path(x) for x in a.onnx.split(",") if x.strip()]
+    labels = (a.labels.split(",") if a.labels else [m.stem[-24:] for m in models])
+    allres = {}
+    for mp, lab in zip(models, labels):
+        dst = Path(a.workdir) / (lab.replace("/", "_") + ".probe.onnx")
+        probes = make_probe(mp, dst)
+        sess = ort.InferenceSession(str(dst), providers=["CPUExecutionProvider"])
+        names = [t for _, t in probes]
+        print(f"\n##### {lab}   probes={[(n,t) for n,t in probes]}", flush=True)
+        rng = np.random.default_rng(1234)
+        acc = {t: [] for t in names}
+        for i in range(a.trials):
+            feed = build_inputs(sess, rng, frames[i % len(frames)] if frames else None)
+            outs = sess.run(names, feed)
+            for t, arr in zip(names, outs):
+                A = np.asarray(arr, dtype=np.float64)
+                A = A.reshape(-1, A.shape[-1])          # (groups, candidates)
+                srt = np.sort(A, axis=1)
+                top1, top2 = srt[:, -1], srt[:, -2]
+                margin = top1 - top2
+                ulp = np.spacing(np.abs(top1).astype(np.float16)).astype(np.float64)
+                ulp = np.where(ulp == 0, np.spacing(np.float16(1e-4)), ulp)
+                acc[t].append(np.stack([margin, np.abs(top1), margin / ulp], 1))
+            if (i + 1) % 10 == 0:
+                print(f"  {i+1}/{a.trials}", flush=True)
+        res = {}
+        for t in names:
+            M = np.concatenate(acc[t], 0)          # (n, 3): margin, |top1|, margin/ulp
+            r = dict(n=int(M.shape[0]),
+                     margin_median=float(np.median(M[:, 0])),
+                     margin_p05=float(np.percentile(M[:, 0], 5)),
+                     margin_min=float(M[:, 0].min()),
+                     top1_median=float(np.median(M[:, 1])),
+                     ulps_median=float(np.median(M[:, 2])),
+                     ulps_p05=float(np.percentile(M[:, 2], 5)),
+                     ulps_min=float(M[:, 2].min()),
+                     frac_under_1ulp=float((M[:, 2] < 1).mean()),
+                     frac_under_4ulp=float((M[:, 2] < 4).mean()),
+                     frac_under_16ulp=float((M[:, 2] < 16).mean()))
+            res[t] = r
+            print(f"  {t:12s} n={r['n']:4d} |top1|~{r['top1_median']:8.3f} "
+                  f"margin med={r['margin_median']:.5f} p05={r['margin_p05']:.5f} "
+                  f"min={r['margin_min']:.6f} | fp16 ULPs: med={r['ulps_median']:8.1f} "
+                  f"p05={r['ulps_p05']:7.2f} min={r['ulps_min']:6.3f} "
+                  f"| <1ULP {100*r['frac_under_1ulp']:.1f}% <4ULP {100*r['frac_under_4ulp']:.1f}% "
+                  f"<16ULP {100*r['frac_under_16ulp']:.1f}%")
+        allres[lab] = res
+    if a.out:
+        Path(a.out).write_text(json.dumps(allres, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.claude/skills/trt-export/scripts/native_vs_ort.py
+++ b/.claude/skills/trt-export/scripts/native_vs_ort.py
@@ -1,0 +1,198 @@
+"""Baseline validation: rmind PyTorch NATIVE vs ONNX-Runtime fp32 on identical inputs.
+
+Every precision result so far was scored against the ONNX fp32 reference. That is only a
+valid baseline if the ONNX export is itself faithful to rmind native. This measures that
+link directly, on the exact harness inputs (same rng seed 1234, same frame cycling, same
+build_inputs), and writes a NATIVE reference cache in parity_matrix.py's npz format so the
+TRT engines can afterwards be re-scored against native instead of transitively.
+
+Native side uses PatchPolicy.load_for_export -- the same wrapper the ONNX was traced from
+(sample_codes=False -> argmax decode; in-model crop/resize replaced by ImageNet Normalize,
+so it consumes the same pre-windowed [0,1] (1,6,3,H,W) frames the ONNX does).
+"""
+from __future__ import annotations
+
+import argparse, json, sys, time
+from pathlib import Path
+
+import numpy as np
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from verify_trt_parity import build_inputs  # noqa: E402
+
+
+def load_frames(spec):
+    """Byte-identical to parity_matrix.load_frames."""
+    import cv2
+    frames = []
+    for fp in [Path(x) for x in spec.split(",") if x.strip()]:
+        if not fp.exists():
+            continue
+        img = cv2.imread(str(fp))
+        if img is None:
+            continue
+        h = img.shape[0]
+        side = min(h, 320)
+        top = max((h - side) // 2, 0)
+        frames.append(cv2.cvtColor(img[top:top + side, :], cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0)
+    return frames
+
+
+def leaves(obj, path=()):
+    """Yield (path, tensor) for every tensor leaf in a nested mapping."""
+    if isinstance(obj, torch.Tensor):
+        yield path, obj
+    elif hasattr(obj, "items"):
+        for k, v in obj.items():
+            yield from leaves(v, (*path, k))
+    elif isinstance(obj, (list, tuple)):
+        for i, v in enumerate(obj):
+            yield from leaves(v, (*path, i))
+
+
+def assign(obj, path, value):
+    cur = obj
+    for k in path[:-1]:
+        cur = cur[k]
+    cur[path[-1]] = value
+
+
+def get_action(out):
+    """Pull policy.joint_actions out of whatever container forward returned."""
+    try:
+        return out["policy", "joint_actions"]
+    except Exception:
+        pass
+    for p, t in leaves(out):
+        if any("joint_action" in str(k) for k in p):
+            return t
+    raise SystemExit(f"could not find joint_actions in output: {type(out)}")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--onnx", type=Path, required=True)
+    ap.add_argument("--artifact", required=True)
+    ap.add_argument("--image-hw", type=int, required=True)
+    ap.add_argument("--repo", default="/home/max/pr265")
+    ap.add_argument("--trials", type=int, default=200)
+    ap.add_argument("--frames",
+                    default="/tmp/native_raw.png,/tmp/frame_video1.jpg,/tmp/frame_video0_.jpg")
+    ap.add_argument("--code-tol", type=float, default=0.02)
+    ap.add_argument("--native-cache", type=Path, required=True)
+    ap.add_argument("--threads", type=int, default=8)
+    a = ap.parse_args()
+
+    torch.set_num_threads(a.threads)
+
+    import onnxruntime as ort
+    from hydra import compose, initialize_config_dir
+    from hydra.utils import instantiate
+
+    print(f"ONNX  : {a.onnx.name}")
+    print(f"native: {a.artifact}  (image_hw={a.image_hw})")
+
+    sess = ort.InferenceSession(str(a.onnx), providers=["CPUExecutionProvider"])
+    out_names = [o.name for o in sess.get_outputs()]
+    action = next(n for n in out_names if "joint_actions" in n)
+    specs = [dict(name=i.name, shape=list(i.shape), type=i.type) for i in sess.get_inputs()]
+    print(f"  onnx inputs : {[s['name'] for s in specs]}")
+    print(f"  onnx outputs: {out_names}  action='{action}'")
+
+    # Build the model AND the batch structure from the very config the ONNX was traced
+    # from, so the native call is the same callable with the same input tree.
+    with initialize_config_dir(config_dir=f"{a.repo}/config", version_base=None):
+        cfg = compose(config_name="export_onnx", overrides=[
+            "export=yaak/patch_policy/finetuned",
+            f"model.artifact={a.artifact}",
+            f"image_hw={a.image_hw}",
+        ])
+    model = instantiate(cfg.model)
+    model = model.eval()
+    args = instantiate(cfg.args, _recursive_=True, _convert_="all")
+    batch = args[0]
+    print(f"  sample_codes={getattr(model, 'sample_codes', '?')} (must be False for argmax)")
+    tl = list(leaves(batch))
+    print(f"  native batch leaves: {[('/'.join(map(str, p)), tuple(t.shape)) for p, t in tl]}")
+
+    # map ONNX feed -> native leaf by tensor rank (one 5-dim cam, one 3-dim speed, one 4-dim wp)
+    by_ndim_native = {}
+    for p, t in tl:
+        by_ndim_native.setdefault(t.dim(), []).append(p)
+    onnx_by_ndim = {}
+    for s in specs:
+        onnx_by_ndim.setdefault(len(s["shape"]), []).append(s["name"])
+    mapping = {}
+    for nd, names in onnx_by_ndim.items():
+        paths = by_ndim_native.get(nd, [])
+        if len(names) != 1 or len(paths) != 1:
+            raise SystemExit(f"ambiguous rank-{nd} mapping: onnx={names} native={paths}")
+        mapping[names[0]] = paths[0]
+    print("  input mapping (onnx -> native):")
+    for k, v in mapping.items():
+        print(f"    {k}  ->  {'/'.join(map(str, v))}")
+
+    frames = load_frames(a.frames)
+    print(f"  {len(frames)} real camera frames" if frames else "  NOISE inputs (not acceptable)")
+
+    rng = np.random.default_rng(1234)   # identical to parity_matrix / verify_trt_parity
+    dec = 0
+    maxabs = 0.0
+    sumabs = 0.0
+    per_trial = []
+    cache = {}
+    t0 = time.time()
+    for t in range(a.trials):
+        feed = build_inputs(sess, rng, frames[t % len(frames)] if frames else None)
+
+        ort_out = dict(zip(out_names, sess.run(out_names, feed)))
+
+        for oname, npath in mapping.items():
+            assign(batch, npath, torch.from_numpy(np.ascontiguousarray(feed[oname])))
+        with torch.no_grad():
+            nat = get_action(model(batch)).detach().cpu().numpy()
+
+        ref = np.asarray(ort_out[action], dtype=np.float64)
+        got = np.asarray(nat, dtype=np.float64)
+        d = np.abs(got - ref)
+        maxabs = max(maxabs, float(d.max()))
+        sumabs += float(d.mean())
+        changed = bool((d > a.code_tol).any())
+        dec += int(changed)
+        per_trial.append((t, float(d.max()), changed))
+        if changed:
+            print(f"    t{t}: DECISION DIFF max|d|={d.max():.6f}", flush=True)
+
+        # native reference cache, parity_matrix.py npz layout
+        for i, n in enumerate(out_names):
+            cache[f"t{t}_{i}"] = nat if n == action else np.asarray(ort_out[n])
+
+        if (t + 1) % 20 == 0:
+            print(f"    {t+1}/{a.trials}  {time.time()-t0:.0f}s  dec={dec} max|d|={maxabs:.2e}",
+                  flush=True)
+
+    cache["meta"] = json.dumps(dict(onnx=a.onnx.name, trials=a.trials, out_names=out_names,
+                                    action=action, inputs=specs, reference="rmind-native-fp32",
+                                    artifact=a.artifact))
+    np.savez_compressed(a.native_cache, **cache)
+
+    print()
+    print(f"RESULT  native vs ONNX-fp32, n={a.trials}, tol={a.code_tol}")
+    print(f"  decision changes : {dec}/{a.trials}")
+    print(f"  max |d|          : {maxabs:.3e}")
+    print(f"  mean |d|         : {sumabs / a.trials:.3e}")
+    worst = sorted(per_trial, key=lambda x: -x[1])[:5]
+    print(f"  worst trials     : {[(t, round(m, 6)) for t, m, _ in worst]}")
+    print(f"  native cache     : {a.native_cache}")
+    if dec == 0:
+        print("  VERDICT: ONNX fp32 is faithful to rmind native at decision level ->"
+              " every parity result scored against it holds transitively.")
+    else:
+        print("  VERDICT: ONNX fp32 DIVERGES from native -> re-score the engines against"
+              " the native cache before trusting any fp16 number.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/trt-export/scripts/parity_matrix.py
+++ b/.claude/skills/trt-export/scripts/parity_matrix.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+"""Parity matrix: one ORT fp32 reference pass per trial, compared against MANY engines.
+
+ORT CPU on a 440 MB ViT is the slow part, so running it once per trial and fanning
+out to every engine is ~N times faster than calling verify_trt_parity.py per engine.
+
+Judged by DECISION changes on policy.joint_actions (|d| > --code-tol on any channel),
+exactly like scripts/verify_trt_parity.py.  If the ONNX exposes ArgMax code indices
+as extra outputs, per-ArgMax flip counts are reported too.
+"""
+from __future__ import annotations
+import argparse, json, sys, time
+from pathlib import Path
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from verify_trt_parity import TRTRunner, build_inputs  # noqa: E402
+
+
+def load_frames(spec):
+    import cv2
+    frames = []
+    for fp in [Path(x) for x in spec.split(",") if x.strip()]:
+        if not fp.exists():
+            continue
+        img = cv2.imread(str(fp))
+        if img is None:
+            continue
+        h = img.shape[0]
+        side = min(h, 320)
+        top = max((h - side) // 2, 0)
+        frames.append(cv2.cvtColor(img[top:top+side, :], cv2.COLOR_BGR2RGB).astype(np.float32) / 255.0)
+    return frames
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--onnx", type=Path, required=True)
+    ap.add_argument("--engines", default="", help="comma-separated engine paths")
+    ap.add_argument("--trials", type=int, default=50)
+    ap.add_argument("--frames",
+                    default="/tmp/native_raw.png,/tmp/frame_video1.jpg,/tmp/frame_video0_.jpg")
+    ap.add_argument("--code-tol", type=float, default=0.02)
+    ap.add_argument("--out", type=Path, default=None)
+    ap.add_argument("--ref-only", action="store_true",
+                    help="compute + write the ORT reference cache and exit (no engines needed). "
+                         "Lets the slow CPU reference run on a big x86 host while the Jetson "
+                         "build host stays idle for TRT builds.")
+    ap.add_argument("--ref-cache", type=Path, default=None,
+                    help="npz of ORT reference outputs; written on first use, reused after "
+                         "(ORT CPU on a 440 MB ViT is the slow part). Feeds are regenerated "
+                         "deterministically from --trials/--frames/seed, so they need no cache.")
+    a = ap.parse_args()
+
+    frames_g = load_frames(a.frames)
+
+    class SpecSess:
+        """Stand-in for an ORT session: only build_inputs' .get_inputs() is needed."""
+        def __init__(self, specs):
+            self._specs = specs
+        def get_inputs(self):
+            return self._specs
+
+    class _Spec:
+        def __init__(self, name, shape, type_):
+            self.name, self.shape, self.type = name, shape, type_
+
+    cache_ok = a.ref_cache is not None and a.ref_cache.exists()
+    if cache_ok:
+        z = np.load(a.ref_cache, allow_pickle=True)
+        meta = json.loads(str(z["meta"]))
+        if meta["trials"] < a.trials or meta["onnx"] != a.onnx.name:
+            print(f"  [ref-cache stale: {meta['onnx']} trials={meta['trials']}] recomputing")
+            cache_ok = False
+    if cache_ok:
+        out_names = meta["out_names"]
+        action = meta["action"]
+        codes = [n for n in out_names if n != action]
+        sess = SpecSess([_Spec(s["name"], s["shape"], s["type"]) for s in meta["inputs"]])
+        refs = [dict(zip(out_names, [z[f"t{t}_{i}"] for i in range(len(out_names))]))
+                for t in range(a.trials)]
+        print(f"ONNX {a.onnx.name}: using cached ORT reference "
+              f"({a.trials} trials) action='{action}' code-probes={codes}")
+    else:
+        import onnxruntime as ort
+        rsess = ort.InferenceSession(str(a.onnx), providers=["CPUExecutionProvider"])
+        out_names = [o.name for o in rsess.get_outputs()]
+        action = next(n for n in out_names if "joint_actions" in n)
+        codes = [n for n in out_names if n != action]
+        print(f"ONNX {a.onnx.name}: action='{action}' code-probes={codes}")
+        print("  running ORT fp32 reference (slow, cached afterwards)...", flush=True)
+        rng0 = np.random.default_rng(1234)
+        refs = []
+        t0r = time.time()
+        for t in range(a.trials):
+            feed = build_inputs(rsess, rng0, frames_g[t % len(frames_g)] if frames_g else None)
+            refs.append(dict(zip(out_names, rsess.run(out_names, feed))))
+            if (t + 1) % 10 == 0:
+                print(f"    ORT {t+1}/{a.trials}  {time.time()-t0r:.0f}s", flush=True)
+        specs = [dict(name=i.name, shape=list(i.shape), type=i.type) for i in rsess.get_inputs()]
+        sess = SpecSess([_Spec(s["name"], s["shape"], s["type"]) for s in specs])
+        if a.ref_cache is not None:
+            d = {f"t{t}_{i}": np.asarray(refs[t][n])
+                 for t in range(a.trials) for i, n in enumerate(out_names)}
+            d["meta"] = json.dumps(dict(onnx=a.onnx.name, trials=a.trials,
+                                        out_names=out_names, action=action, inputs=specs))
+            np.savez_compressed(a.ref_cache, **d)
+            print(f"  wrote ORT reference cache {a.ref_cache}")
+        del rsess
+
+    if a.ref_only:
+        print("--ref-only: reference cache written, exiting without engine comparison")
+        return 0
+
+    engines = {}
+    for p in [x.strip() for x in a.engines.split(",") if x.strip()]:
+        pp = Path(p)
+        if not pp.exists():
+            print(f"  [skip] missing {pp}")
+            continue
+        try:
+            engines[pp.name] = TRTRunner(pp)
+            print(f"  loaded {pp.name}")
+        except SystemExit as e:
+            print(f"  [skip] {pp.name}: {e}")
+    if not engines:
+        raise SystemExit("no engines loaded")
+
+    frames = frames_g
+    print(f"{len(frames)} real camera frames" if frames else "NOISE inputs (not acceptable)")
+
+    stats = {k: dict(dec=0, maxabs=0.0, sumabs=0.0, n=0,
+                     flips={c: 0 for c in codes}) for k in engines}
+    rng = np.random.default_rng(1234)   # same seed as verify_trt_parity.py
+    t0 = time.time()
+    for t in range(a.trials):
+        feed = build_inputs(sess, rng, frames[t % len(frames)] if frames else None)
+        ref = refs[t]
+        for name, run in engines.items():
+            got = run(feed)
+            g = got.get(action)
+            if g is None:
+                g = next(iter(got.values()))
+            d = np.abs(np.asarray(g).astype(np.float64)
+                       - np.asarray(ref[action]).astype(np.float64))
+            s = stats[name]
+            s["maxabs"] = max(s["maxabs"], float(d.max()))
+            s["sumabs"] += float(d.mean())
+            s["n"] += 1
+            changed = bool((d > a.code_tol).any())
+            s["dec"] += int(changed)
+            det = []
+            for c in codes:
+                if c not in got:
+                    continue
+                r = np.asarray(ref[c]).astype(np.int64).ravel()
+                e = np.asarray(got[c]).astype(np.int64).ravel()[:r.size]
+                nd = int((r != e).sum())
+                if nd:
+                    s["flips"][c] += 1
+                    det.append(f"{c}={nd}/{r.size}(ref{r.tolist()}!=trt{e.tolist()})")
+            if changed or det:
+                print(f"  t{t:02d} {name}: dec={changed} max|d|={d.max():.4f} "
+                      f"{' '.join(det)}")
+        if (t + 1) % 10 == 0:
+            print(f"  ... {t+1}/{a.trials} trials, {time.time()-t0:.0f}s", flush=True)
+
+    print(f"\n{'engine':46s} {'decisions':>12s} {'max|d|':>10s} {'mean|d|':>10s}  verdict")
+    results = {}
+    for name, s in stats.items():
+        frac = s["dec"] / max(s["n"], 1)
+        ok = s["dec"] == 0 and s["maxabs"] < 0.05
+        print(f"{name:46s} {s['dec']:5d}/{s['n']:<6d} {s['maxabs']:10.6f} "
+              f"{s['sumabs']/max(s['n'],1):10.6f}  {'PASS' if ok else 'FAIL'}")
+        results[name] = dict(decision_changes=s["dec"], trials=s["n"],
+                             max_abs=s["maxabs"], mean_abs=s["sumabs"]/max(s["n"],1),
+                             pass_=ok, flips=s["flips"])
+    if codes:
+        print(f"\nper-ArgMax flip counts (trials with >=1 differing code index):")
+        hdr = "  " + f"{'engine':46s}" + "".join(f"{c:>12s}" for c in codes)
+        print(hdr)
+        for name, s in stats.items():
+            print("  " + f"{name:46s}" + "".join(f"{s['flips'][c]:>12d}" for c in codes))
+    if a.out:
+        a.out.write_text(json.dumps(dict(onnx=str(a.onnx), trials=a.trials,
+                                         code_tol=a.code_tol, results=results), indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.claude/skills/trt-export/scripts/per_channel_parity.py
+++ b/.claude/skills/trt-export/scripts/per_channel_parity.py
@@ -1,0 +1,76 @@
+"""Per-ACTION-CHANNEL parity over all 200 trials, mixed engine vs rmind-native reference.
+
+max|d| over the whole (6 x 4) chunk conflates turn_signal with the control channels.
+Channels: 0=gas_pedal 1=brake_pedal 2=steering_angle 3=turn_signal (continuous norm = Identity).
+"""
+import json, sys, pathlib
+from pathlib import Path
+import numpy as np
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from verify_trt_parity import TRTRunner, build_inputs
+
+NAMES = ["gas_pedal", "brake_pedal", "steering_angle", "turn_signal"]
+CACHE = None  # --cache
+ENGINES = {}  # --engines
+FRAMES = None  # --frames
+TOL = 0.02
+
+def load_frames(spec):
+    import cv2
+    out = []
+    for fp in [pathlib.Path(x) for x in spec.split(",") if x.strip()]:
+        img = cv2.imread(str(fp))
+        if img is None: continue
+        h = img.shape[0]; side = min(h, 320); top = max((h - side)//2, 0)
+        out.append(cv2.cvtColor(img[top:top+side,:], cv2.COLOR_BGR2RGB).astype(np.float32)/255.0)
+    return out
+
+class _S:
+    def __init__(s, d): s.name, s.shape, s.type = d["name"], d["shape"], d["type"]
+class SS:
+    def __init__(s, x): s._x = x
+    def get_inputs(s): return s._x
+
+import argparse
+_ap = argparse.ArgumentParser(description=__doc__)
+_ap.add_argument("--cache", required=True, help="reference npz (parity_matrix --ref-cache format)")
+_ap.add_argument("--engines", required=True, help="comma-separated name=path pairs, or bare paths")
+_ap.add_argument("--frames", required=True)
+_ap.add_argument("--tol", type=float, default=0.02)
+_a = _ap.parse_args()
+CACHE, FRAMES, TOL = _a.cache, _a.frames, _a.tol
+ENGINES = {}
+for _e in _a.engines.split(","):
+    _e = _e.strip()
+    if not _e: continue
+    ENGINES[_e.split("=",1)[0] if "=" in _e else pathlib.Path(_e).name] = _e.split("=",1)[-1]
+
+z = np.load(CACHE, allow_pickle=True); meta = json.loads(str(z["meta"]))
+action = meta["action"]; ai = meta["out_names"].index(action); N = meta["trials"]
+sess = SS([_S(s) for s in meta["inputs"]]); frames = load_frames(FRAMES)
+runners = {k: TRTRunner(pathlib.Path(v)) for k, v in ENGINES.items()}
+
+stats = {k: dict(mx=np.zeros(4), dec_any=0, dec_ctrl=0, sm=np.zeros(4)) for k in runners}
+rng = np.random.default_rng(1234)
+for t in range(N):
+    feed = build_inputs(sess, rng, frames[t % len(frames)] if frames else None)
+    nat = np.asarray(z[f"t{t}_{ai}"], dtype=np.float64).reshape(-1, 4)
+    for k, r in runners.items():
+        got = np.asarray(r(feed)[action], dtype=np.float64).reshape(-1, 4)
+        d = np.abs(got - nat)
+        s = stats[k]
+        s["mx"] = np.maximum(s["mx"], d.max(axis=0))
+        s["sm"] += d.mean(axis=0)
+        if (d > TOL).any(): s["dec_any"] += 1
+        if (d[:, :3] > TOL).any(): s["dec_ctrl"] += 1
+
+print(f"\nvs rmind-native reference, n={N}, tol={TOL}\n")
+for k, s in stats.items():
+    print(f"### {k}")
+    print(f"  {'channel':<16}{'max|d|':>10}{'mean|d|':>11}")
+    for c, nm in enumerate(NAMES):
+        print(f"  {nm:<16}{s['mx'][c]:10.4f}{s['sm'][c]/N:11.5f}")
+    print(f"  decision changes ANY channel      : {s['dec_any']}/{N}")
+    print(f"  decision changes CONTROL only     : {s['dec_ctrl']}/{N}   "
+          f"(gas/brake/steering; excludes turn_signal)")
+    print()

--- a/.claude/skills/trt-export/scripts/precision_ranges.py
+++ b/.claude/skills/trt-export/scripts/precision_ranges.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+"""Derive the FP32 layer-index ranges for the serving build, per model.
+
+The serving standard is a PAIR of engines:
+  1. fp32                                  -- the reference, bit-exact, always build it
+  2. fp32 encoder + fp16 trunk + fp32 decode -- ~4.3x faster at the same measured parity
+
+Range (2) needs three boundaries, and they are ARCHITECTURE-SPECIFIC -- do not reuse numbers
+from another model. Measured on dinov2_dinowm_big they were 0-1945 / 1946-2850 / 2851-2961,
+but a dinov3 arm at 256x256 has a different layer count entirely.
+
+Why these boundaries: relative error is created in the image encoder (9e-4 -> 3.2e-3) and is
+flat through the temporal trunk (2.46e-3 -> 2.63e-3). Pinning the tail does nothing -- engines
+with TopK/ArgMax/decode pinned came out bit-identical to unpinned ones. The encoder is only
+~18% of runtime, so protecting it is cheap. The decode head is pinned because the code_head
+ArgMax margins live there.
+
+Usage:
+    precision_ranges.py MODEL.onnx [--drivr-dir /home/max/Code/drivr]
+Prints the ranges and a ready-to-run build command.
+"""
+from __future__ import annotations
+import argparse, re, sys
+from pathlib import Path
+
+
+def build_network(onnx_path: Path):
+    import tensorrt as trt
+    logger = trt.Logger(trt.Logger.ERROR)
+    builder = trt.Builder(logger)
+    network = builder.create_network()
+    parser = trt.OnnxParser(network, logger)
+    with open(onnx_path, "rb") as f:
+        if not parser.parse(f.read()):
+            for i in range(parser.num_errors):
+                print(f"  onnx parse error: {parser.get_error(i)}", file=sys.stderr)
+            raise SystemExit("failed to parse ONNX")
+    return network
+
+
+# The temporal trunk is called `encoder` in rmind's PatchPolicy (confusingly -- the IMAGE
+# encoder is `image_encoder`), so its position embedding / first block marks where the
+# per-frame image encoder ends.
+TRUNK_START = re.compile(r"(encoder\.position_embedding|encoder\.layers\.0\.|speed_embedding)")
+DECODE_START = re.compile(r"(code_head\.|offset_head\.)")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("onnx", type=Path)
+    ap.add_argument("--drivr-dir", default="/home/max/Code/drivr")
+    a = ap.parse_args()
+
+    net = build_network(a.onnx)
+    n = net.num_layers
+    names = [net.get_layer(i).name for i in range(n)]
+
+    trunk = next((i for i, nm in enumerate(names) if TRUNK_START.search(nm)), None)
+    decode = next((i for i, nm in enumerate(names) if DECODE_START.search(nm)), None)
+
+    print(f"layers            : {n}")
+    if trunk is None or decode is None:
+        print("  !! could not locate boundaries by name.")
+        print("     Inspect with: build_mixed.py --onnx M.onnx --list-layers")
+        print("     Look for the first `encoder.position_embedding`/`encoder.layers.0.*`")
+        print("     constant (trunk start) and the first `code_head.*` constant (decode start).")
+        return 2
+    if not (0 < trunk < decode < n):
+        print(f"  !! implausible ordering: trunk={trunk} decode={decode} n={n}")
+        return 2
+
+    enc_hi, dec_lo, dec_hi = trunk - 1, decode, n - 1
+    enc_pct = 100.0 * trunk / n
+    print(f"image encoder     : 0-{enc_hi}          ({enc_pct:.0f}% of layers)")
+    print(f"temporal trunk    : {trunk}-{dec_lo - 1}")
+    print(f"decode head       : {dec_lo}-{dec_hi}")
+    print(f"\nfp32 ranges       : 0-{enc_hi},{dec_lo}-{dec_hi}")
+    print(f"\n# 1/2  reference engine (always build this)")
+    print(f"{a.drivr_dir}/.venv/bin/python build_mixed.py \\")
+    print(f"    --onnx {a.onnx} --precision fp32 --workspace-gb 6 \\")
+    print(f"    --engine {a.onnx.with_suffix('')}.trt")
+    print(f"\n# 2/2  serving engine: fp32 encoder + fp16 trunk + fp32 decode")
+    print(f"{a.drivr_dir}/.venv/bin/python build_mixed.py \\")
+    print(f"    --onnx {a.onnx} --precision mixed --workspace-gb 6 \\")
+    print(f"    --fp32-index-ranges 0-{enc_hi},{dec_lo}-{dec_hi} \\")
+    print(f"    --engine {a.onnx.with_suffix('')}.encfp32-fp16trunk.trt")
+    print("\n# then: parity_matrix.py --trials 200 across BOTH, fp32 first as the control")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/skills/trt-export/scripts/verify_trt_parity.py
+++ b/.claude/skills/trt-export/scripts/verify_trt_parity.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python
+"""Verify a TRT engine against its ONNX source: is the engine still the model?
+
+Compares `policy.joint_actions` from TensorRT (GPU, built precision) against
+ONNX Runtime (CPU, fp32 reference) over N randomized-but-realistic inputs.
+
+For codebook policies the float error is the wrong headline: the graph ends in
+ArgMax over code logits, so a small numeric error flips a discrete code and the
+action changes by a step, not a nudge. This reports both:
+
+  * float agreement  — max/mean |TRT - ORT| per channel
+  * DECISION agreement — fraction of samples where any channel moves more than
+    `--code-tol`, i.e. large enough that a code almost certainly flipped
+
+A pure-fp16 build of a VQ policy typically shows tiny mean error and a few
+percent decision disagreement, which is the failure that matters.
+
+Usage:
+  verify_trt_parity.py --onnx model.onnx --engine model.fp16strict.trt [--trials 20]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+CHANNELS = ("gas", "brake", "steering", "turn_signal")
+
+
+def build_inputs(sess, rng, frame01=None):
+    """Realistic input set: [0,1] image, km/h speed, /100 ego waypoints."""
+    feed = {}
+    for i in sess.get_inputs():
+        shape = [1 if not isinstance(d, int) else d for d in i.shape]
+        name = i.name.lower()
+        if "cam" in name:
+            h, w = shape[-2], shape[-1]
+            if frame01 is not None:
+                import cv2
+                img = cv2.resize(frame01, (w, h), interpolation=cv2.INTER_AREA)
+                chw = img.transpose(2, 0, 1)
+                # per-frame jitter so the 6 timesteps aren't identical
+                seq = np.stack([np.clip(chw * (0.94 + 0.02 * k), 0, 1)
+                                for k in range(shape[1])], axis=0)
+                feed[i.name] = seq[None].astype(np.float32)
+            else:
+                feed[i.name] = rng.uniform(0, 1, shape).astype(np.float32)
+        elif "speed" in name:
+            feed[i.name] = np.full(shape, rng.uniform(0, 40), np.float32)
+        elif "waypoint" in name:
+            spacing = rng.uniform(2, 25) / 100.0
+            y = (np.arange(shape[2], dtype=np.float32) + 1) * spacing
+            x = rng.normal(0, 0.02, shape[2]).astype(np.float32)
+            wp = np.stack([x, y], axis=1)
+            feed[i.name] = np.tile(wp, (shape[0], shape[1], 1, 1)).astype(np.float32)
+        else:
+            feed[i.name] = rng.uniform(0, 1, shape).astype(np.float32)
+    return feed
+
+
+class TRTRunner:
+    def __init__(self, path: Path):
+        import tensorrt as trt
+        import torch
+
+        self.torch = torch
+        logger = trt.Logger(trt.Logger.ERROR)
+        with open(path, "rb") as f:
+            self.engine = trt.Runtime(logger).deserialize_cuda_engine(f.read())
+        if self.engine is None:
+            raise SystemExit(f"failed to deserialize {path} "
+                             "(TRT version / GPU arch mismatch?)")
+        self.ctx = self.engine.create_execution_context()
+        self.io = []
+        for i in range(self.engine.num_io_tensors):
+            n = self.engine.get_tensor_name(i)
+            self.io.append((n, self.engine.get_tensor_mode(n) == trt.TensorIOMode.INPUT,
+                            tuple(self.engine.get_tensor_shape(n)),
+                            trt.nptype(self.engine.get_tensor_dtype(n))))
+
+    def __call__(self, feed: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        torch = self.torch
+        bufs, out = {}, {}
+        for name, is_in, shape, npdt in self.io:
+            if is_in:
+                src = None
+                for k, v in feed.items():
+                    if k == name or k.lower().replace("batch_", "") in name.lower() \
+                            or name.lower() in k.lower():
+                        src = v
+                        break
+                if src is None:
+                    raise SystemExit(f"no feed for engine input {name}")
+                t = torch.from_numpy(np.ascontiguousarray(src.astype(npdt))).cuda()
+            else:
+                t = torch.empty(tuple(shape),
+                                dtype=getattr(torch, np.dtype(npdt).name)).cuda()
+                out[name] = t
+            bufs[name] = t
+            self.ctx.set_tensor_address(name, int(t.data_ptr()))
+        stream = torch.cuda.Stream()
+        with torch.cuda.stream(stream):
+            self.ctx.execute_async_v3(stream.cuda_stream)
+        stream.synchronize()
+        return {k: v.cpu().numpy() for k, v in out.items()}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--onnx", type=Path, required=True)
+    ap.add_argument("--engine", type=Path, required=True)
+    ap.add_argument("--trials", type=int, default=20)
+    ap.add_argument("--frames", default="/tmp/native_raw.png",
+                    help="comma-separated real camera frames; trials cycle through "
+                         "them so activations vary as they do while driving")
+    ap.add_argument("--code-tol", type=float, default=0.02,
+                    help="|diff| above this counts as a changed decision, not float noise")
+    ap.add_argument("--out", type=Path, default=None)
+    args = ap.parse_args()
+
+    import onnxruntime as ort
+
+    sess = ort.InferenceSession(str(args.onnx), providers=["CPUExecutionProvider"])
+    trt_run = TRTRunner(args.engine)
+    out_name = sess.get_outputs()[0].name
+
+    import cv2
+    frames = []
+    for fp in [Path(x) for x in args.frames.split(",") if x.strip()]:
+        if not fp.exists():
+            continue
+        img = cv2.imread(str(fp))
+        if img is None:
+            continue
+        h, _ = img.shape[:2]
+        side = min(h, 320)
+        top = max((h - side) // 2, 0)
+        frames.append(cv2.cvtColor(img[top:top + side, :], cv2.COLOR_BGR2RGB)
+                      .astype(np.float32) / 255.0)
+    print(f"images from {len(frames)} real frame(s)" if frames else "images from noise")
+
+    rng = np.random.default_rng(1234)
+    diffs, decision_changes, rows = [], 0, []
+    for t in range(args.trials):
+        feed = build_inputs(sess, rng, frames[t % len(frames)] if frames else None)
+        ref = sess.run([out_name], feed)[0]
+        got = trt_run(feed)
+        eng = next(iter(got.values())) if out_name not in got else got[out_name]
+        d = np.abs(eng.astype(np.float64) - ref.astype(np.float64))
+        diffs.append(d)
+        changed = bool((d > args.code_tol).any())
+        decision_changes += int(changed)
+        rows.append(dict(trial=t, max_abs=float(d.max()),
+                         step0=[round(float(x), 4) for x in ref[0, 0]],
+                         step0_trt=[round(float(x), 4) for x in eng[0, 0]],
+                         decision_changed=changed))
+        if changed:
+            print(f"  trial {t}: DECISION CHANGED  max|d|={d.max():.4f}  "
+                  f"ref step0={np.round(ref[0,0],3)}  trt step0={np.round(eng[0,0],3)}")
+
+    D = np.stack(diffs)
+    print(f"\n=== {args.engine.name} vs {args.onnx.name} ({args.trials} trials) ===")
+    print(f"  max |diff| overall : {D.max():.6f}")
+    print(f"  mean |diff|        : {D.mean():.6f}")
+    for c, ch in enumerate(CHANNELS):
+        print(f"    {ch:12s} max {D[:, :, :, c].max():.6f}  mean {D[:, :, :, c].mean():.6f}")
+    frac = decision_changes / args.trials
+    print(f"  decision changes   : {decision_changes}/{args.trials} ({100*frac:.1f} %) "
+          f"at tol {args.code_tol}")
+    verdict = ("PASS — engine matches the ONNX reference"
+               if decision_changes == 0 and D.max() < 0.05 else
+               "FAIL — engine disagrees with its own ONNX; do not serve this build")
+    print(f"  VERDICT: {verdict}")
+    if args.out:
+        args.out.write_text(json.dumps(
+            dict(engine=str(args.engine), onnx=str(args.onnx), trials=args.trials,
+                 max_abs=float(D.max()), mean_abs=float(D.mean()),
+                 decision_changes=decision_changes, rows=rows), indent=2))
+    return 0 if decision_changes == 0 and D.max() < 0.05 else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Adds the TensorRT export / validation / deploy procedure for PatchPolicy as a tracked skill at `.claude/skills/trt-export/`, so it lives next to the code that produces the ONNX rather than in one person's home directory.

### Why track it

Every expensive failure in this area was **silent**: an engine that loads, runs fast, and decodes *different actions*; a runtime that feeds the wrong image size and shears the frame instead of erroring; an engine built on a loaded host that is simply slower, because TRT picks kernels by timing them. Each rule in the doc is a thing that already went wrong, with the measurement that settled it.

### Load-bearing content

- **Precision by measurement.** Full Pareto curve at n=200 against an fp32 control. Serving standard is a *pair*: `fp32` (reference, decision-exact) and `fp32-encoder / fp16-trunk / fp32-decode` — **420 → 98 ms, 4.3×, at the same parity**. `fp16-strict`, `bf16`, `int8` and `tf32` are each documented as dominated *with numbers*, so nobody re-tries them.
- **Parity = decision changes, not float error.** Mean float error was ~1e-3 even on an engine that decoded 80 % of actions differently.
- **Read `max|d|` per channel.** The action vector is `[gas_pedal, brake_pedal, steering_angle, turn_signal]`; `turn_signal`'s wider range dominates a max-over-channels. A headline `max|d| = 0.546` turned out to be an *indicator* change while the control channels moved ≤ 0.084.
- **The fp32 baseline is itself validated** against rmind PyTorch native: 0/200 decision changes, max `|d|` 7.7e-07. Parity results therefore hold transitively.
- **A 40 s CPU margin screen** predicts fp16 code flips before an engine is built; `min ULP < 1` called every measured failure across 18 checkpoints.

### Scripts

Runnable, not illustrative: graph inspection, margin screen, per-architecture fp32 range derivation (never hardcode — the dinov2 and dinov3 arms differ), mixed-precision build, parity matrix, per-channel parity, and the native-vs-ONNX baseline check.

### Notes for review

- Hostnames and paths in `SKILL.md` describe the yaak setup **deliberately** — which host can reach the car, which venv actually has `tensorrt`. Those are the facts that cost the most time to rediscover. Script defaults point at the same places but are all overridable.
- `CLAUDE.md` is gitignored on `main`, so tracking anything under `.claude/` is a new convention here. Happy to move this to `docs/` instead if that was a deliberate call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fe5b1EgtU5ZTBfPF1dQ4h7