### PR TITLE
feat: decoder-only KV-cached trunk (5-19x cheaper serving), FlexAttention long-context training, and anti-overfitting for patch policy

### DIFF
--- a/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
@@ -54,11 +54,21 @@ defaults:
 #     64      16     3215       749                1.15x
 #     64      64     3233      1151                1.77x
 #
-# So 32 frames of clip with a 16-frame window costs 1.08x today's 6-frame trunk
-# step -- the same ballpark -- where dense SDPA would cost 2.74x. Trunk peak
-# activation memory at 768 frame-slots is ~9.7 GiB (flex) against ~11.0 GiB for
-# today's 6-frame/batch-128 arm, i.e. slightly BETTER, because block-sparsity also
-# shrinks the attention working set.
+# So 32 frames of clip with a 16-frame window costs ~1.08x today's 6-frame trunk
+# step -- the same ballpark -- where dense SDPA would cost 2.74x.
+#
+# Measured directly at the two batches involved, one fresh process per cell
+# (`bench_causal_frame.py trunk --only 32x16 --batches 24`), which is the number
+# this recipe actually rests on:
+#
+#   512-d/8L   6 frames, w6,  batch 128, sdpa (today)  670.7 ms   9.60 GiB
+#   512-d/8L  32 frames, w16, batch  24, flex          701.7 ms   9.60 GiB
+#   768-d/12L  6 frames, w6,  batch 128, sdpa (today) 1713.5 ms  16.80 GiB
+#   768-d/12L 32 frames, w16, batch  24, flex         1779.6 ms  16.79 GiB
+#
+# 1.05x the step time and the same memory to the last 10 MiB, for 5.3x the context.
+# Memory is flat because activation memory scales with `batch x frames`, which is
+# what is being held constant; block-sparsity is worth only another 2-5 % there.
 #
 # Serving cost of `window: 16` is already measured: 59.6 ms/tick for this arm on
 # an AGX Orin at 918 MHz (§9 of docs/decoder_only_kv_cache.md), vs 200.9 ms for

--- a/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
@@ -4,53 +4,130 @@ defaults:
   - /experiment/yaak/patch_policy/dinov2_dinowm
   - _self_
 
-# Decoder-only trunk: causal over frame blocks, bidirectional within a frame,
-# with a sliding window equal to the serving cache capacity. Trains the way it
-# infers (hand-off §6): a full forward under
-# `frame_block_causal_mask(window=episode_length)` is EXACTLY streaming one frame
-# per tick against a ring buffer of `episode_length - 1` past frames -- that
-# equivalence is the gate in tests/test_causal_frame.py.
+# Decoder-only trunk: causal over frame blocks, bidirectional within a frame, with
+# a sliding window equal to the serving cache capacity. Trains the way it infers
+# (hand-off §6): a full forward under `frame_block_causal_mask(window=W)` is
+# EXACTLY streaming one frame per tick against a ring buffer of `W - 1` past
+# frames -- that equivalence is the gate in tests/test_causal_frame.py.
 #
 # Positional encoding is frame-RoPE + a tiled 257-slot intra-frame embedding, so
 # nothing is window-absolute and cached keys never go stale. See
 # src/rmind/components/transformer/causal_frame.py.
 #
-# ⚠️ TRAINING COST. The KV cache makes INFERENCE per-tick cost independent of the
-# window; it does NOT make training cheaper. Training still does one dense
-# forward over the whole clip, and the attention terms are quadratic in the
-# flattened length:
+# ---------------------------------------------------------------------------
+# 1. WHY `episode_length` AND `window` ARE DIFFERENT NUMBERS HERE
+# ---------------------------------------------------------------------------
+# `window` is the CONTEXT DEPTH per readout, and it is also the serving ring
+# capacity. `episode_length` is the SUPERVISION DENSITY: every frame in the clip
+# is a readout with its own action-chunk target, so a 32-frame clip yields 32
+# training targets from one frozen-ViT pass over 32 images.
 #
-#   frames  flattened tokens  per-query cost  attention cost
-#      6           1542             1.0x            1.0x
-#     16           4112             2.7x            7.1x
-#     32           8224             5.3x           28.4x
-#     64          16448            10.7x          113.8x
+# Setting them equal (the previous version of this file) throws away the main
+# reason to have a window at all. With `episode_length == window` the mask is
+# plain block-causal, cost still grows as F^2, and the first `window - 1` readouts
+# of every clip are trained with LESS context than they will be served with. With
+# `episode_length > window` cost grows LINEARLY in F, and 17 of the 32 readouts
+# see a full 16-frame window (frames 0..14 see a short one, and that is the same
+# cold-start ramp drivr has after every engage).
 #
-# The `window` mask makes the attention BLOCK-SPARSE but plain SDPA still
-# materializes the dense score matrix, so the saving is not realized without a
-# block-sparse kernel (FlexAttention / `create_block_mask`). Hence 16 frames as
-# the default first step rather than 64, and the batch size cut accordingly.
-# Re-derive lr_warmup_steps / lr_total_steps for the new steps-per-epoch before
-# launching anything -- the cosine schedule oscillates past num_training_steps.
-episode_length: 16
-
-# clip_length becomes episode_length + clip_horizon - 1 = 21 automatically, so
-# the dataset must be rebuilt (rbyte clip_length); see the report's rbyte notes.
+# ---------------------------------------------------------------------------
+# 2. WHY THIS IS AFFORDABLE: `attention_impl: flex`
+# ---------------------------------------------------------------------------
+# A dense bool `attn_mask` disqualifies SDPA's flash backend, so plain SDPA
+# computes every masked position and the window buys nothing. `attention_impl:
+# flex` hands the same mask to FlexAttention as a `BlockMask`, whose Triton kernel
+# skips whole 128x128 blocks. Numerically identical (fp32 fwd+bwd parity to
+# <=1.5e-6 scale-relative, tests/test_causal_frame.py).
+#
+# Measured on an RTX 5090, bf16, FULL trunk fwd+bwd with gradient checkpointing
+# (tests/bench_causal_frame.py, 2026-08-05), normalized to a constant 768
+# frame-slots per step -- today's `batch 128 x 6 frames`, which is what fixes the
+# frozen-ViT cost, the readouts per step and the activation memory:
+#
+#   frames  window  sdpa ms   flex ms   flex vs today's dense 6-frame step
+#      6       6      652       497                0.76x
+#     16       6     1085       550                0.84x
+#     16      16     1085       626                0.96x
+#     32       8     1787       593                0.91x
+#     32      16     1787       705                1.08x   <-- this recipe
+#     32      32     1791       800                1.23x
+#     64      16     3215       749                1.15x
+#     64      64     3233      1151                1.77x
+#
+# So 32 frames of clip with a 16-frame window costs 1.08x today's 6-frame trunk
+# step -- the same ballpark -- where dense SDPA would cost 2.74x. Trunk peak
+# activation memory at 768 frame-slots is ~9.7 GiB (flex) against ~11.0 GiB for
+# today's 6-frame/batch-128 arm, i.e. slightly BETTER, because block-sparsity also
+# shrinks the attention working set.
+#
+# Serving cost of `window: 16` is already measured: 59.6 ms/tick for this arm on
+# an AGX Orin at 918 MHz (§9 of docs/decoder_only_kv_cache.md), vs 200.9 ms for
+# today's 6-frame non-cached baseline. A 16-frame window is 3.4x cheaper to serve
+# than what runs today, so this recipe does not trade serving cost for context.
+#
+# ---------------------------------------------------------------------------
+# 3. BATCH AND SCHEDULE ARITHMETIC
+# ---------------------------------------------------------------------------
+# batch 24 x 32 frames = 768 frame-slots and 768 readouts per step: identical to
+# today's batch 128 x 6. The loss means over `(b t)` readouts, so the gradient's
+# scale is unchanged and `lr` is left at 1e-4 (see §4 for the caveat).
+#
+# The clip11 train set is ~1.97M samples (FT baseline zcglgth4: 308,038 steps @
+# batch 64 for 10 epochs). Raising `episode_length` does NOT materially change
+# that count: the rbyte sampler is `DataFrameGroupByDynamic(every=${episode_stride}
+# = 10i, period=${clip_period}, gather_every=${episode_step})`, so clip STARTS are
+# strided by 10 raw frames independently of clip length -- only the tail of each
+# drive is lost, ~26 samples of ~3.1k per drive (<1%).
+#
+#   steps/epoch = 1.97M / 24 = ~82.1k   (today: 1.97M / 128 = ~15.4k)
+#
+# Today's arm plans 15 epochs = 231k steps = 177M supervised readouts. At 768
+# readouts/step that is the same 231k steps here, i.e. ~2.8 epochs -- so
+# `max_epochs: 3` and `lr_total_steps: 246000` (3 x 82.1k) spends about today's
+# wall clock. Do NOT leave `lr_total_steps` at 231000 with `max_epochs: 3`: the
+# cosine in `get_cosine_schedule_with_warmup` has no clamp and comes back UP past
+# `num_training_steps`. Warmup keeps today's 8% ratio.
+#
+# ---------------------------------------------------------------------------
+# 4. WHAT TO WATCH
+# ---------------------------------------------------------------------------
+# * `attn_dropout: 0.0` is REQUIRED: FlexAttention has no `dropout_p` and the
+#   trunk raises rather than silently dropping it. `raw.yaml` does not set it, so
+#   the Python default of 0.1 would otherwise apply. This is a regularization
+#   change riding along with the kernel change -- an A/B against today's arm must
+#   set `attn_dropout: 0.0` on the sdpa side too, or the two effects confound.
+# * 768 readouts from 24 clips are more correlated than 768 from 128 clips, so the
+#   effective batch is somewhat smaller than the count suggests. If early training
+#   is unstable, halve `lr` before touching anything else.
+# * `clip_length` becomes 37 (`episode_length + clip_horizon - 1`), so the dataset
+#   must be rebuilt (`just generate-config`, then a SINGLE-writer rbyte cache
+#   build -- two concurrent builds corrupt the samples store).
+# * 80 GB nodes: see dinov2_dinowm_causal_80gb.yaml, which only raises the batch.
+episode_length: 32
+window: 16
 
 model:
   encoder:
     _target_: rmind.components.transformer.causal_frame.CausalFrameTransformer
     tokens_per_frame: "${eval:'${num_patches} + 1'}"
-    # the training mask width == the serving cache capacity, in frames
-    window: ${episode_length}
+    # context depth per readout == the serving ring capacity, in frames
+    window: ${window}
+    # block-sparse kernel; the whole point of the window
+    attention_impl: flex
+    # required by attention_impl: flex (no dropout_p in FlexAttention)
+    attn_dropout: 0.0
     # 64 positions of range; base 10000 leaves most frequency pairs inert
     rope_base: 1000.0
 
-# 128 -> 16 keeps activation memory in the same ballpark as the 6-frame arm at
-# 128 (5.3x the tokens per sample). Placeholder: profile before committing.
 datamodule:
   train:
-    batch_size: 16
+    batch_size: 24
+
+trainer:
+  max_epochs: 3
+
+lr_warmup_steps: 19700
+lr_total_steps: 246000
 
 wandb:
   tags: [patch_policy, dinov2_dinowm_causal]

--- a/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
@@ -163,6 +163,10 @@ datamodule:
 
 trainer:
   max_epochs: 3
+  # causal epochs are 82.1k steps (~28h): at the default once-per-epoch cadence
+  # a run yields 3 val points and the quality gap/repr signals are unusable.
+  # 0.25 -> val every ~20.5k steps (~7h), 12 points per run.
+  val_check_interval: 0.25
 
 lr_warmup_steps: 19700
 lr_total_steps: 246000

--- a/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
@@ -128,6 +128,24 @@ model:
     attn_dropout: 0.0
     # 64 positions of range; base 10000 leaves most frequency pairs inert
     rope_base: 1000.0
+    # stochastic depth, timm-style linear ramp 0 -> 0.1 over the 8 layers.
+    # Anti-overfitting package (with label_smoothing + code_head decay below):
+    # the mid/big arms overfit hard (train p_gt ~0.6 vs val ~0.13).
+    drop_path_rate: 0.1
+
+  losses:
+    modules:
+      code:
+        # smooths only the CE term; the focal (1-pt)^gamma keeps the true-class
+        # pt. Also counteracts the entropy collapse behind the H6 calibration
+        # blowup (val focal exploding while p_gt rises).
+        label_smoothing: 0.1
+
+  optimizer:
+    # the code head is where overconfidence lives; decay it harder than the
+    # global 0.1 (biases stay decay-free via the blacklist)
+    weight_decay_overrides:
+      code_head: 0.2
 
 datamodule:
   train:

--- a/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
@@ -1,0 +1,56 @@
+# @package _global_
+
+defaults:
+  - /experiment/yaak/patch_policy/dinov2_dinowm
+  - _self_
+
+# Decoder-only trunk: causal over frame blocks, bidirectional within a frame,
+# with a sliding window equal to the serving cache capacity. Trains the way it
+# infers (hand-off §6): a full forward under
+# `frame_block_causal_mask(window=episode_length)` is EXACTLY streaming one frame
+# per tick against a ring buffer of `episode_length - 1` past frames -- that
+# equivalence is the gate in tests/test_causal_frame.py.
+#
+# Positional encoding is frame-RoPE + a tiled 257-slot intra-frame embedding, so
+# nothing is window-absolute and cached keys never go stale. See
+# src/rmind/components/transformer/causal_frame.py.
+#
+# ⚠️ TRAINING COST. The KV cache makes INFERENCE per-tick cost independent of the
+# window; it does NOT make training cheaper. Training still does one dense
+# forward over the whole clip, and the attention terms are quadratic in the
+# flattened length:
+#
+#   frames  flattened tokens  per-query cost  attention cost
+#      6           1542             1.0x            1.0x
+#     16           4112             2.7x            7.1x
+#     32           8224             5.3x           28.4x
+#     64          16448            10.7x          113.8x
+#
+# The `window` mask makes the attention BLOCK-SPARSE but plain SDPA still
+# materializes the dense score matrix, so the saving is not realized without a
+# block-sparse kernel (FlexAttention / `create_block_mask`). Hence 16 frames as
+# the default first step rather than 64, and the batch size cut accordingly.
+# Re-derive lr_warmup_steps / lr_total_steps for the new steps-per-epoch before
+# launching anything -- the cosine schedule oscillates past num_training_steps.
+episode_length: 16
+
+# clip_length becomes episode_length + clip_horizon - 1 = 21 automatically, so
+# the dataset must be rebuilt (rbyte clip_length); see the report's rbyte notes.
+
+model:
+  encoder:
+    _target_: rmind.components.transformer.causal_frame.CausalFrameTransformer
+    tokens_per_frame: "${eval:'${num_patches} + 1'}"
+    # the training mask width == the serving cache capacity, in frames
+    window: ${episode_length}
+    # 64 positions of range; base 10000 leaves most frequency pairs inert
+    rope_base: 1000.0
+
+# 128 -> 16 keeps activation memory in the same ballpark as the 6-frame arm at
+# 128 (5.3x the tokens per sample). Placeholder: profile before committing.
+datamodule:
+  train:
+    batch_size: 16
+
+wandb:
+  tags: [patch_policy, dinov2_dinowm_causal]

--- a/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
@@ -147,6 +147,11 @@ model:
     weight_decay_overrides:
       code_head: 0.2
 
+  # data-measured element-RMS of gzxgumtf's z_q (H3 eval 2026-08-06): the
+  # seeded MC calibration overestimates 1.86x because real code usage is
+  # non-uniform, landing the goal stream at 0.54 instead of 1.0
+  fusion_goal_rms: 0.077
+
 # scale-balanced patch/goal fusion (learnable calibrated gains). The dinowm
 # features are post-norm but still ~34x the goal z_q's element RMS; the causal
 # line adopts the fix from the start (per Max, 2026-08-06).

--- a/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml
@@ -147,6 +147,11 @@ model:
     weight_decay_overrides:
       code_head: 0.2
 
+# scale-balanced patch/goal fusion (learnable calibrated gains). The dinowm
+# features are post-norm but still ~34x the goal z_q's element RMS; the causal
+# line adopts the fix from the start (per Max, 2026-08-06).
+fusion_norm: true
+
 datamodule:
   train:
     batch_size: 24

--- a/config/experiment/yaak/patch_policy/dinov2_dinowm_causal_80gb.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dinowm_causal_80gb.yaml
@@ -7,14 +7,22 @@ defaults:
 # The same 32-frame/16-window geometry as dinov2_dinowm_causal, with the batch an
 # 80 GB A100/H100 can hold instead of the one a 32 GB 5090 can.
 #
-# Trunk peak activation memory is linear in frame-slots per step and was measured
-# at ~9.7 GiB for 768 slots (RTX 5090, bf16, gradient checkpointing,
-# tests/bench_causal_frame.py). batch 64 x 32 frames = 2048 slots -> ~26 GiB of
-# trunk activations, plus the frozen ViT's forward-only working set for 2048
-# images, the VQ-BeT heads over 2048 readouts, and AdamW state for the ~53 M
-# trainable parameters (~0.6 GiB). That leaves comfortable headroom in 80 GB;
-# batch 96 (3072 slots, ~39 GiB trunk) is the next step if a smoke run shows room,
-# but re-derive the schedule below before trying it.
+# Trunk peak activation memory is linear in frame-slots per step and was MEASURED at
+# 9.60 GiB (512-d/8L) and 16.79 GiB (768-d/12L) for 768 slots -- batch 24 x 32
+# frames, RTX 5090, bf16, gradient checkpointing, `bench_causal_frame.py trunk
+# --only 32x16 --batches 24`. batch 64 x 32 frames = 2048 slots therefore needs
+# ~25.6 / ~44.8 GiB of trunk activations, plus the frozen ViT's forward-only working
+# set for 2048 images (~5.4 GiB extrapolated from 2031 MiB at 768), the VQ-BeT heads
+# over 2048 readouts, and AdamW state for the trainable parameters (~0.6 GiB at
+# 512-d). Comfortable in 80 GB, and measured to OOM on a 32 GB 5090 -- which is why
+# this is a separate file rather than a batch override on the main arm.
+#
+# Leave headroom beyond the steady-state figure: the first compile of a new shape
+# benchmarks several kernel configs while the activations are live, so peak during
+# step 1 exceeds peak at step 100.
+#
+# batch 96 (3072 slots, ~38 GiB trunk at 512-d) is the next step if a smoke run
+# shows room, but re-derive the schedule below before trying it.
 #
 # Schedule: 1.97M / 64 = ~30.8k steps/epoch. Today's 15-epoch/231k-step plan is
 # 177M supervised readouts; at 64 x 32 = 2048 readouts/step that is ~86.6k steps,

--- a/config/experiment/yaak/patch_policy/dinov2_dinowm_causal_80gb.yaml
+++ b/config/experiment/yaak/patch_policy/dinov2_dinowm_causal_80gb.yaml
@@ -1,0 +1,37 @@
+# @package _global_
+
+defaults:
+  - /experiment/yaak/patch_policy/dinov2_dinowm_causal
+  - _self_
+
+# The same 32-frame/16-window geometry as dinov2_dinowm_causal, with the batch an
+# 80 GB A100/H100 can hold instead of the one a 32 GB 5090 can.
+#
+# Trunk peak activation memory is linear in frame-slots per step and was measured
+# at ~9.7 GiB for 768 slots (RTX 5090, bf16, gradient checkpointing,
+# tests/bench_causal_frame.py). batch 64 x 32 frames = 2048 slots -> ~26 GiB of
+# trunk activations, plus the frozen ViT's forward-only working set for 2048
+# images, the VQ-BeT heads over 2048 readouts, and AdamW state for the ~53 M
+# trainable parameters (~0.6 GiB). That leaves comfortable headroom in 80 GB;
+# batch 96 (3072 slots, ~39 GiB trunk) is the next step if a smoke run shows room,
+# but re-derive the schedule below before trying it.
+#
+# Schedule: 1.97M / 64 = ~30.8k steps/epoch. Today's 15-epoch/231k-step plan is
+# 177M supervised readouts; at 64 x 32 = 2048 readouts/step that is ~86.6k steps,
+# i.e. ~2.8 epochs again -- the readout budget is what is being held constant, not
+# the epoch count. `max_epochs: 3` -> 92.4k steps, and `lr_total_steps` must match
+# that or the cosine schedule oscillates back up (it has no clamp).
+#
+# NOTE the larger batch is 2.67x today's 768 readouts per step, so this is also a
+# 2.67x larger effective batch: scale `lr` accordingly (1e-4 * sqrt(2.67) ~ 1.6e-4
+# if you prefer sqrt scaling, 2.7e-4 for linear). Left at the inherited 1e-4 here
+# because that is the conservative choice and nothing has been swept.
+datamodule:
+  train:
+    batch_size: 64
+
+lr_warmup_steps: 7400
+lr_total_steps: 92400
+
+wandb:
+  tags: [patch_policy, dinov2_dinowm_causal, causal_80gb]

--- a/config/trainer/callbacks/patch_policy.yaml
+++ b/config/trainer/callbacks/patch_policy.yaml
@@ -59,3 +59,5 @@
     highway:
       - policy/score_l1/value/continuous/gas_pedal
       - policy/score_signed_error/value/continuous/gas_pedal
+- _target_: rmind.callbacks.TrainingQualityLogger
+  every_n_steps: 50

--- a/docs/causal_patch_policy_architecture.svg
+++ b/docs/causal_patch_policy_architecture.svg
@@ -1,0 +1,209 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1180 1500" font-family="Helvetica, Arial, sans-serif">
+  <defs>
+    <marker id="arr" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="7" markerHeight="7" orient="auto-start-reverse">
+      <path d="M 0 0 L 10 5 L 0 10 z" fill="#555"/>
+    </marker>
+  </defs>
+
+  <rect width="1180" height="1500" fill="#fcfcfd"/>
+  <text x="590" y="38" text-anchor="middle" font-size="24" font-weight="bold" fill="#1a1a2e">Causal Patch Policy — decoder-only trunk with KV cache</text>
+
+  <!-- legend -->
+  <rect x="700" y="56" width="14" height="14" rx="3" fill="#dbeafe" stroke="#3b82f6"/>
+  <text x="720" y="68" font-size="13" fill="#333">frozen (not trained)</text>
+  <rect x="860" y="56" width="14" height="14" rx="3" fill="#ffedd5" stroke="#f97316"/>
+  <text x="880" y="68" font-size="13" fill="#333">trained</text>
+  <rect x="950" y="56" width="14" height="14" rx="3" fill="#dcfce7" stroke="#22c55e"/>
+  <text x="970" y="68" font-size="13" fill="#333">KV cache (state, not weights)</text>
+
+  <!-- ===================== BAND 1: per-frame packing ===================== -->
+  <text x="30" y="100" font-size="16" font-weight="bold" fill="#1a1a2e">1 · Per-frame packing Z_t — unchanged from PR #265, plus scale-balanced fusion (fusion_norm)</text>
+
+  <rect x="40" y="118" width="220" height="50" rx="8" fill="#f1f5f9" stroke="#94a3b8"/>
+  <text x="150" y="139" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">camera frame t</text>
+  <text x="150" y="157" text-anchor="middle" font-size="12" fill="#555">cam_front_left · 224×224</text>
+
+  <rect x="40" y="196" width="220" height="50" rx="8" fill="#dbeafe" stroke="#3b82f6"/>
+  <text x="150" y="217" text-anchor="middle" font-size="14" font-weight="bold" fill="#1e3a8a">DINOv2 ViT-S (frozen)</text>
+  <text x="150" y="235" text-anchor="middle" font-size="12" fill="#1e3a8a">x_norm_patchtokens → 256×384</text>
+
+  <line x1="150" y1="168" x2="150" y2="196" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <rect x="310" y="118" width="220" height="50" rx="8" fill="#f1f5f9" stroke="#94a3b8"/>
+  <text x="420" y="139" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">waypoints (ego frame)</text>
+  <text x="420" y="157" text-anchor="middle" font-size="12" fill="#555">10 × 2, /100</text>
+
+  <rect x="310" y="196" width="220" height="50" rx="8" fill="#dbeafe" stroke="#3b82f6"/>
+  <text x="420" y="217" text-anchor="middle" font-size="14" font-weight="bold" fill="#1e3a8a">waypoints tokenizer (frozen)</text>
+  <text x="420" y="235" text-anchor="middle" font-size="12" fill="#1e3a8a">RVQ z_q → g_t (384)</text>
+
+  <line x1="420" y1="168" x2="420" y2="196" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <rect x="580" y="118" width="200" height="50" rx="8" fill="#f1f5f9" stroke="#94a3b8"/>
+  <text x="680" y="139" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">speed (km/h)</text>
+  <text x="680" y="157" text-anchor="middle" font-size="12" fill="#555">1 scalar per frame</text>
+
+  <rect x="580" y="196" width="200" height="50" rx="8" fill="#ffedd5" stroke="#f97316"/>
+  <text x="680" y="217" text-anchor="middle" font-size="14" font-weight="bold" fill="#7c2d12">binner + embedding</text>
+  <text x="680" y="235" text-anchor="middle" font-size="12" fill="#7c2d12">512 bins → 512-d token</text>
+
+  <line x1="680" y1="168" x2="680" y2="196" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- fusion norm -->
+  <rect x="40" y="278" width="490" height="66" rx="8" fill="#ffedd5" stroke="#f97316"/>
+  <text x="285" y="300" text-anchor="middle" font-size="14" font-weight="bold" fill="#7c2d12">fusion_norm — scale-balanced T×P×(D+G) concat</text>
+  <text x="285" y="318" text-anchor="middle" font-size="12" fill="#7c2d12">LN(patches)·gain_p  ⊕  g_t·gain_g   (gain_g init 1/RMS(z_q), data-measured 0.077)</text>
+  <text x="285" y="335" text-anchor="middle" font-size="12" fill="#7c2d12">without it the ~34× patch/goal gap swamps conditioning (H3, measured)</text>
+
+  <line x1="150" y1="246" x2="150" y2="278" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="420" y1="246" x2="420" y2="278" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <rect x="40" y="372" width="490" height="44" rx="8" fill="#ffedd5" stroke="#f97316"/>
+  <text x="285" y="399" text-anchor="middle" font-size="14" font-weight="bold" fill="#7c2d12">Linear(768 → 512) per patch token</text>
+
+  <line x1="285" y1="344" x2="285" y2="372" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- frame block strip -->
+  <rect x="40" y="446" width="740" height="58" rx="8" fill="#fff" stroke="#94a3b8"/>
+  <text x="60" y="470" font-size="13" font-weight="bold" fill="#333">frame block t (257 tokens):</text>
+  <rect x="230" y="458" width="34" height="34" rx="4" fill="#ffedd5" stroke="#f97316"/>
+  <text x="247" y="480" text-anchor="middle" font-size="11" fill="#7c2d12">spd</text>
+  <rect x="270" y="458" width="420" height="34" rx="4" fill="#dbeafe" stroke="#3b82f6"/>
+  <text x="480" y="480" text-anchor="middle" font-size="12" fill="#1e3a8a">256 goal-fused patch tokens</text>
+  <rect x="694" y="458" width="34" height="34" rx="4" fill="#93c5fd" stroke="#1d4ed8"/>
+  <text x="711" y="480" text-anchor="middle" font-size="10" fill="#1e3a8a">read</text>
+  <text x="745" y="480" font-size="11" fill="#555">← readout</text>
+
+  <line x1="285" y1="416" x2="285" y2="446" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="680" y1="246" x2="680" y2="446" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- ===================== BAND 2: positional scheme ===================== -->
+  <text x="30" y="548" font-size="16" font-weight="bold" fill="#1a1a2e">2 · Positional scheme — THE causal change (replaces the window-absolute 1542-slot table)</text>
+
+  <rect x="40" y="566" width="440" height="88" rx="8" fill="#ffedd5" stroke="#f97316"/>
+  <text x="260" y="590" text-anchor="middle" font-size="14" font-weight="bold" fill="#7c2d12">intra-frame: learned 257-slot embedding, TILED</text>
+  <text x="260" y="610" text-anchor="middle" font-size="12" fill="#7c2d12">token k of every frame gets intra_pos[k]</text>
+  <text x="260" y="628" text-anchor="middle" font-size="12" fill="#7c2d12">frame-relative → never stale as the window slides</text>
+
+  <rect x="510" y="566" width="470" height="88" rx="8" fill="#f1f5f9" stroke="#94a3b8"/>
+  <text x="745" y="590" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">inter-frame: RoPE at FRAME granularity (base 1000)</text>
+  <text x="745" y="610" text-anchor="middle" font-size="12" fill="#555">all 257 tokens of frame f share one rotation R_f (no params)</text>
+  <text x="745" y="628" text-anchor="middle" font-size="12" fill="#555">(R_f q)ᵀ(R_f k) = qᵀk → intra-frame exactly unrotated; cross-frame</text>
+  <text x="745" y="644" text-anchor="middle" font-size="12" fill="#555">logits depend only on f_q − f_k → cached keys stay valid forever</text>
+
+  <!-- ===================== BAND 3: training ===================== -->
+  <text x="30" y="700" font-size="16" font-weight="bold" fill="#1a1a2e">3 · Training — causal frame transformer, FlexAttention block-sparse window mask</text>
+
+  <!-- mask mini grid: 6 frames, window 3 -->
+  <text x="40" y="726" font-size="13" font-weight="bold" fill="#333">frame-window mask (shown: 6 frames, W=3)</text>
+  <g transform="translate(40,736)">
+    <!-- rows = query frame i, cols = key frame j; allowed: j<=i and i-j<W; diagonal = intra-frame bidirectional -->
+    <!-- row 0 -->
+    <rect x="0"   y="0"  width="26" height="26" fill="#93c5fd"/>
+    <rect x="28"  y="0"  width="26" height="26" fill="#f1f5f9"/>
+    <rect x="56"  y="0"  width="26" height="26" fill="#f1f5f9"/>
+    <rect x="84"  y="0"  width="26" height="26" fill="#f1f5f9"/>
+    <rect x="112" y="0"  width="26" height="26" fill="#f1f5f9"/>
+    <rect x="140" y="0"  width="26" height="26" fill="#f1f5f9"/>
+    <!-- row 1 -->
+    <rect x="0"   y="28" width="26" height="26" fill="#dbeafe"/>
+    <rect x="28"  y="28" width="26" height="26" fill="#93c5fd"/>
+    <rect x="56"  y="28" width="26" height="26" fill="#f1f5f9"/>
+    <rect x="84"  y="28" width="26" height="26" fill="#f1f5f9"/>
+    <rect x="112" y="28" width="26" height="26" fill="#f1f5f9"/>
+    <rect x="140" y="28" width="26" height="26" fill="#f1f5f9"/>
+    <!-- row 2 -->
+    <rect x="0"   y="56" width="26" height="26" fill="#dbeafe"/>
+    <rect x="28"  y="56" width="26" height="26" fill="#dbeafe"/>
+    <rect x="56"  y="56" width="26" height="26" fill="#93c5fd"/>
+    <rect x="84"  y="56" width="26" height="26" fill="#f1f5f9"/>
+    <rect x="112" y="56" width="26" height="26" fill="#f1f5f9"/>
+    <rect x="140" y="56" width="26" height="26" fill="#f1f5f9"/>
+    <!-- row 3: window drops frame 0 -->
+    <rect x="0"   y="84" width="26" height="26" fill="#f1f5f9"/>
+    <rect x="28"  y="84" width="26" height="26" fill="#dbeafe"/>
+    <rect x="56"  y="84" width="26" height="26" fill="#dbeafe"/>
+    <rect x="84"  y="84" width="26" height="26" fill="#93c5fd"/>
+    <rect x="112" y="84" width="26" height="26" fill="#f1f5f9"/>
+    <rect x="140" y="84" width="26" height="26" fill="#f1f5f9"/>
+    <!-- row 4 -->
+    <rect x="0"   y="112" width="26" height="26" fill="#f1f5f9"/>
+    <rect x="28"  y="112" width="26" height="26" fill="#f1f5f9"/>
+    <rect x="56"  y="112" width="26" height="26" fill="#dbeafe"/>
+    <rect x="84"  y="112" width="26" height="26" fill="#dbeafe"/>
+    <rect x="112" y="112" width="26" height="26" fill="#93c5fd"/>
+    <rect x="140" y="112" width="26" height="26" fill="#f1f5f9"/>
+    <!-- row 5 -->
+    <rect x="0"   y="140" width="26" height="26" fill="#f1f5f9"/>
+    <rect x="28"  y="140" width="26" height="26" fill="#f1f5f9"/>
+    <rect x="56"  y="140" width="26" height="26" fill="#f1f5f9"/>
+    <rect x="84"  y="140" width="26" height="26" fill="#dbeafe"/>
+    <rect x="112" y="140" width="26" height="26" fill="#dbeafe"/>
+    <rect x="140" y="140" width="26" height="26" fill="#93c5fd"/>
+  </g>
+  <text x="40" y="928" font-size="11" fill="#555">dark = intra-frame (bidirectional) · light = causal window · gray = masked,</text>
+  <text x="40" y="943" font-size="11" fill="#555">skipped for real by FlexAttention (dense SDPA pays for gray anyway — measured flat in W)</text>
+
+  <!-- trunk box -->
+  <rect x="260" y="736" width="420" height="170" rx="8" fill="#ffedd5" stroke="#f97316"/>
+  <text x="470" y="762" text-anchor="middle" font-size="15" font-weight="bold" fill="#7c2d12">CausalFrameTransformer — 8L / 8H / 512</text>
+  <text x="470" y="784" text-anchor="middle" font-size="12" fill="#7c2d12">pre-LN GPT blocks · attention_impl: flex</text>
+  <text x="470" y="804" text-anchor="middle" font-size="12" fill="#7c2d12">episode_length 32 &gt; window 16 — supervision density</text>
+  <text x="470" y="820" text-anchor="middle" font-size="12" fill="#7c2d12">decoupled from context depth: cost linear in frames</text>
+  <text x="470" y="844" text-anchor="middle" font-size="12" fill="#7c2d12">regularizers: drop-path 0→0.1 ramp · label-smoothed</text>
+  <text x="470" y="860" text-anchor="middle" font-size="12" fill="#7c2d12">focal (ε=0.1, focal factor on true class only)</text>
+  <text x="470" y="884" text-anchor="middle" font-size="12" fill="#7c2d12">32 fr × batch 24 = 768 slots/step ≈ 1.05× old step time</text>
+
+  <!-- vq-bet head -->
+  <rect x="720" y="736" width="420" height="170" rx="8" fill="#ffedd5" stroke="#f97316"/>
+  <text x="930" y="762" text-anchor="middle" font-size="15" font-weight="bold" fill="#7c2d12">VQ-BeT joint chunk head (#258, unchanged)</text>
+  <text x="930" y="786" text-anchor="middle" font-size="12" fill="#7c2d12">at EVERY frame's readout token:</text>
+  <text x="930" y="806" text-anchor="middle" font-size="12" fill="#7c2d12">code head → 4×16 logits (focal, wd 0.2)</text>
+  <text x="930" y="826" text-anchor="middle" font-size="12" fill="#7c2d12">offset table gathered at GT codes (teacher-forced, L1)</text>
+  <text x="930" y="850" text-anchor="middle" font-size="12" fill="#7c2d12">frozen chunk tokenizer y74asdtd:v9</text>
+  <text x="930" y="870" text-anchor="middle" font-size="12" fill="#1e3a8a">frozen: RVQ codebooks (blue)</text>
+  <text x="930" y="890" text-anchor="middle" font-size="12" fill="#7c2d12">17/32 readouts train under the FULL served window</text>
+
+  <line x1="680" y1="820" x2="720" y2="820" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <!-- ===================== BAND 4: serving ===================== -->
+  <text x="30" y="985" font-size="16" font-weight="bold" fill="#1a1a2e">4 · Serving — KV-cached decode step (per 333 ms control tick)</text>
+
+  <rect x="40" y="1005" width="250" height="60" rx="8" fill="#f1f5f9" stroke="#94a3b8"/>
+  <text x="165" y="1030" text-anchor="middle" font-size="14" font-weight="bold" fill="#333">1 NEW frame only</text>
+  <text x="165" y="1049" text-anchor="middle" font-size="12" fill="#555">encode 257 tokens (not 6×257)</text>
+
+  <rect x="340" y="1005" width="330" height="150" rx="8" fill="#ffedd5" stroke="#f97316"/>
+  <text x="505" y="1030" text-anchor="middle" font-size="14" font-weight="bold" fill="#7c2d12">trunk.step()</text>
+  <text x="505" y="1052" text-anchor="middle" font-size="12" fill="#7c2d12">257 queries vs (cached ∪ new) keys/values</text>
+  <text x="505" y="1072" text-anchor="middle" font-size="12" fill="#7c2d12">old frames NEVER recomputed or re-attended</text>
+  <text x="505" y="1092" text-anchor="middle" font-size="12" fill="#7c2d12">final block computes the readout position only</text>
+  <text x="505" y="1116" text-anchor="middle" font-size="12" fill="#7c2d12">cos/sin host-computed inputs — zero trig in graph</text>
+  <text x="505" y="1136" text-anchor="middle" font-size="12" fill="#7c2d12">cold = warm (cache_bias masks unfilled slots)</text>
+
+  <line x1="290" y1="1035" x2="340" y2="1035" stroke="#555" stroke-width="1.5" marker-end="url(#arr)"/>
+
+  <rect x="720" y="1005" width="420" height="150" rx="8" fill="#dcfce7" stroke="#22c55e"/>
+  <text x="930" y="1030" text-anchor="middle" font-size="14" font-weight="bold" fill="#14532d">host-side ring: per-layer K/V, W−1 = 15 frames</text>
+  <text x="930" y="1052" text-anchor="middle" font-size="12" fill="#14532d">read-only engine inputs · new frame's K/V are outputs</text>
+  <text x="930" y="1072" text-anchor="middle" font-size="12" fill="#14532d">eviction by age never invalidates retained K/V</text>
+  <text x="930" y="1092" text-anchor="middle" font-size="12" fill="#14532d">cleared on engage / disengage / override</text>
+  <text x="930" y="1116" text-anchor="middle" font-size="12" fill="#14532d">8 MiB per cached frame (this trunk) — memory is</text>
+  <text x="930" y="1132" text-anchor="middle" font-size="12" fill="#14532d">not the binding constraint on Orin</text>
+
+  <line x1="720" y1="1060" x2="670" y2="1060" stroke="#22c55e" stroke-width="1.5" marker-end="url(#arr)"/>
+  <line x1="670" y1="1100" x2="720" y2="1100" stroke="#f97316" stroke-width="1.5" marker-end="url(#arr)"/>
+  <text x="695" y="1050" text-anchor="middle" font-size="10" fill="#14532d">read</text>
+  <text x="695" y="1116" text-anchor="middle" font-size="10" fill="#7c2d12">write</text>
+
+  <!-- measured latency -->
+  <rect x="40" y="1195" width="1100" height="130" rx="8" fill="#fff" stroke="#94a3b8"/>
+  <text x="60" y="1222" font-size="14" font-weight="bold" fill="#1a1a2e">Measured — AGX Orin (delta-dev1), TRT, pinned 918 MHz, this 8L/512 trunk</text>
+  <text x="60" y="1248" font-size="13" fill="#333">block-causal baseline (6-frame window, full recompute): <tspan font-weight="bold">200.9 ms</tspan> — does not fit the 333 ms tick with headroom</text>
+  <text x="60" y="1272" font-size="13" fill="#333">causal decode, fp32: <tspan font-weight="bold">41.8 ms</tspan> @ 6 frames (4.8×) · <tspan font-weight="bold">59.6 ms</tspan> @ W=16 (this arm) · 92.3 ms @ 32 · 160.5 ms @ 64</text>
+  <text x="60" y="1296" font-size="13" fill="#333">causal decode, fp16 (one fused MHA kernel/layer): <tspan font-weight="bold">10.5 ms</tspan> @ 6 · <tspan font-weight="bold">27.2 ms</tspan> @ 32 · 45.7 ms @ 64 — parity ladder pending on trained weights</text>
+  <text x="60" y="1316" font-size="12" fill="#555">streaming ≡ full-window recompute verified to 1.8e-15 (fp64); window-absolute control fails by 5 orders of magnitude</text>
+
+  <text x="590" y="1360" text-anchor="middle" font-size="13" fill="#555">training run: vague-shape-587 (do8m9ot8) · branch feat/patch-policy-decoder-causal · docs/decoder_only_kv_cache.md</text>
+  <text x="590" y="1382" text-anchor="middle" font-size="13" fill="#555">same per-timestep training cost as PR #265 (768 frame-slots/step), 2.7× the served context, 3.4–19× cheaper per tick</text>
+</svg>

--- a/docs/decoder_only_kv_cache.md
+++ b/docs/decoder_only_kv_cache.md
@@ -12,8 +12,9 @@ past frames, and never recomputes or re-attends old frames to each other.
 | --- | --- |
 | trunk + mask + RoPE + cache | `src/rmind/components/transformer/causal_frame.py` |
 | one-tick export wrapper | `src/rmind/models/patch_policy_decoder.py` |
-| correctness gate (CPU) | `tests/test_causal_frame.py` |
-| training arm | `config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml` |
+| correctness gate | `tests/test_causal_frame.py` (cache/positional gates on CPU; the FlexAttention fwd+bwd parity gate needs CUDA and skips without it) |
+| block-sparse training benchmark | `tests/bench_causal_frame.py` |
+| training arms | `config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml`, `..._causal_80gb.yaml` |
 
 Everything outside the trunk is unchanged: the frozen DINOv2 ViT-S encoder, the
 frozen goal encoder and its RVQ, the fusion, `patch_projection`,
@@ -134,9 +135,11 @@ frames attend to those. Verified equivalent in
 
 ## 5. Correctness gate — `tests/test_causal_frame.py`
 
-Runs on CPU in <1 s. Every equivalence is paired with a **negative control** on a
-window-absolute variant of the same trunk, driven through the same harness, so a
-pass is falsifiable.
+The cache, mask and positional gates run on CPU in ~2 s (27 passed, 8 skipped);
+with a CUDA device the 8 skips are the FlexAttention parity gates of §11.2 and the
+whole file is 35 passed in ~9 s. Every equivalence is paired with a **negative
+control** on a window-absolute variant of the same trunk, driven through the same
+harness, so a pass is falsifiable.
 
 The literal §5.1 phrasing — "run on `[0..5]` cold, then `[1..6]` warm vs a full
 recompute of `[1..6]`" — is exact only when "full recompute" means the
@@ -286,9 +289,16 @@ takes clips from 11 to 21 samples, and 64 frames would need 69. Consequences:
 * the dataset must be **rebuilt** — `clip_period` is derived from `clip_length`
   and the existing clip-11 build is not reusable;
 * at `episode_step = 10` (≈3 Hz), 21 samples span ~7 s of driving and 69 span
-  ~23 s. Long clips are cut at session boundaries, so the number of usable
-  windows falls roughly linearly with `clip_length` — expect a materially
-  smaller train set at 64 frames, on top of the compute cost;
+  ~23 s;
+* **the train-set SIZE barely changes**, which is worth stating because the
+  opposite is the intuitive guess. The sampler is
+  `rbyte.io.DataFrameGroupByDynamic(every=${episode_stride} = 10i,
+  period=${clip_period}, gather_every=${episode_step})`: clip *starts* are strided
+  by `every`, independently of `period`, so a longer clip does not thin the
+  windows — it only truncates each drive's tail. Going from `clip_length` 11 to 37
+  costs ~26 windows of ~3.1k per drive, <1 % of the ~1.97M samples (assuming short
+  trailing windows are dropped; confirm on the first cache rebuild). Steps/epoch is
+  therefore `~1.97M / batch_size` at any `episode_length`;
 * per-sample decode/IO grows linearly with `clip_length`, so the loader becomes a
   real cost at long context, not just the GPU.
 
@@ -591,31 +601,47 @@ readouts per step and the activation memory:
 | 64 | 16 | 3215 | **749** | **1.15×** | 7469 | **1897** | **1.12×** |
 | 64 | 64 | 3233 | 1151 | 1.77× | 7501 | 2809 | 1.66× |
 
-("vs today" is against the 6-frame **dense** step of the same width, 652 / 1695 ms,
-which is what runs now. Raw per-batch measurements are in the commit message and
-reproducible with `tests/bench_causal_frame.py trunk`.)
+("vs today" is against the 6-frame step of **the same trunk with
+`attention_impl: sdpa`**, 652 / 1695 ms — the honest denominator for "what does
+flex buy". It is not literally the production `BlockCausalTransformer`, which has
+the same widths and the same dense-mask cost structure but no per-layer RoPE.
+Reproduce with `tests/bench_causal_frame.py trunk`.)
 
 **32-frame training lands inside today's 6-frame budget**: 1.08× at 512-d, 1.06× at
 768-d, against 2.74× / 2.50× if the mask stays dense. 64 frames is 1.15× / 1.12×.
 The cost of context has gone from quadratic to essentially free, and what is left
 is set by `window`, not by clip length: `32/8` (0.91×) is *cheaper* than today.
 
-Trunk peak activation memory at 768 frame-slots is likewise ~flat and slightly
-better than today's:
+And the recipe point itself, measured directly at the batch each arm actually
+uses — no normalization, and one fresh process per cell
+(`bench_causal_frame.py trunk --only 32x16 --batches 24`, plus the same for the
+6-frame/batch-128 baseline: a shared process that has already peaked at tens of GiB
+fragments the allocator for whatever runs next, which shows up as a spurious OOM):
 
-| frames | window | batch | 512-d/8L | 768-d/12L |
-| --- | --- | --- | --- | --- |
-| 6 | 6 | 128 | 11.0 GiB (sdpa, today) | 20.0 GiB |
-| 16 | 16 | 48 | 9.9 GiB | 17.6 GiB |
-| 32 | 16 | 24 | **9.7 GiB** | **17.4 GiB** |
-| 64 | 16 | 12 | 9.5 GiB | 17.1 GiB |
+| arm | geometry | batch | impl | step | trunk peak |
+| --- | --- | --- | --- | --- | --- |
+| 512-d / 8L | 6 frames, window 6 | 128 | sdpa (today) | 670.7 ms | 9.60 GiB |
+| 512-d / 8L | **32 frames, window 16** | **24** | **flex** | **701.7 ms** | **9.60 GiB** |
+| 768-d / 12L | 6 frames, window 6 | 128 | sdpa (today) | 1713.5 ms | 16.80 GiB |
+| 768-d / 12L | **32 frames, window 16** | **24** | **flex** | **1779.6 ms** | **16.79 GiB** |
 
-(Extrapolated linearly in batch from the measured batch-16 rows, which is how
-activation memory scales; flex is 3–5 % below sdpa at every measured point.) The
-768-d/64-frame/batch-16 **dense** case measures 23.6 GiB of trunk activations
-alone — that is what "does not fit a 32 GB card" looks like, and flex brings the
-same geometry to 22.8 GiB, i.e. block-sparsity is not the lever for memory. Holding
-frame-slots constant is.
+**1.05× the step time and the same memory to the last 10 MiB, for 5.3× the
+context.** Both arms. That is the whole result, and it agrees with the normalized
+table above to within 3 %, which is the check on the normalization.
+
+Peak activation memory at a constant 768 frame-slots is flat because the trunk's
+memory is dominated by the per-token residual/MLP activations that gradient
+checkpointing keeps, and those scale with `batch × frames`, not with either factor
+alone. Block-sparsity is not the memory lever (flex is only 2–5 % under sdpa at
+equal shape: 9825 vs 10017 MiB at 32 frames/batch 24, 22.8 vs 23.6 GiB at 64
+frames/batch 16) — **holding frame-slots constant is**.
+
+For the 80 GB arm, batch 64 × 32 frames scales to ~25.6 GiB (512-d) / ~44.8 GiB
+(768-d) of trunk activations. It **OOMs on a 32 GB 5090** — measured, in a fresh
+process — which is exactly why it is a separate yaml. Note also that the first
+compile of a new shape needs headroom *beyond* steady state (inductor benchmarks
+several kernel configs while the activations are live), so leave more margin than
+the steady-state figure suggests.
 
 The recipe built from this is
 `config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml` (32 frames, window

--- a/docs/decoder_only_kv_cache.md
+++ b/docs/decoder_only_kv_cache.md
@@ -829,11 +829,19 @@ the slope falls at all is the interesting part: the marginal term is cache traff
 and attention against `(N-1)·257` keys, so halving the data width buys close to
 halving the marginal cost, which is what a bandwidth-bound term should do.
 
-The **controlled** statement is the same-host, same-day, same-flags random-weight
-control: `decoder_random_n16` fp32 measured **59.65 ms** against the trained
-engine's **59.82 ms**, i.e. **0.3 %**. Weight values do not move a static-shape
-engine's latency, now measured rather than assumed. (§9's 59.58 ms is separate,
-weaker corroboration — a different build path, built four days earlier.)
+The **controlled** statement is the same-host, same-day, same-flags randomly
+initialized control, exported from the same script at the same context and built
+minutes apart:
+
+| window 16 | trained | random control | delta |
+| --- | --- | --- | --- |
+| fp32 | 59.82 ms | 59.65 ms | 0.3 % |
+| fp16 | 16.97 ms | 16.93 ms | 0.2 % |
+
+Weight values do not move a static-shape engine's latency — now measured rather
+than assumed, and measured at *both* precisions, which matters because fp16
+tactic selection could in principle have been value-sensitive. (§9's 59.58 ms is
+separate, weaker corroboration: a different build path, built four days earlier.)
 
 fp16 is **3.53× faster than fp32 at window 16** (59.82 → 16.97 ms) and the
 engine is half the size (203 → 107 MiB).

--- a/docs/decoder_only_kv_cache.md
+++ b/docs/decoder_only_kv_cache.md
@@ -172,7 +172,21 @@ new K/V and 5.7e-07 on the action chunk (ORT CPU fp32 vs PyTorch). Note
 `new_k`; that is per-element relative error on near-zero entries and is a false
 alarm — compare absolute error against the tensor scale.
 
-## 6. KV memory budget on Orin
+## 6. Memory budget on Orin — weights and KV cache
+
+### Weights (measured, fp32 engines)
+
+| arm | parameters | fp32 TRT engine | ONNX initializers |
+| --- | --- | --- | --- |
+| small (8L/512d) | 52.6 M | **207.2 MiB** | 213.0 MB |
+| `_big` (12L/768d) | ~115 M | **440.2 MiB** | 453.3 MB |
+
+The decoder-step engine is marginally *smaller* than the baseline's at the same
+arm (434.2 vs 440.2 MiB for `_big`) — the 1542-slot positional table is gone and
+the 257-slot one replaces it. Weights are context-independent, so a longer window
+costs cache, never weights.
+
+### KV cache
 
 `bytes = 2 (K,V) × L × (cache_frames × 257) × D × sizeof(dtype)`, with
 `cache_frames = context_frames − 1`.
@@ -188,10 +202,20 @@ Per cached frame: small (8L/512d) **8.03 MiB** fp32 / 4.02 MiB fp16; `_big`
 | 64 | 16191 | 506 MiB | 1138 MiB | 253 MiB | 569 MiB |
 | 128 | 32639 | 1020 MiB | 2295 MiB | 510 MiB | 1147 MiB |
 
+### Total resident
+
 delta-dev1 has **15 GiB** of LPDDR5 shared between CPU and GPU, ~12 GiB
-practically available. Memory is not the binding constraint at any context length
-worth training: `_big` at 64 frames is 9.3 % of available RAM in fp32, 4.6 % in
-fp16. Latency and the per-tick cache read bandwidth bind first.
+practically available (measured `free`). Weights + cache, fp32:
+
+| | 6 frames | 16 | 32 | 64 |
+| --- | --- | --- | --- | --- |
+| small | 247 MiB | 327 MiB | 456 MiB | 713 MiB |
+| `_big` | 530 MiB | 711 MiB | **1000 MiB** | 1578 MiB |
+
+**Memory is not the binding constraint at any context length worth training** —
+`_big` at 64 frames is 1.5 GiB, 13 % of what is available, and halves again with an
+fp16 cache. Latency binds first, and it binds well before memory does: `_big`
+leaves the 333 ms tick at 64 frames (§9) while still using only an eighth of RAM.
 
 ## 7. drivr serving sketch
 
@@ -216,13 +240,29 @@ rope_cos, rope_sin = frame_rope_cos_sin(frame_index, head_dim=head_dim, base=100
 out = engine.run(image=frame, speed=..., waypoints=...,
                  past_k=past_k, past_v=past_v, cache_bias=cache_bias,
                  rope_cos=rope_cos, rope_sin=rope_sin)
-# ring-buffer advance: shift one frame block left, write 257 tokens per layer
-past_k[..., :-tokens_per_frame, :] = past_k[..., tokens_per_frame:, :]
-past_k[..., -tokens_per_frame:, :] = out["new_k"]
-# ... same for V ...
-cache_bias[..., -tokens_per_frame:] = 0.0     # the tail is now filled
+
+# ring advance: write into ONE slot and move nothing else
+slot = slice((frame_index % cache_frames) * tokens_per_frame,
+             (frame_index % cache_frames + 1) * tokens_per_frame)
+past_k[..., slot, :] = out["new_k"]
+past_v[..., slot, :] = out["new_v"]
+cache_bias[..., slot] = 0.0     # after the first `cache_frames` ticks: all zeros
 frame_index += 1
 ```
+
+**Do not shift the cache.** The obvious form,
+`past_k[..., :-257, :] = past_k[..., 257:, :]`, is wrong twice: it is an
+*overlapping* in-place copy on one storage (undefined in torch, a genuine
+read/write race on GPU), and it moves the entire cache every tick — ~1129 MiB in
+and out, ~2.3 GiB of device traffic, order 20 ms at `_big`/64 frames, versus
+18 MiB for a slot write.
+
+The slot write is valid because **attention is permutation-invariant over keys**,
+and each key carries its own position (RoPE-rotated with its absolute frame index)
+and its own `cache_bias` entry — so the *order* of the cache carries no
+information. Verified, not assumed:
+`test_ring_slot_write_matches_shift_left` streams both policies and requires the
+readouts to agree to 1e-6.
 
 Three failure modes, all silent, all worth an explicit check:
 
@@ -264,6 +304,12 @@ verified by sampling `cur_freq` continuously *through* a 5 s idle gap (all 25
 samples at 918 MHz, so the `nvhost_podgov` 306 MHz artifact is not present).
 `trtexec --iterations=60 --avgRuns=20 --useSpinWait --warmUp=1000`, median GPU
 compute time.
+
+These are **engine GPU compute** and therefore exclude the host-side ring update,
+as `inference_ms` in drivr's logs also does. With the slot write of §7 that update
+is one 257-token copy per layer — ~18 MiB at `_big`/64 frames, sub-millisecond. With
+the naive shift-left it would be ~2.3 GiB and order 20 ms, which is the other reason
+not to write it that way.
 
 **Gate zero — the baseline reproduces.** Randomly-initialized fp32 exports of the
 *existing* block-causal architecture at 6 frames:
@@ -380,10 +426,13 @@ episode.
    established that aggregate L1 is blind to this failure class.
 3. **Train/infer mismatch if the window is not matched.** Serving with a ring of
    `N-1` is only equivalent to training if training used
-   `frame_block_causal_mask(window=N)`. `CausalFrameTransformer` cross-checks
-   `max_sequence_length == window * tokens_per_frame` so a config mismatch raises,
-   but nothing prevents serving a checkpoint against the wrong cache size —
-   validate the engine's `inputs_past_k` shape against the checkpoint's `window`.
+   `frame_block_causal_mask(window=N)`. `CausalFrameTransformer` rejects
+   `max_sequence_length < window * tokens_per_frame` (a clip shorter than the
+   window trains a narrower context than will be served), but **nothing prevents
+   serving a checkpoint against the wrong cache size** — the trunk has no intrinsic
+   maximum length any more, so a 32-frame-trained model will happily run against a
+   64-frame cache and silently extrapolate. Validate the engine's `inputs_past_k`
+   shape against the checkpoint's `window` at load time.
 4. **No parity/precision verification yet.** All measurements are fp32 with random
    weights, so `parity_matrix.py --trials 200` has not been and cannot be run — it
    needs a trained checkpoint. The 5 in-graph `ArgMax` nodes and the code-flip

--- a/docs/decoder_only_kv_cache.md
+++ b/docs/decoder_only_kv_cache.md
@@ -441,11 +441,13 @@ episode.
    maximum length any more, so a 32-frame-trained model will happily run against a
    64-frame cache and silently extrapolate. Validate the engine's `inputs_past_k`
    shape against the checkpoint's `window` at load time.
-4. **No parity/precision verification yet.** All measurements are fp32 with random
-   weights, so `parity_matrix.py --trials 200` has not been and cannot be run — it
-   needs a trained checkpoint. The 5 in-graph `ArgMax` nodes and the code-flip
-   defect are unchanged by this work (hand-off §6), and the margin screen must be
-   re-run on any real checkpoint before serving anything below fp32.
+4. ~~**No parity/precision verification yet.**~~ **Resolved for the first trained
+   checkpoint — see §12.** The margin screen and a 200-trial decision-parity ladder
+   have now been run on `do8m9ot8:v0`. What remains of this risk is narrower and
+   unavoidable: margins are **per-checkpoint**, so §12 must be re-run for every
+   checkpoint before it is served below fp32. A verdict cannot be inherited from a
+   sibling — 2 of 7 checkpoints in the baseline family genuinely flip ~4 % while
+   their own parents pass.
 5. **RoPE base is unvalidated.** `rope_base=1000` is reasoned (base 10000 leaves
    most frequency pairs inert over 64 positions) but not measured. It is a
    trainable-arm hyperparameter, and changing it after training invalidates the
@@ -732,3 +734,128 @@ expressible in FlexAttention (`Q_LEN = F`, `KV_LEN = F·257`, `mask_mod` mapping
 query index straight to a frame index), and §4 already proves the equivalence for
 the decode path. Not wired up, because it changes `PatchPolicy`'s readout indexing
 and the win is small next to the 2.5–4× already realized.
+## 12. Trained-checkpoint verification (resolves §10.4)
+
+Everything above §11 was measured with **randomly initialized** weights, which is
+sufficient for latency and memory but cannot speak to precision: an `ArgMax`
+margin is a property of what the head learned. This section is the first
+measurement of this architecture with a real checkpoint.
+
+**Checkpoint.** `yaak/rmind/model-do8m9ot8:v0` — run `do8m9ot8` ("vague-shape-587"),
+**epoch 0, step 80797**, `dinov2_dinowm_causal`: 8L/512d/8H, `window: 16`,
+`rope_base: 1000`, `fusion_norm: true`, `attention_impl: flex`, 52.78 M
+parameters. It is past warmup and **far from converged**. That is fine for
+everything here — latency depends on shapes, and parity depends on weight
+*statistics* — but **no quality conclusion may be drawn from it**.
+
+`attention_impl: flex` does not reach the export: `CausalFrameTransformer.step`
+is always SDPA (§11.6.7), so the trained trunk exports through the same path a
+`sdpa` checkpoint would.
+
+Tooling: `rmind.scripts.decoder_only_export --artifact ...` (the architecture then
+comes from the checkpoint's hparams and the trunk is used as trained) and
+`rmind.scripts.decoder_only_verify {gates,onnx-vs-eager,margins}`.
+
+### 12.1 The equivalence gate still holds with trained weights
+
+Same gate as §5, on the trained trunk at its trained `window=16`, T=17 frames
+(one frame past a full window, so the sliding case is exercised):
+
+| | max abs | scale-relative |
+| --- | --- | --- |
+| float64 | 2.66e-15 | **6.41e-16** |
+| float32 | 1.19e-06 | **2.87e-07** |
+| negative control (RoPE counter not advanced) | 2.29e-01 | **5.50e-02** |
+
+float64 sits at machine epsilon, so the equivalence is **exact** and the float32
+residual is purely accumulation order — the same conclusion as §5, and the
+float32 figure (2.87e-07) lands on §5's random-weight 3.2e-07. The negative
+control is five orders of magnitude worse, so the gate is falsifiable rather
+than vacuous. Note the control chosen here is the *operational* one — a runtime
+that resets the cache but forgets `frame_index` (§7 failure mode 3) — rather
+than §5's architectural window-absolute trunk.
+
+### 12.2 ONNX agrees with eager
+
+ORT CPU fp32 vs PyTorch, warm cache, 3 input sets. Scored as **absolute error
+against each tensor's own scale**, never per-element relative:
+
+| output | max abs | scale-relative |
+| --- | --- | --- |
+| `policy.joint_actions` | 8.9e-09 | 2.6e-06 |
+| `new_k` | 1.55e-05 | 2.2e-06 |
+| `new_v` | 1.13e-05 | 3.1e-06 |
+
+Worst 3.11e-06 scale-relative, reproducing §5's random-weight 1.4e-05 absolute on
+the new K/V. `torch.onnx.export(verify=True)` again reports a "large relative
+difference" of ~2.7 on `new_k`; it is again the documented false alarm — per-element
+relative error on near-zero entries.
+
+### 12.3 Latency: the random-weight architecture numbers were right
+
+Rebuilt and re-benchmarked on delta-dev1, TRT 10.7.0.23, **GPU clock pinned at
+918 MHz** (`governor=performance`, verified: every clock sample taken *through*
+each benchmark was 918 MHz), load ~0.1, no other users. `trtexec
+--iterations=60 --avgRuns=20 --useSpinWait --warmUp=1000`, median GPU compute.
+
+**fp32 here means TF32 CLEARED** (`--noTF32`). trtexec's default "fp32" is the
+TF32 tensor-core path — a different numeric configuration, and the one that has
+never been decision-exact.
+
+| context | fp32 trained | fp32 predicted (§9, random) | fp16 trained | fp16 predicted | fp16 speedup |
+| --- | --- | --- | --- | --- | --- |
+| 6 | **41.79 ms** | 41.79 | **10.55 ms** | 10.5 | 3.96× |
+| 16 (**served**) | **59.82 ms** | 59.58 | **16.97 ms** | — | **3.53×** |
+| 32 | **92.20 ms** | 92.26 | **27.19 ms** | 27.2 | 3.39× |
+
+**Every random-weight prediction was confirmed, none corrected** — the largest
+disagreement anywhere in the table is 0.4 % (59.82 vs 59.58 at window 16) and the
+6- and 32-frame cells agree to 0.1 % or better. So §9's central claim, that random
+weights are sufficient to measure this *architecture*, is now itself measured
+rather than argued.
+
+The linear-in-context correction of §9 also survives. Least-squares over the three
+contexts:
+
+| | marginal cost per extra frame | fixed cost (N→1) |
+| --- | --- | --- |
+| fp32 trained | **1.95 ms/frame** | 31.5 ms |
+| fp32 §9 (random, 6→64) | 2.05 ms/frame | ~31.5 ms |
+| fp16 trained | **0.64 ms/frame** | 7.4 ms |
+
+Per-tick cost still does **not** stop scaling with context — §2's claim remains
+wrong — but fp16 cuts the *slope* by 3.0× as well as the fixed term by 4.3×. That
+the slope falls at all is the interesting part: the marginal term is cache traffic
+and attention against `(N-1)·257` keys, so halving the data width buys close to
+halving the marginal cost, which is what a bandwidth-bound term should do.
+
+The **controlled** statement is the same-host, same-day, same-flags random-weight
+control: `decoder_random_n16` fp32 measured **59.65 ms** against the trained
+engine's **59.82 ms**, i.e. **0.3 %**. Weight values do not move a static-shape
+engine's latency, now measured rather than assumed. (§9's 59.58 ms is separate,
+weaker corroboration — a different build path, built four days earlier.)
+
+fp16 is **3.53× faster than fp32 at window 16** (59.82 → 16.97 ms) and the
+engine is half the size (203 → 107 MiB).
+
+### 12.4 The fused MHA kernel is present — the fp16 win is real
+
+`_gemm_mha_v2` was the thing to check, because without it the entire fp16
+speedup evaporates, and because the in-graph `Concat` of `past_k` with the new
+frame's keys is **load-bearing** for the fusion (§9, §10.6) — it must not be
+"optimized away".
+
+Built with `--profilingVerbosity=detailed` so tactic names survive into the
+engine (profiling a default-verbosity engine returns stripped names, and
+absence-of-name would read as absence-of-kernel — a false alarm on exactly this
+check). Grepped in four places:
+
+| source | `_gemm_mha_v2` hits |
+| --- | --- |
+| fp16 build log | 38 |
+| fp16 `--exportLayerInfo` | 38 |
+| fp16 `--exportProfile` | 19 |
+| fp16 profile log | 57 |
+| **fp32 build log / layer info / profile** | **0** (expected: it is an fp16 tensor-core kernel) |
+
+**Verdict: present.** No alarm.

--- a/docs/decoder_only_kv_cache.md
+++ b/docs/decoder_only_kv_cache.md
@@ -996,3 +996,82 @@ Total resident at the served window 16, measured: 203 MiB of fp32 weights +
 120 MiB cache = **323 MiB** (§6 predicted 327 MiB), or 107 MiB + 60 MiB =
 **167 MiB** on the fp16 + fp16-cache engine. Memory remains nowhere near binding
 on a 15 GiB Orin.
+
+### 12.8 The serving decision
+
+All four engines at the served window 16, on the same host at 918 MHz, scored
+against one shared ORT fp32 reference over the same 200 trials:
+
+| engine | latency | vs fp32 | engine | KV cache | decisions | worst \|d\| | mean \|d\| | `_gemm_mha_v2` |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| **fp32** (TF32 cleared) | 59.82 ms | 1.00× | 203 MiB | 120 MiB | **0/200** | 4.2e-07 | 1.8e-08 | n/a |
+| `encfp32-fp16trunk` | 21.79 ms | 2.75× | 155 MiB | 120 MiB | 2/200 | 0.0427 | 1.2e-04 | 7 |
+| fp16 | 16.97 ms | 3.53× | 107 MiB | 120 MiB | 5/200 | 0.1827 | 5.0e-04 | 38 |
+| **fp16 + fp16 cache I/O** | **13.63 ms** | **4.39×** | 105 MiB | **60 MiB** | 2/200 | 0.0426 | 1.6e-04 | 38 |
+
+**Serve fp32.** Not because low precision looks bad, but because at this window
+there is no latency pressure to trade anything for: 59.82 ms is **3.36× cheaper
+than the 200.85 ms 6-frame baseline that is served today** (§9's gate zero), while
+attending 16 frames instead of 6. The tick carrying an inference costs
+`333 + 59.8 = 393 ms` against today's `333 + 200.9 = 534 ms`. fp32 is the only
+0/200 configuration and it is *also* the faster-than-today one, so accepting even
+1 % of flipped control decisions buys nothing.
+
+**If a faster engine is ever needed** — the `_big` arm, window 32/64, or a tighter
+tick — the answer for *this* architecture is **fp16 with fp16 cache I/O**, and that
+is a **departure from the skill's standing recommendation**. `encfp32-fp16trunk` is
+the skill's designated "fast one", but here it is dominated on every axis at once:
+
+| | latency | KV cache | decisions | worst \|d\| |
+| --- | --- | --- | --- | --- |
+| `encfp32-fp16trunk` | 21.79 ms | 120 MiB | 2/200 | 0.0427 |
+| fp16 + fp16 cache | **13.63 ms** | **60 MiB** | 2/200 | 0.0426 |
+
+1.6× faster, half the cache, indistinguishable parity. The reason is structural
+and specific to the decoder step: **the step encodes only ONE frame**, so the image
+encoder is 69 % of the graph's layers (1950 of 2818) instead of the ~18 % of
+runtime it is in the recompute-everything baseline. Pinning it is no longer cheap.
+Meanwhile the fp16 cache lever does not exist in the baseline at all, because the
+baseline has no cache.
+
+Two honesty notes on those parity counts:
+
+* **2/200 vs 5/200 is not a distinguishable difference.** The 95 % intervals
+  overlap (≈0.1–3.6 % against ≈0.8–5.7 %), and the skill's own warning about
+  2/50 vs 4/50 applies with less force but still applies. What *is* a clean signal
+  is the magnitude, which is not a counting statistic: worst \|d\| falls 4.3×
+  (0.183 → 0.043) and mean \|d\| 3–4× when either the encoder is pinned or the
+  cache is handed over in fp16. Both flagged trials in both better engines are
+  control-channel-only.
+* ⚠️ **The fp16-cache parity number is optimistic and must not be shipped on.** The
+  harness streams each history through ORT in **fp32** and casts to fp16 once per
+  trial. A real fp16 ring accumulates the cache *in fp16 across every tick*, so
+  rounding compounds over an episode in a way this measures nothing about. Before
+  serving that engine, re-run the ladder with a genuinely fp16 ring — the harness
+  needs one change, to keep `past_k`/`past_v` in fp16 between ticks.
+
+`encfp32-fp16trunk` carries **7** `_gemm_mha_v2` instances rather than 8. That is
+consistent with §4: `readout_only_final_block=True` makes the last block's
+attention a 1-query op, a different shape that does not take the fused kernel.
+Note also that `build_mixed.py`'s log showed **0** hits, because it uses a
+non-verbose TRT logger — the engine had to be interrogated with
+`--dumpLayerInfo` instead. Reading that 0 as "the fusion is gone" would have been
+a false alarm, which is why the check greps the engine and not only the build log.
+
+### 12.9 What is NOT established
+
+* **Nothing about driving quality.** epoch 0, step 80797. Latency and parity are
+  properties of shapes and weight statistics; behaviour is not, and PR #248
+  established that aggregate val L1 is blind to this failure class anyway.
+* **Windows 6 and 32 are latency artifacts only.** They were built from a
+  window-16 checkpoint, which `step` will run against any cache size while
+  silently extrapolating (§10.3). The engines on delta-dev1 are renamed
+  `LATENCY-ONLY-WRONG-WINDOW.*` with a `PARITY-NOTES.md` beside them.
+* **The harness shares 10 caches across 200 trials** (20 current-frame variants
+  each) rather than using 200 independent histories, because a cache is 126 MiB.
+  The cache is the slowest-moving real input, but this is a genuine narrowing of
+  the input distribution.
+* **Speed and waypoints are synthetic**, which makes this harness ~7× harsher than
+  the road on the baseline arm. Do not quote 2/200 as a deployment rate.
+* **Margins are per-checkpoint.** Re-run §12.5 and §12.6 for every checkpoint
+  before serving it below fp32. A verdict cannot be inherited from a sibling.

--- a/docs/decoder_only_kv_cache.md
+++ b/docs/decoder_only_kv_cache.md
@@ -411,16 +411,14 @@ episode.
 
 ## 10. Open risks
 
-1. **Training cost is untouched, and it is now the bottleneck.** The cache makes
-   *inference* per-tick cost linear in context. Training still does one dense
-   forward over the whole clip, and the attention terms are quadratic in the
-   flattened length: 6 frames = 1542 tokens, 32 frames = 8224 (5.3× the tokens,
-   **28×** the attention work), 64 frames = 16448 (10.7× / **114×**). The `window`
-   mask makes attention block-sparse but plain SDPA still materializes the dense
-   score matrix, so the saving is not realized without a block-sparse kernel
-   (FlexAttention / `create_block_mask`). At `clip_length == window` the mask is
-   dense anyway. **This is the single largest practical risk to the bonus track**;
-   16 frames is the defensible first step, not 64.
+1. ~~**Training cost is untouched, and it is now the bottleneck.**~~ **Resolved —
+   see §11.** `attention_impl: flex` realizes the block-sparsity the `window` mask
+   always had, and with `episode_length > window` training cost becomes linear in
+   context length instead of quadratic. At a constant 768 frame-slots per step,
+   32-frame clips with a 16-frame window cost **1.08×** today's 6-frame trunk step
+   (dense SDPA: 2.74×), and 64 frames costs 1.15×. What remains of this risk is
+   narrower and listed in §11.6: `attn_dropout` must go to 0, the block-sparse
+   path is CUDA-only, and it loses to SDPA below roughly 1000 frame-slots per step.
 2. **Behaviour change, not just speed** (hand-off §6). Conditioning on 16–64
    frames is a different model. Needs rsim and road, not val L1 — PR #248
    established that aggregate L1 is blind to this failure class.
@@ -450,3 +448,261 @@ episode.
 7. **`_big` at 64 frames does not fit a tick at fp32** (364 ms). Not a defect, but
    it bounds the context length that is servable today without the mixed-precision
    engine.
+
+## 11. Block-sparse training — FlexAttention vs FlashAttention-2 vs dense
+
+**Recommendation: FlexAttention (`attention_impl: flex`), and it is the only exact
+option.** Everything below was measured on 2026-08-05 on an idle RTX 5090
+(sm_120, torch 2.12.1+cu130) with `tests/bench_causal_frame.py`; correctness is
+`tests/test_causal_frame.py`.
+
+### 11.1 The problem
+
+`CausalSelfAttention.forward` handed a materialized bool mask to
+`F.scaled_dot_product_attention`. Any `attn_mask` disqualifies the flash backend,
+so every masked position is computed anyway: cost `O((F·257)²)` no matter how
+narrow `window` is. The mask, however, is blocky in 257-token frame units — dense
+bidirectional blocks on the diagonal, a causal band below — which is exactly what a
+block-sparse kernel wants.
+
+### 11.2 Correctness (the gate)
+
+fp32, tf32 disabled, production geometry (257 tokens/frame, `window` 6 and 16,
+512-d/8-head and 768-d/12-head), forward **and** backward:
+
+| tensor | max abs diff | max abs value | scale-relative |
+| --- | --- | --- | --- |
+| output | 1.4e-6 | 5.2 | 2.7e-7 |
+| d/d input | 1.2e-6 | 5.0 | 2.4e-7 |
+| d/d `in_proj_weight` | 1.8e-5 | 12.8 | 1.4e-6 |
+| d/d `out_proj.weight` | 3.6e-5 | 43.3 | 8.4e-7 |
+| d/d `intra_position_embedding` | 3.3e-6 | 20.3 | 1.6e-7 |
+
+The gate is applied **scale-relative** (`max|diff| / max|ref|`), not as an absolute
+1e-5, and that is a deliberate choice worth stating plainly: a parameter gradient
+is a sum over all 1542–4112 sequence positions, so its entries are O(10) and its
+fp32 accumulation noise alone exceeds 1e-5 in absolute terms whichever kernel
+produced it. That the residual **is** that noise is shown independently, by
+comparing both fp32 arms against the same trunk run in float64 on the CPU:
+
+| | sdpa vs exact fp64 | flex vs exact fp64 |
+| --- | --- | --- |
+| worst tensor (scale-rel) | 6.8e-7 | 9.4e-7 |
+
+flex sits 1.4× sdpa's own distance from the exact answer, not 10×. Parity is also
+verified in `.train()`, i.e. with the compiled kernel inside
+`checkpoint(use_reentrant=False)` and its recompute, and the frame-offset
+shift-invariance of §1 still holds on the flex path — RoPE is applied to q/k before
+attention, so the positional scheme and the kernel are orthogonal.
+
+### 11.3 The 257-token tile-alignment finding
+
+`create_block_mask` tiles at 128, and **128 is the only usable block size**:
+`BLOCK_SIZE=64` fails to lower on sm_120/torch 2.12 (`ValueError: Q and KV block
+size must be divisible by BLOCK_M and BLOCK_N`). 257 = 2·128 + 1, so a frame block
+can never tile exactly and every frame boundary yields partial blocks, which the
+kernel computes in full and then masks elementwise. Measured computed area against
+the exact mask area:
+
+| frames | window | BLOCK 128 | BLOCK 64 | BLOCK 32 | frame padded to 384, BLOCK 128 |
+| --- | --- | --- | --- | --- | --- |
+| 6 | 6 | **1.288×** | 1.137× | 1.064× | 2.233× |
+| 16 | 6 | **1.191×** | 1.091× | 1.041× | 2.233× |
+| 16 | 16 | **1.111×** | 1.051× | 1.022× | 2.233× |
+| 32 | 16 | **1.074×** | 1.033× | 1.013× | 2.233× |
+| 64 | 16 | **1.063×** | 1.027× | 1.014× | 2.233× |
+| 64 | 64 | **1.023×** | 1.008× | 1.004× | 2.233× |
+
+Two conclusions. The waste is a **boundary effect that amortizes**: 29 % at 6
+frames, 6 % at 64, because the number of straddling blocks grows with `F` while the
+computed area grows with `F·window`. And **padding each frame to 384 to align it is
+strictly worse** — exactly `(384/257)² = 2.233×` at every geometry, since it pays
+1.49× more queries against 1.49× more keys to remove a ≤29 % overhead. Reordering
+tokens so frames tile 128 would need the 256 patches kept together and the speed
+token moved elsewhere; not worth it against a 6–11 % overhead in the regime that
+matters. The BLOCK 64/32 columns are what the hardware would allow if the kernel
+did — they are not available, and they would trade tile efficiency for the
+alignment anyway.
+
+### 11.4 Kernel benchmark — one attention layer, fwd+bwd (RoPE included), bf16
+
+`tests/bench_causal_frame.py attention --batches 4,16`:
+
+#### 512-d / 8 heads
+
+| frames | window | seq | b4 sdpa | b4 flex | b16 sdpa | b16 flex | b16 peak sdpa / flex |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 6 | 6 | 1542 | 1.26 ms | **1.40** | 4.24 | **2.11** | 396 / 350 MiB |
+| 16 | 6 | 4112 | 6.68 | **1.75** | 25.05 | **6.97** | 1083 / 933 |
+| 16 | 16 | 4112 | 6.68 | **2.47** | 25.06 | **9.51** | 1083 / 933 |
+| 32 | 8 | 8224 | 24.32 | **4.05** | 94.71 | **16.97** | 2263 / 1866 |
+| 32 | 16 | 8224 | 24.35 | **5.96** | 94.95 | **24.44** | 2263 / 1866 |
+| 32 | 32 | 8224 | 24.37 | **7.68** | 95.16 | **30.70** | 2263 / 1866 |
+| 64 | 16 | 16448 | 95.32 | **13.53** | 377.40 | **54.65** | 4914 / 3745 |
+| 64 | 64 | 16448 | 95.70 | **27.37** | 379.92 | **108.25** | 4914 / 3745 |
+
+#### 768-d / 12 heads
+
+| frames | window | seq | b4 sdpa | b4 flex | b16 sdpa | b16 flex | b16 peak sdpa / flex |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 6 | 6 | 1542 | 1.85 ms | **1.26** | 6.34 | **3.15** | 594 / 525 MiB |
+| 16 | 6 | 4112 | 9.66 | **2.53** | 37.29 | **10.59** | 1602 / 1399 |
+| 16 | 16 | 4112 | 9.66 | **3.55** | 37.26 | **14.33** | 1602 / 1399 |
+| 32 | 8 | 8224 | 36.00 | **6.18** | 142.08 | **25.50** | 3295 / 2798 |
+| 32 | 16 | 8224 | 36.08 | **9.04** | 142.43 | **36.67** | 3295 / 2798 |
+| 32 | 32 | 8224 | 36.11 | **11.50** | 142.69 | **45.85** | 3295 / 2798 |
+| 64 | 16 | 16448 | 142.25 | **20.38** | 568.75 | **82.35** | 6979 / 5602 |
+| 64 | 64 | 16448 | 143.18 | **40.81** | 572.26 | **163.13** | 6979 / 5602 |
+
+Three things to read off. **Dense SDPA is flat in `window`** — 24.32 / 24.35 / 24.37
+ms across windows 8/16/32 at 32 frames — which is the defect, stated as a
+measurement: the mask is doing nothing for cost. **flex is proportional to
+`F·window`**: 6.97 → 9.51 ms as the window goes 6 → 16 at 16 frames, and 54.65 ms
+at 64 frames/window 16 against 377.40 dense, a **6.9×** kernel speedup. And **flex
+uses less memory**, 24 % less at 64 frames, because there is no dense mask tensor
+and fewer score tiles in flight.
+
+The one row where flex loses is batch 4 at 6 frames (1.40 vs 1.26 ms): 13 kv blocks
+and 4 sequences cannot fill a 5090. It wins by 2× at the same geometry with batch
+16. See §11.6.5.
+
+For scale: the frozen DINOv2 ViT-S forward over the 768 images a step consumes
+costs **79.9 ms / 2031 MiB** on the same GPU (`bench_causal_frame.py vit
+--batches 768`). It is linear in frame-slots, identical for every row of §11.5, and
+about a tenth of the trunk step — so the trunk really is the term worth attacking.
+
+### 11.5 What the training step actually costs
+
+Attention is only part of a step; the MLP is linear in tokens and dilutes the
+saving, and the frozen ViT is linear in `batch × frames` and is untouched. The row
+that answers "is long-context training affordable" is the **full trunk**, in
+`.train()` (gradient checkpointing on), normalized to a constant **768 frame-slots
+per step** — today's `batch 128 × 6 frames`, which is what fixes the ViT cost, the
+readouts per step and the activation memory:
+
+| frames | window | 512-d/8L sdpa | 512-d/8L flex | vs today | 768-d/12L sdpa | 768-d/12L flex | vs today |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 6 | 6 | 652 ms | 497 ms | 0.76× | 1695 ms | 1323 ms | 0.78× |
+| 16 | 6 | 1085 | 550 | 0.84× | 2649 | 1447 | 0.85× |
+| 16 | 16 | 1085 | 626 | 0.96× | 2652 | 1616 | 0.95× |
+| 32 | 8 | 1787 | 593 | 0.91× | 4223 | 1538 | 0.91× |
+| 32 | 16 | 1787 | **705** | **1.08×** | 4237 | **1792** | **1.06×** |
+| 32 | 32 | 1791 | 800 | 1.23× | 4245 | 2001 | 1.18× |
+| 64 | 16 | 3215 | **749** | **1.15×** | 7469 | **1897** | **1.12×** |
+| 64 | 64 | 3233 | 1151 | 1.77× | 7501 | 2809 | 1.66× |
+
+("vs today" is against the 6-frame **dense** step of the same width, 652 / 1695 ms,
+which is what runs now. Raw per-batch measurements are in the commit message and
+reproducible with `tests/bench_causal_frame.py trunk`.)
+
+**32-frame training lands inside today's 6-frame budget**: 1.08× at 512-d, 1.06× at
+768-d, against 2.74× / 2.50× if the mask stays dense. 64 frames is 1.15× / 1.12×.
+The cost of context has gone from quadratic to essentially free, and what is left
+is set by `window`, not by clip length: `32/8` (0.91×) is *cheaper* than today.
+
+Trunk peak activation memory at 768 frame-slots is likewise ~flat and slightly
+better than today's:
+
+| frames | window | batch | 512-d/8L | 768-d/12L |
+| --- | --- | --- | --- | --- |
+| 6 | 6 | 128 | 11.0 GiB (sdpa, today) | 20.0 GiB |
+| 16 | 16 | 48 | 9.9 GiB | 17.6 GiB |
+| 32 | 16 | 24 | **9.7 GiB** | **17.4 GiB** |
+| 64 | 16 | 12 | 9.5 GiB | 17.1 GiB |
+
+(Extrapolated linearly in batch from the measured batch-16 rows, which is how
+activation memory scales; flex is 3–5 % below sdpa at every measured point.) The
+768-d/64-frame/batch-16 **dense** case measures 23.6 GiB of trunk activations
+alone — that is what "does not fit a 32 GB card" looks like, and flex brings the
+same geometry to 22.8 GiB, i.e. block-sparsity is not the lever for memory. Holding
+frame-slots constant is.
+
+The recipe built from this is
+`config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml` (32 frames, window
+16, batch 24, 5090-32 GB) and `..._80gb.yaml` (batch 64); both carry their own
+step-count arithmetic, because the cosine LR schedule oscillates past
+`num_training_steps`.
+
+### 11.6 Operational hazards (all of these bit or nearly bit)
+
+1. **No `dropout_p` in FlexAttention.** `attn_dropout` must be 0 on the flex path;
+   the constructor raises rather than silently dropping it. This is a
+   regularization change riding along with a kernel change — an A/B against
+   today's arm must zero `attn_dropout` on the sdpa side too.
+2. **An in-place op in a `mask_mod` kills the path entirely.** Inductor lowers a
+   `mask_mod` as a pointwise subgraph, in which no buffer may be created, so
+   `keep &= x` fails with `SubgraphLoweringException: Buffers cannot be created
+   while lowering a pointwise subgraph` — at *every* shape. `ruff check` in this
+   repo runs with `fix = true, unsafe-fixes = true` and rewrites
+   `keep = keep & x` into `keep &= x` under PLR6104, which is exactly that. It
+   happened during this work and cost a benchmark run.
+   `test_mask_mod_is_free_of_in_place_ops` guards it on CPU.
+3. **dynamo's 8-entry compile cache.** One compiled `flex_attention` serves every
+   shape and `dynamic=False` specializes per shape; past 8 specializations dynamo
+   silently falls back to **eager** flex, which materializes the score matrix. Fine
+   in training (2–3 shapes), fatal in a sweep — raise
+   `torch._dynamo.config.cache_size_limit` there.
+4. **Build the `BlockMask` once.** `create_block_mask` costs 1.6–9 ms; per layer per
+   step that is ~25 ms of pure launch overhead at 8 layers, more than the attention
+   it feeds. `frame_block_causal_block_mask` is memoized on
+   `(num_frames, tokens_per_frame, window, device)`.
+5. **flex is not free at small shapes.** At batch 4 / 6 frames the whole trunk is
+   *slower* under flex (58.7 vs 52.6 ms at 512-d; 84.2 vs 71.6 at 768-d): 13 kv
+   blocks and a batch of 4 do not fill the GPU. The crossover is around 1000
+   frame-slots per step; below that, keep `sdpa`. This is why the default stays
+   `sdpa` and the flex path is opt-in per experiment.
+6. **CUDA only.** There is no CPU backward for FlexAttention, so the CPU path is
+   the eager reference implementation (correct, not fast) and the fwd+bwd parity
+   tests are CUDA-gated. A CPU-only CI run skips them; it still runs the mask-mod,
+   block-accounting and CPU-forward-parity tests.
+7. **Serving is untouched, on purpose.** `step` stays SDPA: it is the ONNX/TRT
+   export target (a `torch.compile`d Triton kernel is not exportable) and it has
+   257 queries against a fully-visible cache, i.e. no sparsity to exploit.
+   `attention_impl` therefore cannot change what an exported engine computes.
+
+### 11.7 Why not FlashAttention-2
+
+`flash_attn` is not installed in the repo venv and installing it was out of scope,
+so this is an analytic rejection — but it does not depend on a measurement, because
+the mismatch is in what FA2 can *express*.
+
+FA2's windowed attention is **token-granular and strictly causal**
+(`window_size=(left, right)` over token indices). Our mask is frame-granular with
+**bidirectional** intra-frame blocks. The closest approximation is a token window of
+`window · 257`, and it is wrong in two independent ways. Counting mask entries:
+
+| frames | window | exact keeps | missing | of which intra-frame future | spurious |
+| --- | --- | --- | --- | --- | --- |
+| 16 | 6 | 5,349,969 | 526,336 (9.8 %) | **100 %** | 328,960 (6.1 %) |
+| 32 | 16 | 25,891,208 | 1,052,672 (4.1 %) | **100 %** | 526,336 (2.0 %) |
+| 64 | 16 | 59,708,296 | 2,105,344 (3.5 %) | **100 %** | 1,579,008 (2.6 %) |
+
+* Every missing pair is an **intra-frame future** pair: the current frame's 257
+  tokens stop being mutually visible, so a patch at intra-frame position 3 cannot
+  see position 200 of its own frame. That destroys the one property the whole
+  positional scheme is built around (§1: frame-granular RoPE exists so that
+  intra-frame attention is *exactly unrotated* and stays bidirectional), and it
+  makes the trunk a raster-order scanner over patches rather than a per-frame
+  encoder.
+* The spurious pairs are a **ragged window edge**: a query late in its frame still
+  reaches keys of frame `f - window`, which the ring buffer has already evicted.
+  That breaks the streaming/recompute equivalence of §5 — the training mask would
+  no longer be any ring capacity's mask, so there is no `N` to serve with.
+
+`is_causal` at "frame level" via reshaping does not exist either: attention would
+have to be causal in one index and dense in another within a single softmax, and no
+reshape of `(B, H, S, D)` produces that. Options: (b) is not expressible; (a) is
+expressible but changes the model into a different one and forfeits the correctness
+gate; therefore (c) reject. Note the comparison is not even a performance question —
+torch's own flash backend with plain `is_causal` is the lower bound FA2 could reach,
+and flex at 64 frames/window 16 already computes only 23.5 % of the dense area.
+
+### 11.8 Not done
+
+**Readout-only final block during training.** Only each frame's last token is read
+by the heads, so the final layer could run `F` queries instead of `F·257` — worth
+about `1/L` of attention plus `1/L` of MLP, ~10 % of the trunk at `L = 8`. It is
+expressible in FlexAttention (`Q_LEN = F`, `KV_LEN = F·257`, `mask_mod` mapping the
+query index straight to a frame index), and §4 already proves the equivalence for
+the decode path. Not wired up, because it changes `PatchPolicy`'s readout indexing
+and the win is small next to the 2.5–4× already realized.

--- a/docs/decoder_only_kv_cache.md
+++ b/docs/decoder_only_kv_cache.md
@@ -824,10 +824,16 @@ contexts:
 | fp16 trained | **0.64 ms/frame** | 7.4 ms |
 
 Per-tick cost still does **not** stop scaling with context — §2's claim remains
-wrong — but fp16 cuts the *slope* by 3.0× as well as the fixed term by 4.3×. That
-the slope falls at all is the interesting part: the marginal term is cache traffic
-and attention against `(N-1)·257` keys, so halving the data width buys close to
-halving the marginal cost, which is what a bandwidth-bound term should do.
+wrong — but fp16 cuts the *slope* by 3.0× as well as the fixed term by 4.3×.
+
+⚠️ **Do not explain that slope drop as halved cache bandwidth.** All three fp16
+engines in this fit are plain `--fp16` builds, and §12.7 shows those keep their KV
+cache in **float32** — there is no halved data width anywhere in their cache path.
+The marginal term is cache traffic *and* attention against `(N-1)·257` keys, and
+only the latter moved to tensor cores, so the mechanism is not established by these
+three points. Separating the two would need fp16-cache engines at 6 and 32 frames,
+which were not built; at window 16 the fp16 cache is worth a further 3.4 ms (§12.7),
+which is a fixed-cost saving at that one context, not a slope measurement.
 
 The **controlled** statement is the same-host, same-day, same-flags randomly
 initialized control, exported from the same script at the same context and built
@@ -858,7 +864,7 @@ engine (profiling a default-verbosity engine returns stripped names, and
 absence-of-name would read as absence-of-kernel — a false alarm on exactly this
 check). Grepped in four places:
 
-| source | `_gemm_mha_v2` hits |
+| source | `_gemm_mha_v2` name occurrences |
 | --- | --- |
 | fp16 build log | 38 |
 | fp16 `--exportLayerInfo` | 38 |
@@ -867,6 +873,19 @@ check). Grepped in four places:
 | **fp32 build log / layer info / profile** | **0** (expected: it is an fp16 tensor-core kernel) |
 
 **Verdict: present.** No alarm.
+
+⚠️ Those are **name occurrences, not kernel counts**, and they are not comparable
+between engines or between files: detailed verbosity emits hash-suffixed tactic
+names that recur several times per kernel in one dump, and an engine built at
+default verbosity has them partly stripped. The attributed figure — the one to
+quote — comes from the profile JSON, where each instance carries its own time:
+**19 instances, 5.34 ms, 29.4 % of the step** at window 16 fp16, i.e. the fused
+attention is the single largest bucket in the graph.
+
+The same profile shows standalone `cat`/`concat` kernels at **0.00 ms**. The
+`Concat` has not vanished — TRT absorbed it *into* `_gemm_mha_v2`, which is exactly
+why §9 and §10.6 call it load-bearing. Removing it to "save a copy" would take the
+fusion with it.
 
 ### 12.5 Margin screen — and which `ArgMax` is actually yours
 
@@ -1005,9 +1024,9 @@ against one shared ORT fp32 reference over the same 200 trials:
 | engine | latency | vs fp32 | engine | KV cache | decisions | worst \|d\| | mean \|d\| | `_gemm_mha_v2` |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- |
 | **fp32** (TF32 cleared) | 59.82 ms | 1.00× | 203 MiB | 120 MiB | **0/200** | 4.2e-07 | 1.8e-08 | n/a |
-| `encfp32-fp16trunk` | 21.79 ms | 2.75× | 155 MiB | 120 MiB | 2/200 | 0.0427 | 1.2e-04 | 7 |
-| fp16 | 16.97 ms | 3.53× | 107 MiB | 120 MiB | 5/200 | 0.1827 | 5.0e-04 | 38 |
-| **fp16 + fp16 cache I/O** | **13.63 ms** | **4.39×** | 105 MiB | **60 MiB** | 2/200 | 0.0426 | 1.6e-04 | 38 |
+| `encfp32-fp16trunk` | 21.79 ms | 2.75× | 155 MiB | 120 MiB | 2/200 | 0.0427 | 1.2e-04 | present |
+| fp16 | 16.97 ms | 3.53× | 107 MiB | 120 MiB | 5/200 | 0.1827 | 5.0e-04 | present |
+| **fp16 + fp16 cache I/O** | **13.63 ms** | **4.39×** | 105 MiB | **60 MiB** | 2/200 | 0.0426 | 1.6e-04 | present |
 
 **Serve fp32.** Not because low precision looks bad, but because at this window
 there is no latency pressure to trade anything for: 59.82 ms is **3.36× cheaper
@@ -1050,13 +1069,26 @@ Two honesty notes on those parity counts:
   serving that engine, re-run the ladder with a genuinely fp16 ring — the harness
   needs one change, to keep `past_k`/`past_v` in fp16 between ticks.
 
-`encfp32-fp16trunk` carries **7** `_gemm_mha_v2` instances rather than 8. That is
-consistent with §4: `readout_only_final_block=True` makes the last block's
-attention a 1-query op, a different shape that does not take the fused kernel.
-Note also that `build_mixed.py`'s log showed **0** hits, because it uses a
-non-verbose TRT logger — the engine had to be interrogated with
-`--dumpLayerInfo` instead. Reading that 0 as "the fusion is gone" would have been
-a false alarm, which is why the check greps the engine and not only the build log.
+**The fusion is present in every fp16-containing engine**, and that is the whole
+verdict — do not read the raw hit counts in the table as kernel counts. They are
+not comparable across engines: `build_mixed.py` never sets
+`profiling_verbosity`, so the mixed engine was built at TRT's default and its
+tactic names are partly stripped, while the trtexec builds used
+`--profilingVerbosity=detailed` and emit hash-suffixed names that appear several
+times per kernel in the same dump. The one quantity that is defensible is from the
+profile JSON of the plain fp16 engine, where instances and times are attributed:
+**19 instances, 5.34 ms, 29.4 % of the step**.
+
+Two traps this check walked into, both worth remembering:
+
+* `build_mixed.py`'s **build log showed 0 hits**, purely because its TRT logger is
+  not verbose. Reading that as "the fusion is gone" would have fired the alarm on
+  the one check that matters. The engine has to be interrogated with
+  `--dumpLayerInfo` / `--dumpProfile`, never only the build log.
+* An earlier version of `decoder_only_trt_measure.sh` grepped `[fm]mha`, which
+  matches `fmha`/`mmha` but **not** `_gemm_mha_v2`, so its "here is what fused MHA
+  exists" fallback printed an empty list next to a primary check reporting 38 hits.
+  Fixed to `mha`.
 
 ### 12.9 What is NOT established
 

--- a/docs/decoder_only_kv_cache.md
+++ b/docs/decoder_only_kv_cache.md
@@ -1,0 +1,183 @@
+# Decoder-only PatchPolicy with a bounded KV cache
+
+Implements `/nasa/max/docs/decoder_only_handoff.md`. Turns the block-causal
+temporal trunk (fixed 6-frame sliding window, recomputed from scratch every tick)
+into a causal decoder over frame blocks with a reusable, bounded KV cache.
+
+Per tick the model encodes **one** new frame (257 tokens: 1 speed token prepended
+to 256 goal-fused patch tokens), runs those 257 queries against the cached K/V of
+past frames, and never recomputes or re-attends old frames to each other.
+
+| | file |
+| --- | --- |
+| trunk + mask + RoPE + cache | `src/rmind/components/transformer/causal_frame.py` |
+| one-tick export wrapper | `src/rmind/models/patch_policy_decoder.py` |
+| correctness gate (CPU) | `tests/test_causal_frame.py` |
+| training arm | `config/experiment/yaak/patch_policy/dinov2_dinowm_causal.yaml` |
+
+Everything outside the trunk is unchanged: the frozen DINOv2 ViT-S encoder, the
+frozen goal encoder and its RVQ, the fusion, `patch_projection`,
+`speed_embedding`, `norm`, and the VQ-BeT `code_head` / `offset_head` / tokenizer.
+`CausalSelfAttention` even keeps `nn.MultiheadAttention`'s parameter names, so a
+trunk trained with `BlockCausalTransformer` loads into it 1:1 — this is a
+positional-encoding change, not a re-parameterization.
+
+## 1. The positional encoding, which is the whole problem
+
+`BlockCausalTransformer` adds `nn.Embedding(1542, d)` indexed over the flattened
+sequence. That index is **window-absolute**: slot 0 always means "oldest frame
+currently in the window". Slide the window and every frame's positional input
+changes, so every cached key is stale. Nothing is reusable even though 5 of 6
+frames are identical.
+
+Replaced by a **factorized** scheme, each factor stable under a sliding window.
+
+**Intra-frame — a learned 257-slot embedding, tiled onto every frame.** Token *k*
+of frame *f* always gets `intra_pos[k]`, for every *f*. Frame-relative by
+construction, never stale. This keeps exactly the intra-frame capacity the
+1542-slot table had (patch identity; speed-token vs patch-token identity), so
+nothing about what the model sees is reduced — §4 of the hand-off forbids buying
+latency with representation.
+
+**Inter-frame — RoPE at *frame* granularity**, applied to q and k in every layer.
+All 257 tokens of a frame share one rotation `R_f`, which gives both properties
+the hand-off asks for:
+
+* intra-frame attention is **exactly unrotated**, `(R_f q)ᵀ(R_f k) = qᵀk`, so it
+  stays fully bidirectional and is ordered only by the intra-frame embedding;
+* inter-frame logits depend only on `f_q − f_k`, so a key rotated with its own
+  episode-absolute frame index is valid **forever**, at any future window
+  position. That is precisely cache-safety.
+
+`rope_base = 1000`, not the customary 10000: over a 64-frame range, base 10000
+leaves most frequency pairs rotating <0.01 rad and therefore inert.
+
+**Why not ALiBi.** ALiBi is equally cache-safe and, being a pure additive bias,
+folds into the existing mask with no new ops. It remains the better choice for a
+low-precision *serving* engine, since RoPE normally introduces `Sin`/`Cos` and the
+trt-export skill flags trigonometric ops as the most fp16-fragile part of this
+model family. Two reasons it is not the default here:
+
+1. RoPE's `Sin`/`Cos` are avoided anyway — `rope_cos`/`rope_sin` are **graph
+   inputs**, computed host-side in float64 from the episode frame counter. The
+   exported engine contains zero trigonometric nodes, so ALiBi's advantage
+   evaporates.
+2. ALiBi's bias is per-head and query-dependent, so the training path must
+   materialize an `(H, S, S)` tensor. At 32 frames that is 12 × 8224² × 4 B ≈
+   3.2 TB. RoPE has no such term.
+
+**Episode-absolute learned embeddings** were rejected: they bound the episode
+length and reintroduce a table that must be re-derived if the context changes.
+
+## 2. Mask
+
+`frame_block_causal_mask(num_frames, tokens_per_frame, window=N)` — bidirectional
+within a frame, causal across frames, and additionally blocking frames more than
+`N-1` older than the query. With `window=None` it is bit-identical to the existing
+`patch_policy.block_causal_mask`.
+
+The `window` is not cosmetic. **Streaming one frame per tick against a ring of
+capacity `N-1` past frames is exactly one full forward under
+`frame_block_causal_mask(window=N)`** — in both, frame *f*'s layer-*l* input
+attends to frames `[f-N+1 .. f]`. That equivalence is the correctness gate and it
+is also the operational meaning of "train the way you infer" (§6): train with
+`window=N`, serve with a ring of `N-1`.
+
+At serving time the step needs **no causal mask at all**: every cached key is in
+the past by construction and every own-frame key is visible. The only masking is
+`cache_bias`, which zeroes out unfilled ring slots.
+
+## 3. Cache layout and the runtime contract
+
+Single stacked tensor per side:
+
+```
+past_k, past_v : (num_layers, batch, num_heads, cache_frames * 257, head_dim)
+new_k,  new_v  : (num_layers, batch, num_heads,            257, head_dim)
+cache_bias     : (1, 1, 1, cache_frames * 257)   0 = filled, -1e4 = empty
+rope_cos/sin   : (1, head_dim)
+```
+
+`past_k`/`past_v` are **read-only** graph inputs; only the new frame's K/V come
+out. **The ring buffer lives in the host, not the graph.** No in-graph scatter, no
+`ScatterElements` in TRT, and the cache is ordinary engine I/O. Between ticks the
+host shifts by one frame block and writes 257 tokens per layer.
+
+ONNX input names (`torch.export` flattens the `Mapping` argument):
+`inputs_image`, `inputs_speed`, `inputs_waypoints`, `inputs_past_k`,
+`inputs_past_v`, `inputs_cache_bias`, `inputs_rope_cos`, `inputs_rope_sin`.
+Outputs: `policy.joint_actions`, `new_k`, `new_v`.
+
+Two silent-failure hazards on the drivr side:
+
+* `TRTEngine.run` binds via `set_tensor_address` — a raw pointer with **no size
+  validation** (§3.4). A cache allocated for a different `cache_frames`, layer
+  count, head count or dtype is not an error; TRT reinterprets the buffer and the
+  model merely looks weak. **Validate every binding against
+  `engine.get_tensor_shape(name)` before the first `run`.**
+* Cache and frame counter must be **reset on every episode boundary** — engage,
+  disengage, manual override. drivr already clears the action plan on those
+  transitions; hook the same paths. A stale cache is not detectable from the
+  output.
+
+`Resize=0` and in-graph ImageNet normalization are unchanged, so the host still
+owes an exact 224×224 (dinov2) `[0,1]` frame and `--image-norm unit`.
+
+## 4. Gather before the final block (hand-off §3.3)
+
+The head reads one token per frame, so in the final trunk block the attention
+output and the MLP for the other 256 positions are discarded.
+`readout_only_final_block=True` (the default in `PatchPolicyDecoderStep`) computes
+them for the readout position only, while still emitting K/V for all 257 — future
+frames attend to those. Verified equivalent in
+`test_readout_only_final_block_matches_full_final_block`.
+
+## 5. Correctness gate — `tests/test_causal_frame.py`
+
+Runs on CPU in <1 s. Every equivalence is paired with a **negative control** on a
+window-absolute variant of the same trunk, driven through the same harness, so a
+pass is falsifiable.
+
+The literal §5.1 phrasing — "run on `[0..5]` cold, then `[1..6]` warm vs a full
+recompute of `[1..6]`" — is exact only when "full recompute" means the
+sliding-window recompute described in §2. Re-running `[1..6]` as a *fresh isolated
+6-frame episode* is a **different computation** and cannot match for any bounded
+window with more than one layer: there frame 5 never saw frame 0, whereas in the
+stream its layer-2+ K/V were produced with frame 0 in context. That residual is
+recorded as a quantified diagnostic, and corroborated by the fact that it
+vanishes at `num_layers=1`.
+
+## 6. KV memory budget on Orin
+
+`bytes = 2 (K,V) × L × (cache_frames × 257) × D × sizeof(dtype)`, with
+`cache_frames = context_frames − 1`.
+
+Per cached frame: small (8L/512d) **8.03 MiB** fp32 / 4.02 MiB fp16; `_big`
+(12L/768d) **18.07 MiB** fp32 / 9.04 MiB fp16.
+
+| context (frames) | cached keys | small fp32 | `_big` fp32 | small fp16 | `_big` fp16 |
+| --- | --- | --- | --- | --- | --- |
+| 6 | 1285 | 40 MiB | 90 MiB | 20 MiB | 45 MiB |
+| 16 | 3855 | 120 MiB | 271 MiB | 60 MiB | 136 MiB |
+| 32 | 7967 | 249 MiB | 560 MiB | 124 MiB | 280 MiB |
+| 64 | 16191 | 506 MiB | 1138 MiB | 253 MiB | 569 MiB |
+| 128 | 32639 | 1020 MiB | 2295 MiB | 510 MiB | 1147 MiB |
+
+delta-dev1 has **15 GiB** of LPDDR5 shared between CPU and GPU, ~12 GiB
+practically available. Memory is not the binding constraint at any context length
+worth training: `_big` at 64 frames is 9.3 % of available RAM in fp32, 4.6 % in
+fp16. Latency and the per-tick cache read bandwidth bind first.
+
+## 7. Measured latency
+
+See the measurement table in the accompanying report. Method: fp32 engines (the
+hand-off's 194.8 / 448.8 ms baseline is fp32, and fp32 is the only precision that
+has ever reached 0/200 on parity), built and benchmarked on an idle delta-dev1
+with the GPU clock pinned at 918 MHz, `trtexec --iterations=60 --avgRuns=20
+--useSpinWait --warmUp=1000`.
+
+Note **cold vs warm cache costs the same** for a static-shape engine: the graph
+does identical work at any fill level, and correctness at cold start comes from
+`cache_bias`, not from a smaller computation. A cheaper first tick would need a
+dedicated small-context engine; it is not worth an engine to save one tick per
+episode.

--- a/docs/decoder_only_kv_cache.md
+++ b/docs/decoder_only_kv_cache.md
@@ -147,6 +147,31 @@ stream its layer-2+ K/V were produced with frame 0 in context. That residual is
 recorded as a quantified diagnostic, and corroborated by the fact that it
 vanishes at `num_layers=1`.
 
+**Result at production sizes** (257 tokens/frame, max over every frame's readout):
+
+| configuration | float64 | float32 |
+| --- | --- | --- |
+| small 8L/512d, window 6, T=7 | 1.78e-15 | 1.43e-06 (3.2e-07 rel) |
+| `_big` 12L/768d, window 6, T=7 | 2.67e-15 | 1.55e-06 (4.0e-07 rel) |
+| `_big` 12L/768d, window 32, T=40 | 4.44e-15 | 1.91e-06 (4.2e-07 rel) |
+| **negative control** (window-absolute, small, window 6) | — | **9.37e-02 (2.1e-02 rel)** |
+
+The float64 residual is at machine epsilon, which proves the equivalence is exact
+and the ~1.5e-6 float32 residual is purely floating-point accumulation order —
+streaming computes a 257×1542 attention where the recompute computes 1542×1542, so
+the sums are ordered differently. The window-absolute control misses by **five
+orders of magnitude**, which is what the gate is there to catch.
+
+Isolated-episode diagnostic, same trunk, float64: **7.1e-02** at `L=8` and
+**4.4e-16** at `L=1` — exactly the layer-≥2 leakage explanation, and not a
+positional or cache defect.
+
+The ONNX graph agrees with eager to **1.4e-05 absolute / 4e-06 relative** on the
+new K/V and 5.7e-07 on the action chunk (ORT CPU fp32 vs PyTorch). Note
+`torch.onnx.export(verify=True)` reports a "large relative difference of 2.87" for
+`new_k`; that is per-element relative error on near-zero entries and is a false
+alarm — compare absolute error against the tensor scale.
+
 ## 6. KV memory budget on Orin
 
 `bytes = 2 (K,V) × L × (cache_frames × 257) × D × sizeof(dtype)`, with
@@ -168,16 +193,190 @@ practically available. Memory is not the binding constraint at any context lengt
 worth training: `_big` at 64 frames is 9.3 % of available RAM in fp32, 4.6 % in
 fp16. Latency and the per-tick cache read bandwidth bind first.
 
-## 7. Measured latency
+## 7. drivr serving sketch
 
-See the measurement table in the accompanying report. Method: fp32 engines (the
-hand-off's 194.8 / 448.8 ms baseline is fp32, and fp32 is the only precision that
-has ever reached 0/200 on parity), built and benchmarked on an idle delta-dev1
-with the GPU clock pinned at 918 MHz, `trtexec --iterations=60 --avgRuns=20
---useSpinWait --warmUp=1000`.
+```python
+# --- once, at engine load: the graph is the authority on every cache dimension
+for name in ("inputs_past_k", "inputs_past_v", "inputs_cache_bias",
+             "inputs_rope_cos", "inputs_rope_sin", "new_k", "new_v"):
+    expected = tuple(engine.get_tensor_shape(name))
+    if tuple(buffers[name].shape) != expected:      # set_tensor_address does NOT check
+        raise ValueError(f"{name}: engine wants {expected}, got {buffers[name].shape}")
+layers, _, heads, cache_tokens, head_dim = engine.get_tensor_shape("inputs_past_k")
+tokens_per_frame = engine.get_tensor_shape("new_k")[3]      # 257
+cache_frames = cache_tokens // tokens_per_frame             # context - 1
+
+# --- on engage / disengage / manual override, wherever the action plan is cleared
+def reset_cache():
+    cache_bias.fill_(-1e4)     # every slot invalid; K/V contents then do not matter
+    frame_index = 0            # RoPE counter; fp64 host-side, monotone per episode
+
+# --- per tick
+rope_cos, rope_sin = frame_rope_cos_sin(frame_index, head_dim=head_dim, base=1000.0)
+out = engine.run(image=frame, speed=..., waypoints=...,
+                 past_k=past_k, past_v=past_v, cache_bias=cache_bias,
+                 rope_cos=rope_cos, rope_sin=rope_sin)
+# ring-buffer advance: shift one frame block left, write 257 tokens per layer
+past_k[..., :-tokens_per_frame, :] = past_k[..., tokens_per_frame:, :]
+past_k[..., -tokens_per_frame:, :] = out["new_k"]
+# ... same for V ...
+cache_bias[..., -tokens_per_frame:] = 0.0     # the tail is now filled
+frame_index += 1
+```
+
+Three failure modes, all silent, all worth an explicit check:
+
+1. **Wrong cache shape** — `set_tensor_address` takes a raw pointer, so a
+   mismatched cache is reinterpreted rather than rejected. Validate at load.
+2. **Cache not reset at an episode boundary** — the model conditions on frames
+   from before the disengage. The output stays plausible. Hook the paths that
+   already clear the action plan.
+3. **`frame_index` not monotone** (e.g. reset mid-episode, or wrapped) — RoPE
+   offsets become wrong for the frames still in the ring. Reset the counter
+   **only** together with the cache.
+
+Optional but cheap: assert the number of valid slots in `cache_bias` equals
+`min(frame_index, cache_frames) * 257`. That single invariant catches all three.
+
+## 8. rbyte / dataset considerations
+
+`clip_length = episode_length + clip_horizon - 1`, so moving from 6 to 16 frames
+takes clips from 11 to 21 samples, and 64 frames would need 69. Consequences:
+
+* the dataset must be **rebuilt** — `clip_period` is derived from `clip_length`
+  and the existing clip-11 build is not reusable;
+* at `episode_step = 10` (≈3 Hz), 21 samples span ~7 s of driving and 69 span
+  ~23 s. Long clips are cut at session boundaries, so the number of usable
+  windows falls roughly linearly with `clip_length` — expect a materially
+  smaller train set at 64 frames, on top of the compute cost;
+* per-sample decode/IO grows linearly with `clip_length`, so the loader becomes a
+  real cost at long context, not just the GPU.
+
+This is the practical reason to step 6 → 16 → 32 rather than jumping to 64.
+
+## 9. Measured latency
+
+Method: fp32 engines (the hand-off's 194.8 / 448.8 ms baseline is fp32, and fp32
+is the only precision that has ever reached 0/200 on parity), built and
+benchmarked on an idle delta-dev1 (AGX Orin 16 GB, 8 cores, TRT 10.7) with the
+GPU clock **pinned at 918 MHz** — `governor=performance`, `min_freq=918000000`,
+verified by sampling `cur_freq` continuously *through* a 5 s idle gap (all 25
+samples at 918 MHz, so the `nvhost_podgov` 306 MHz artifact is not present).
+`trtexec --iterations=60 --avgRuns=20 --useSpinWait --warmUp=1000`, median GPU
+compute time.
+
+**Gate zero — the baseline reproduces.** Randomly-initialized fp32 exports of the
+*existing* block-causal architecture at 6 frames:
+
+| arm | measured here | hand-off §1 | delta |
+| --- | --- | --- | --- |
+| small (8L/512d) | **200.85 ms** | 194.8 ms | +3.1 % |
+| `_big` (12L/768d) | **420.16 ms** | 448.8 ms | −6.4 % |
+
+Close enough that the comparison is sound, and it confirms `_big` is **12** layers
+(§7 says 8; an 8-layer 768-d trunk could not cost 420 ms). Speedups below are
+quoted against *these* numbers, measured on the same host on the same day through
+the same export path, not against the hand-off's.
+
+**Decoder step, per tick, fp32, median GPU compute:**
+
+| context (frames) | small (8L/512d) | vs 6-frame baseline | `_big` (12L/768d) | vs 6-frame baseline |
+| --- | --- | --- | --- | --- |
+| 6 | **41.79 ms** | **4.81×** | **87.21 ms** | **4.82×** |
+| 16 | 59.58 ms | 3.37× | 127.79 ms | 3.29× |
+| 32 | 92.26 ms | 2.18× | 205.05 ms | 2.05× |
+| 64 | 160.51 ms | 1.25× | 364.22 ms | 1.15× |
+
+At the same 6 frames of context the step is **4.8× cheaper in both arms**. The
+hand-off estimated ~75 ms for `_big`; the measurement is 87.2 ms, i.e. the
+estimate was optimistic by ~16 % — close, and the reason is exactly the "no new
+overhead from cache management" assumption it flagged (§8): the in-graph
+`Concat` of `past_k` with the new frame's keys is real work.
+
+### Correcting the hand-off: per-tick cost does NOT stop scaling with context
+
+§2 claims "per-tick cost stops scaling with window length". It does not. The step
+runs 257 queries against `(N-1) × 257 + 257` keys, so both the attention terms
+and the cache traffic are **linear in N**. Measured, over 6 → 64 frames:
+
+| | fixed cost (N→1) | marginal cost per extra frame | R² of the linear fit |
+| --- | --- | --- | --- |
+| small | ~31.5 ms | **2.05 ms/frame** | >0.999 |
+| `_big` | ~63.3 ms | **4.78 ms/frame** | >0.999 |
+
+The marginal term is attention against the cache. Per extra cached frame it is
+`2 × 257 × 257 × D × 2 × L` FLOPs — 1.08 GFLOP (small) and 2.43 GFLOP (`_big`) —
+so the measured slopes correspond to **528 and 509 GFLOP/s effective**, ~16 % of
+the module's ~3.3 TFLOP/s fp32 peak, and *identical between arms*. That agreement
+says the scaling is dominated by a thin (257-query) attention GEMM rather than by
+the `Concat` or by cache bandwidth, and it means the slope is predictable: it
+scales with `L × D`, nothing else.
+
+What *does* improve superlinearly is the comparison against recomputing an
+N-frame window, which is quadratic. The right way to state the prize:
+
+* **`_big` attends to 32 frames for 205 ms — less than half of what it costs today
+  to attend to 6** (420 ms). Recomputing a 32-frame window block-causally would be
+  ~28× the trunk work of the 6-frame one, i.e. several seconds.
+* **small attends to 32 frames for 92 ms, versus 201 ms today for 6.**
+* Every configuration measured except `_big` at 64 frames (364 ms) fits inside one
+  333 ms tick, and `_big` clears the ~270 ms threshold that removes the
+  plan-execution distortion (hand-off §7) at **up to 32 frames** — where today it
+  does not clear it at 6.
+
+Practical reading of the slope: 32 frames is the point where `_big` still fits
+comfortably (205 ms, half of today's cost) and 64 frames is where it stops being
+free (364 ms, no longer inside a tick at fp32). If 64 frames is wanted, the levers
+are the fp32-encoder + fp16-trunk serving engine from the trt-export skill §9 —
+which halves the cache and its traffic as well as the GEMM cost — or a
+block-sparse/paged attention kernel. Not more caching: the cache is already exact.
+
+⚠️ The decoder numbers include §3.3's gather-before-final-block, which the
+baseline does not have. That optimization is free and applies to the baseline
+independently; the hand-off measured it at 30.6 ms (6.8 %) there. Subtracting it
+from the comparison would put the like-for-like `_big` speedup at ~4.5× rather
+than 4.8×.
 
 Note **cold vs warm cache costs the same** for a static-shape engine: the graph
 does identical work at any fill level, and correctness at cold start comes from
 `cache_bias`, not from a smaller computation. A cheaper first tick would need a
 dedicated small-context engine; it is not worth an engine to save one tick per
 episode.
+
+## 10. Open risks
+
+1. **Training cost is untouched, and it is now the bottleneck.** The cache makes
+   *inference* per-tick cost linear in context. Training still does one dense
+   forward over the whole clip, and the attention terms are quadratic in the
+   flattened length: 6 frames = 1542 tokens, 32 frames = 8224 (5.3× the tokens,
+   **28×** the attention work), 64 frames = 16448 (10.7× / **114×**). The `window`
+   mask makes attention block-sparse but plain SDPA still materializes the dense
+   score matrix, so the saving is not realized without a block-sparse kernel
+   (FlexAttention / `create_block_mask`). At `clip_length == window` the mask is
+   dense anyway. **This is the single largest practical risk to the bonus track**;
+   16 frames is the defensible first step, not 64.
+2. **Behaviour change, not just speed** (hand-off §6). Conditioning on 16–64
+   frames is a different model. Needs rsim and road, not val L1 — PR #248
+   established that aggregate L1 is blind to this failure class.
+3. **Train/infer mismatch if the window is not matched.** Serving with a ring of
+   `N-1` is only equivalent to training if training used
+   `frame_block_causal_mask(window=N)`. `CausalFrameTransformer` cross-checks
+   `max_sequence_length == window * tokens_per_frame` so a config mismatch raises,
+   but nothing prevents serving a checkpoint against the wrong cache size —
+   validate the engine's `inputs_past_k` shape against the checkpoint's `window`.
+4. **No parity/precision verification yet.** All measurements are fp32 with random
+   weights, so `parity_matrix.py --trials 200` has not been and cannot be run — it
+   needs a trained checkpoint. The 5 in-graph `ArgMax` nodes and the code-flip
+   defect are unchanged by this work (hand-off §6), and the margin screen must be
+   re-run on any real checkpoint before serving anything below fp32.
+5. **RoPE base is unvalidated.** `rope_base=1000` is reasoned (base 10000 leaves
+   most frequency pairs inert over 64 positions) but not measured. It is a
+   trainable-arm hyperparameter, and changing it after training invalidates the
+   checkpoint.
+6. **The `Concat` of cache and new keys is unavoidable without a plugin.** It costs
+   an extra read+write of the cache per tick. Measured slopes say it is not
+   dominant, but at 128 frames it would be. A paged/in-place attention plugin is
+   the escape hatch; `ScatterElements` in the ONNX graph is deliberately not.
+7. **`_big` at 64 frames does not fit a tick at fp32** (364 ms). Not a defect, but
+   it bounds the context length that is servable today without the mixed-precision
+   engine.

--- a/docs/decoder_only_kv_cache.md
+++ b/docs/decoder_only_kv_cache.md
@@ -859,3 +859,132 @@ check). Grepped in four places:
 | **fp32 build log / layer info / profile** | **0** (expected: it is an fp16 tensor-core kernel) |
 
 **Verdict: present.** No alarm.
+
+### 12.5 Margin screen — and which `ArgMax` is actually yours
+
+Five in-graph `ArgMax` nodes, screened with `decoder_only_verify margins`
+(ORT-only, no GPU, 25 trials over 3 real camera frames). `margin = top1 − top2`
+expressed in **fp16 ULPs at that magnitude**: below ~1 ULP the two codes are not
+distinguishable in fp16 at all.
+
+Running the identical screen on the **randomly initialized** export of the same
+graph separates the frozen subgraph from the trained one — the skill's trick, and
+it works exactly as advertised:
+
+| probe | decisions/trial | trained min ULP | random min ULP | trained median | random median |
+| --- | --- | --- | --- | --- | --- |
+| `node_argmax` | 1 | 2.688 | **2.688** | 412.9 | **412.9** |
+| `node_argmax_1` | 1 | 11.557 | **11.557** | 44.4 | **44.4** |
+| `node_argmax_2` | 1 | 2.875 | **2.875** | 49.3 | **49.3** |
+| `node_argmax_3` | 1 | 3.317 | **3.317** | 41.1 | **41.1** |
+| `node_argmax_4` | **4** | **1.938** | 21.362 | 162.9 | 678.7 |
+
+Probes 0–3 are **byte-identical** between a trained checkpoint and a random one,
+so they are the **frozen waypoints-tokenizer RVQ** — four quantizer stages, one
+decision each, fixed for every checkpoint in this family. They are not a
+checkpoint risk and they are not fixable by training. `node_argmax_4` emits four
+decisions per trial and is the only probe that moved: it is the **trained VQ-BeT
+`code_head`** (4 quantizers × 16 codes).
+
+So the number that matters is the code head's, and reading the aggregate
+`min ULP` is misleading — the aggregate floor of 2.688 belongs to a frozen table.
+
+**The trained code head, at epoch 0:** min **1.94 ULP**, p1 4.22, median 162.9,
+**0 % of decisions under 1 ULP**, 1 % under 4. Against the skill's validated
+thresholds (`<1 ULP` predicted every measured fp16 failure across 16 checkpoints;
+`≥4 ULP` has never failed) that is the **marginal** band: not a predicted failure,
+but low precision must be verified at n≥200 rather than assumed.
+
+Worth noting for the training side: **training has tightened these margins**, from
+21.4 ULP min / 679 median at initialization to 1.9 / 163 after 80.8 k steps. That is
+the tie geometry the code-flip defect is made of, forming early. It is a quantity
+worth tracking per checkpoint, and this is a baseline for it.
+
+### 12.6 The parity ladder — n=200, real frames, decision changes
+
+`decoder_parity_orin.py`, run on delta-dev1 so the reference and the engines see
+byte-identical inputs. 10 histories, each a genuinely **streamed** 15-frame warm
+cache (cold start, ring slot writes, monotone frame counter — what drivr does),
+× 20 current-frame/speed/waypoint variations = 200 trials. Reference is ORT CPU
+fp32 on the same ONNX. A trial counts as a **decision change** when any action
+channel moves more than 0.02 — float noise is ~1e-4 here and a flipped code is
+~0.1, so the threshold is not delicate.
+
+| engine | latency | decision changes | of which control-channel only | worst \|d\| | mean \|d\| |
+| --- | --- | --- | --- | --- | --- |
+| **fp32** (TF32 cleared) | 59.82 ms | **0/200** | 0 | 4.2e-07 | 1.8e-08 |
+| fp16 | 16.97 ms | **5/200** (2.5 %) | **5** | 0.1827 | 5.0e-04 |
+
+**fp32 is 0/200, so the harness is sound** — that is the skill's gate on the
+harness itself, and it passes. Its residual is 4.2e-07 max, i.e. fp32 round-off
+between ORT CPU and TRT, not a modelling difference.
+
+Per channel, fp16 vs the fp32 reference:
+
+| channel | max \|d\| | mean \|d\| |
+| --- | --- | --- |
+| gas_pedal | 0.1065 | 1.18e-03 |
+| brake_pedal | 0.0068 | 6.02e-05 |
+| **steering_angle** | **0.1827** | 7.09e-04 |
+| turn_signal | 0.0041 | 5.46e-05 |
+
+**This arm's fp16 failure is different in kind from the baseline's, and worse.**
+On the block-causal baseline the headline magnitude was entirely `turn_signal`
+(0.546) — an indicator state, not a trajectory. Here `turn_signal` never even
+crosses tolerance (max 0.0041) and **all five flips are control channels**: up to
+**18.3 % of steering range** and **10.6 % of throttle** on 2.5 % of plans. There is
+no "it was only the indicator" reading available.
+
+### 12.7 KV-cache memory — the halving is real but is NOT the default
+
+§6's arithmetic is confirmed against the actual graph: at window 16 the cache is
+`8 layers × 15 frames × 257 × 512 × 4 B × 2 (K,V)` = **120.47 MiB**, and the
+engine's own `inputs_past_k` binding reports exactly that.
+
+The part §6 did not say is that **a plain `--fp16` build does not halve it.** TRT
+preserves the dtypes the ONNX declares for network *I/O* and casts internally, so
+the fp16 engine's cache bindings come back **float32**:
+
+| engine | `inputs_past_k` dtype | KV cache | latency |
+| --- | --- | --- | --- |
+| fp32 | float32 | 120.47 MiB | 59.82 ms |
+| fp16 (plain `--fp16`) | **float32** | **120.47 MiB** | 16.97 ms |
+| fp16 + fp16 cache I/O | float16 | **60.23 MiB** | **13.57 ms** |
+
+The halving has to be *asked for*, per tensor:
+
+```
+trtexec --onnx=M.onnx --fp16 \
+  --inputIOFormats=fp32:chw,fp32:chw,fp32:chw,fp16:chw,fp16:chw,fp16:chw,fp32:chw,fp32:chw \
+  --outputIOFormats=fp32:chw,fp16:chw,fp16:chw
+```
+
+i.e. `past_k`/`past_v`/`cache_bias` and `new_k`/`new_v` in fp16, while the camera
+frame, speed, waypoints, RoPE and the action chunk stay fp32 — so the only host
+contract that changes is the cache itself.
+
+**And it is not only memory: it is 20 % of the step.** Profiling the plain fp16
+engine (`--dumpProfile`, detailed verbosity) the two most expensive kernels in the
+whole graph are not compute at all:
+
+| kernel | time | share |
+| --- | --- | --- |
+| `Reformatting CopyNode for Input Tensor 3` (`past_k`) | 1.264 ms | 7.0 % |
+| `Reformatting CopyNode for Input Tensor 2` (`past_v`) | 1.250 ms | 6.9 % |
+| 19 × `_gemm_mha_v2` (fused MHA, the actual attention) | 5.34 ms | 29.4 % |
+| kernels naming `cat`/`concat` | **0.00 ms** | 0 % |
+
+2.51 ms — 14 % of the step — is spent converting a 120 MiB fp32 cache to fp16
+every tick, and it disappears when the cache is handed over as fp16 already:
+16.97 → 13.57 ms, a 3.40 ms saving that matches the reformat cost plus the halved
+cache traffic. **So the default `--fp16` build leaves 60 MiB and 3.4 ms on the
+table for nothing.**
+
+Note also the `Concat` line: **0 ms as a standalone kernel.** It has not
+disappeared — TRT has absorbed it *into* `_gemm_mha_v2`, which is precisely why §9
+called it load-bearing for the fusion. Do not "optimize" it away.
+
+Total resident at the served window 16, measured: 203 MiB of fp32 weights +
+120 MiB cache = **323 MiB** (§6 predicted 327 MiB), or 107 MiB + 60 MiB =
+**167 MiB** on the fp16 + fp16-cache engine. Memory remains nowhere near binding
+on a 15 GiB Orin.

--- a/docs/decoder_only_kv_cache.md
+++ b/docs/decoder_only_kv_cache.md
@@ -304,13 +304,33 @@ and the cache traffic are **linear in N**. Measured, over 6 → 64 frames:
 | small | ~31.5 ms | **2.05 ms/frame** | >0.999 |
 | `_big` | ~63.3 ms | **4.78 ms/frame** | >0.999 |
 
-The marginal term is attention against the cache. Per extra cached frame it is
-`2 × 257 × 257 × D × 2 × L` FLOPs — 1.08 GFLOP (small) and 2.43 GFLOP (`_big`) —
-so the measured slopes correspond to **528 and 509 GFLOP/s effective**, ~16 % of
-the module's ~3.3 TFLOP/s fp32 peak, and *identical between arms*. That agreement
-says the scaling is dominated by a thin (257-query) attention GEMM rather than by
-the `Concat` or by cache bandwidth, and it means the slope is predictable: it
-scales with `L × D`, nothing else.
+The slope tracks `L × D` and nothing else, which makes it predictable: the extra
+attention work per cached frame is `2 × 257 × 257 × D × 2 × L` FLOPs — 1.08 GFLOP
+(small), 2.43 GFLOP (`_big`) — and the two measured slopes correspond to the same
+**~510–530 GFLOP/s effective** (~16 % of the module's ~3.3 TFLOP/s fp32 peak) in
+both arms.
+
+**Where the marginal time actually goes is split, and the `Concat` is a first-order
+term.** Bucketing `trtexec --dumpProfile` by kernel kind (TRT fuses and renames
+everything to `__myl_*`, so the module hierarchy is *not* recoverable — this is why
+the hand-off cross-checked its §1 split against an independent FLOP count instead):
+
+| bucket | small, N=6 | small, N=64 |
+| --- | --- | --- |
+| MatMul (qkv / proj / MLP / head / unfused attention GEMMs) | 25.5 ms (55 %) | 62.2 ms (31 %) |
+| fused kernels containing the cache `Concat` | 6.6 ms (14 %) | **68.2 ms (34 %)** |
+| `scaled_dot_product_attention` | 4.1 ms (9 %) | 35.0 ms (17 %) |
+| standalone fused softmax | 3.4 ms (7 %) | 30.5 ms (15 %) |
+| other fused elementwise | 6.4 ms (14 %) | 6.5 ms (3 %) |
+| conv2d (ViT patch embed) | 0.15 ms | 0.15 ms |
+
+⚠️ Treat this as *indicative only*: `--dumpProfile` inflates the total (46.2 ms
+against a benchmarked 41.8 ms at N=6, 202.5 against 160.5 at N=64) and it inflates
+large-tensor kernels most, which is exactly the `Concat` bucket. Both sources agree
+on the actionable conclusion though: **at long context the in-graph `Concat` of
+`past_k` with the new frame's keys is comparable to the attention itself**, so an
+in-place / paged attention plugin is the highest-value follow-up if 64+ frames are
+wanted — bigger than any further caching, because the cache is already exact.
 
 What *does* improve superlinearly is the comparison against recomputing an
 N-frame window, which is quadratic. The right way to state the prize:
@@ -373,10 +393,11 @@ episode.
    most frequency pairs inert over 64 positions) but not measured. It is a
    trainable-arm hyperparameter, and changing it after training invalidates the
    checkpoint.
-6. **The `Concat` of cache and new keys is unavoidable without a plugin.** It costs
-   an extra read+write of the cache per tick. Measured slopes say it is not
-   dominant, but at 128 frames it would be. A paged/in-place attention plugin is
-   the escape hatch; `ScatterElements` in the ONNX graph is deliberately not.
+6. **The `Concat` of cache and new keys is unavoidable without a plugin**, and the
+   profile says it is already a first-order cost at 64 frames (§9) — the largest
+   single bucket, comparable to the attention. A paged / in-place attention plugin
+   is the escape hatch; an in-graph `ScatterElements` deliberately is not (TRT
+   support risk, and the host-side ring is free).
 7. **`_big` at 64 frames does not fit a tick at fp32** (364 ms). Not a defect, but
    it bounds the context length that is servable today without the mixed-precision
    engine.

--- a/src/rmind/callbacks/__init__.py
+++ b/src/rmind/callbacks/__init__.py
@@ -16,6 +16,7 @@ from .prediction import (
 )
 from .prediction_config import PredictionConfigSetter
 from .safe import SafeCallback
+from .training_quality import TrainingQualityLogger
 
 __all__ = [
     "DataFramePredictionWriter",
@@ -27,6 +28,7 @@ __all__ = [
     "RerunPredictionWriter",
     "SafeCallback",
     "TensorDictPredictionWriter",
+    "TrainingQualityLogger",
     "WandbAttentionMaskLogger",
     "WandbForesightMetricsLogger",
     "WandbImageParamLogger",

--- a/src/rmind/callbacks/training_quality.py
+++ b/src/rmind/callbacks/training_quality.py
@@ -1,0 +1,180 @@
+from collections import defaultdict
+from typing import Any, override
+
+import pytorch_lightning as pl
+import torch
+from pydantic import validate_call
+from pytorch_lightning.callbacks import Callback
+from torch import Tensor
+
+
+class TrainingQualityLogger(Callback):
+    """Debug signals for training health, logged to the trainer's logger (wandb).
+
+    Every `every_n_steps` optimizer steps (pre-clipping):
+      - `quality/grad_norm/global` and per-module-group grad norms
+      - `quality/weight_norm/<group>` and `quality/grad_to_weight/<group>`
+      - `quality/dead_grad_frac/<group>`: fraction of parameters with exactly
+        zero gradient (dead units / unused embedding rows)
+
+    At each validation epoch end:
+      - `quality/gap/<objective>/<loss>`: val loss minus the mean train loss
+        over the elapsed train window, for every matching `val/.../loss/...`
+        key (positive gap growing over time = overfitting early-warning).
+
+    Module groups: top-level plus one extra level under `objectives`,
+    `episode_builder` and `encoder` (for the patch-policy trunks this
+    separates `encoder.layers` from `encoder.intra_position_embedding`,
+    i.e. the block stack from the positional machinery). Frozen modules
+    never appear (their `grad` is None).
+    """
+
+    @validate_call
+    def __init__(self, every_n_steps: int = 50, *, repr_max_tokens: int = 8192) -> None:
+        super().__init__()
+        self.every_n_steps = every_n_steps
+        self.repr_max_tokens = repr_max_tokens
+        self._train_loss_sums: dict[str, float] = defaultdict(float)
+        self._train_loss_counts: dict[str, int] = defaultdict(int)
+        self._repr_sample: Tensor | None = None  # last val encoder embedding
+        self._hook_handle: Any = None
+
+    @staticmethod
+    def _effective_rank(x: Tensor) -> float:
+        """Entropy-based effective rank of a (N, D) feature matrix.
+
+        exp(H) of the normalized singular-value spectrum of the centered
+        features; collapses toward 1 under representation collapse and toward
+        min(N, D) for an isotropic (full-rank) representation. This is the
+        primary signal LeJEPA/SIGReg is meant to keep high.
+        """
+        x -= x.mean(0, keepdim=True)
+        try:
+            s = torch.linalg.svdvals(x.float())
+        except RuntimeError:
+            return float("nan")
+        p = s / s.sum().clamp_min(1e-12)
+        return float(torch.exp(-(p * (p + 1e-12).log()).sum()))
+
+    @override
+    def setup(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule, stage: str
+    ) -> None:
+        # capture the encoder output during validation for representation health
+        encoder = getattr(pl_module, "encoder", None)
+        if encoder is not None and self._hook_handle is None:
+
+            def _hook(_module: Any, _inp: Any, out: Any) -> None:
+                if not pl_module.training and self._repr_sample is None:
+                    t = out[0] if isinstance(out, tuple) else out
+                    if isinstance(t, Tensor):
+                        flat = t.detach().flatten(0, -2)
+                        self._repr_sample = flat[: self.repr_max_tokens].float().cpu()
+
+            self._hook_handle = encoder.register_forward_hook(_hook)
+
+    @staticmethod
+    def _group(name: str) -> str:
+        parts = name.split(".")
+        # one extra level where the interesting structure lives: per-objective
+        # (control transformer), per-embedding (episode builder), and -- for
+        # patch policy's trunk -- layers vs the positional machinery
+        if parts[0] in {"objectives", "episode_builder", "encoder"} and len(parts) > 1:
+            return f"{parts[0]}.{parts[1]}"
+        return parts[0]
+
+    @override
+    def on_before_optimizer_step(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        optimizer: torch.optim.Optimizer,
+    ) -> None:
+        if trainer.global_step % self.every_n_steps != 0:
+            return
+
+        grad_sq: dict[str, Tensor] = defaultdict(lambda: torch.tensor(0.0))
+        weight_sq: dict[str, Tensor] = defaultdict(lambda: torch.tensor(0.0))
+        dead: dict[str, int] = defaultdict(int)
+        numel: dict[str, int] = defaultdict(int)
+
+        for name, param in pl_module.named_parameters():
+            if param.grad is None:
+                continue
+            g = self._group(name)
+            grad = param.grad.detach()
+            grad_sq[g] += grad.square().sum().cpu()
+            weight_sq[g] += param.detach().square().sum().cpu()
+            dead[g] += int((grad == 0).sum().item())
+            numel[g] += grad.numel()
+
+        if not grad_sq:
+            return
+
+        metrics: dict[str, float] = {}
+        total_sq = torch.stack(list(grad_sq.values())).sum()
+        metrics["quality/grad_norm/global"] = total_sq.sqrt().item()
+        for g, sq in grad_sq.items():
+            gn = sq.sqrt().item()
+            wn = weight_sq[g].sqrt().item()
+            metrics[f"quality/grad_norm/{g}"] = gn
+            metrics[f"quality/weight_norm/{g}"] = wn
+            metrics[f"quality/grad_to_weight/{g}"] = gn / (wn + 1e-12)
+            metrics[f"quality/dead_grad_frac/{g}"] = dead[g] / max(numel[g], 1)
+
+        for logger in trainer.loggers:
+            logger.log_metrics(metrics, step=trainer.global_step)
+
+    @override
+    def on_train_batch_end(
+        self,
+        trainer: pl.Trainer,
+        pl_module: pl.LightningModule,
+        outputs: Any,
+        batch: Any,
+        batch_idx: int,
+    ) -> None:
+        # accumulate per-objective train losses for the train/val gap
+        for key, value in trainer.callback_metrics.items():
+            if key.startswith("train/") and "/loss/" in key:
+                self._train_loss_sums[key] += float(value)
+                self._train_loss_counts[key] += 1
+
+    @override
+    def on_validation_epoch_end(
+        self, trainer: pl.Trainer, pl_module: pl.LightningModule
+    ) -> None:
+        if trainer.sanity_checking:
+            self._train_loss_sums.clear()
+            self._train_loss_counts.clear()
+            self._repr_sample = None
+            return
+
+        metrics: dict[str, float] = {}
+        for key, value in trainer.callback_metrics.items():
+            if not key.startswith("val/"):
+                continue
+            train_key = "train/" + key.removeprefix("val/")
+            if self._train_loss_counts.get(train_key):
+                train_mean = (
+                    self._train_loss_sums[train_key]
+                    / self._train_loss_counts[train_key]
+                )
+                gap = float(value) - train_mean
+                suffix = key.removeprefix("val/")
+                metrics[f"quality/gap/{suffix}"] = gap
+
+        # representation health from the captured val encoder embedding
+        if self._repr_sample is not None:
+            z = self._repr_sample
+            metrics["quality/repr/effective_rank"] = self._effective_rank(z)
+            metrics["quality/repr/feature_std"] = float(z.std(0).mean())
+            metrics["quality/repr/feature_std_min"] = float(z.std(0).min())
+            self._repr_sample = None
+
+        if metrics:
+            for logger in trainer.loggers:
+                logger.log_metrics(metrics, step=trainer.global_step)
+
+        self._train_loss_sums.clear()
+        self._train_loss_counts.clear()

--- a/src/rmind/components/loss.py
+++ b/src/rmind/components/loss.py
@@ -14,19 +14,35 @@ class HasLogitBias(Protocol):
 
 
 class FocalLoss(Module):
-    """https://arxiv.org/pdf/1708.02002.pdf."""
+    """https://arxiv.org/pdf/1708.02002.pdf.
 
-    def __init__(self, *, gamma: float = 2.0) -> None:
+    `label_smoothing` uses the smoothed-CE decomposition
+    `(1-eps) * ce_true + eps * ce_uniform`, but focal-modulates ONLY the
+    true-class term. Modulating both would let `(1-pt)^gamma -> 0` cancel
+    the smoothing penalty exactly on confident predictions -- the case
+    smoothing exists for. The unmodulated `eps * ce_uniform` term grows
+    with the logit margin, capping overconfidence (and the entropy
+    collapse behind the calibration blowup). At `label_smoothing=0.0`
+    this is exactly the unsmoothed focal loss.
+    """
+
+    def __init__(self, *, gamma: float = 2.0, label_smoothing: float = 0.0) -> None:
         super().__init__()
 
         self.gamma: float = gamma
+        self.label_smoothing: float = label_smoothing
 
     @override
     def forward(self, input: Tensor, target: Tensor) -> Tensor:
-        ce_loss = F.cross_entropy(input, target, reduction="none")
-        pt = torch.exp(-ce_loss)
+        ce_raw = F.cross_entropy(input, target, reduction="none")
+        pt = torch.exp(-ce_raw)
+        focal = (1 - pt).pow(self.gamma) * ce_raw
+        eps = self.label_smoothing
+        if not eps:
+            return focal.mean()
 
-        return ((1 - pt).pow(self.gamma) * ce_loss).mean()
+        ce_uniform = -F.log_softmax(input, dim=-1).mean(dim=-1)
+        return ((1 - eps) * focal + eps * ce_uniform).mean()
 
 
 class LogitBiasFocalLoss(FocalLoss, HasLogitBias):

--- a/src/rmind/components/optimizers/selective_adamw.py
+++ b/src/rmind/components/optimizers/selective_adamw.py
@@ -5,6 +5,38 @@ from torch.nn import Module
 from torch.optim.adamw import AdamW
 
 
+def _partition_overrides(
+    overrides: dict[str, float], decayed: set[str]
+) -> dict[str, set[str]]:
+    """Assign decayed param names to weight-decay override prefixes.
+
+    Params under an override prefix (and not blacklisted -- biases/norms stay
+    decay-free) get their own group with that decay instead of the global one.
+
+    Raises:
+        ValueError: on overlapping prefixes or a prefix matching nothing.
+    """
+    groups: dict[str, set[str]] = {prefix: set() for prefix in overrides}
+    for param_name in sorted(decayed):
+        matches = [
+            prefix
+            for prefix in overrides
+            if param_name == prefix or param_name.startswith(prefix + ".")
+        ]
+        if len(matches) > 1:
+            msg = (
+                f"weight_decay_overrides prefixes overlap on '{param_name}': {matches}"
+            )
+            raise ValueError(msg)
+        if matches:
+            groups[matches[0]].add(param_name)
+    for prefix, names in groups.items():
+        if not names:
+            msg = f"weight_decay_overrides prefix '{prefix}' matched no decayed params"
+            raise ValueError(msg)
+    return groups
+
+
 class SelectiveAdamW(AdamW):
     """AdamW with selective weight decay.
 
@@ -18,6 +50,7 @@ class SelectiveAdamW(AdamW):
         *,
         weight_decay: float = 1e-2,
         weight_decay_module_blacklist: tuple[type[Module], ...],
+        weight_decay_overrides: dict[str, float] | None = None,
         **kwargs: Any,
     ) -> None:
         if "params" in kwargs or weight_decay == 0.0:  # noqa: RUF069
@@ -62,6 +95,13 @@ class SelectiveAdamW(AdamW):
 
         weight_decay_param_whitelist = params.keys() - weight_decay_param_blacklist
 
+        override_groups = _partition_overrides(
+            weight_decay_overrides or {}, weight_decay_param_whitelist
+        )
+        for names in override_groups.values():
+            weight_decay_param_whitelist -= names
+        overrides = weight_decay_overrides or {}
+
         # sorted: set iteration order is salted per process, and torch's
         # Optimizer.load_state_dict maps saved state onto params POSITIONALLY --
         # unsorted groups corrupt Adam moments on any cross-process resume
@@ -74,6 +114,13 @@ class SelectiveAdamW(AdamW):
                 "weight_decay": weight_decay,
                 "params": [params[k] for k in sorted(weight_decay_param_whitelist)],
             },
+            *(
+                {
+                    "weight_decay": overrides[prefix],
+                    "params": [params[k] for k in sorted(override_groups[prefix])],
+                }
+                for prefix in sorted(overrides)
+            ),
         ]
 
         super().__init__(params=param_groups, **kwargs)

--- a/src/rmind/components/transformer/causal_frame.py
+++ b/src/rmind/components/transformer/causal_frame.py
@@ -114,7 +114,7 @@ def frame_block_causal_mask(
     delta = frames[:, None] - frames[None, :]  # query frame - key frame
     blocked = delta < 0  # future frames
     if window is not None:
-        blocked = blocked | (delta > window - 1)  # evicted frames
+        blocked |= delta > window - 1  # evicted frames
     return blocked
 
 
@@ -136,6 +136,9 @@ def frame_rope_cos_sin(
     Note the intra-frame cancellation `(Rq)ᵀ(Rk) = qᵀk` is algebraically exact but
     numerically only as exact as `cos² + sin² = 1` in `dtype`; at float32 that is
     ~1e-7 relative, well inside the 1e-6 cache gate.
+
+    Raises:
+        ValueError: if `head_dim` is odd.
     """
     if head_dim % 2:
         msg = f"head_dim must be even for RoPE, got {head_dim}"
@@ -167,9 +170,7 @@ class CausalSelfAttention(nn.Module):
     positional embedding differs, and that is the intended change.
     """
 
-    def __init__(
-        self, *, dim_model: int, num_heads: int, dropout: float = 0.1
-    ) -> None:
+    def __init__(self, *, dim_model: int, num_heads: int, dropout: float = 0.1) -> None:
         super().__init__()
         if dim_model % num_heads:
             msg = f"dim_model {dim_model} not divisible by num_heads {num_heads}"
@@ -205,15 +206,11 @@ class CausalSelfAttention(nn.Module):
         q, k, v = self._qkv(x)
         q, k = apply_rope(q, cos, sin), apply_rope(k, cos, sin)
         attn = F.scaled_dot_product_attention(
-            q,
-            k,
-            v,
-            attn_mask=~mask,
-            dropout_p=self.dropout if self.training else 0.0,
+            q, k, v, attn_mask=~mask, dropout_p=self.dropout if self.training else 0.0
         )
         return self._out(attn)
 
-    def step(
+    def step(  # noqa: PLR0913, PLR0917
         self,
         x: Tensor,
         cos: Tensor,
@@ -221,6 +218,8 @@ class CausalSelfAttention(nn.Module):
         past_k: Tensor,
         past_v: Tensor,
         cache_bias: Tensor,
+        *,
+        readout_only: bool = False,
     ) -> tuple[Tensor, Tensor, Tensor]:
         """One frame's `tokens_per_frame` queries against the cache plus itself.
 
@@ -229,6 +228,11 @@ class CausalSelfAttention(nn.Module):
         frame). The only masking is `cache_bias`, which zeroes out unfilled ring
         slots.
 
+        `readout_only` computes the attention output for the LAST query position
+        only -- the head reads a single token per frame (§3.3 of the hand-off), so
+        in the final block the other `tokens_per_frame - 1` outputs are discarded.
+        K/V are still produced for every position; future frames attend to them.
+
         Returns `(out, new_k, new_v)` where the K/V are for the new frame only.
         """
         q, k, v = self._qkv(x)
@@ -236,32 +240,8 @@ class CausalSelfAttention(nn.Module):
         keys = torch.cat((past_k, k), dim=-2)
         values = torch.cat((past_v, v), dim=-2)
         bias = F.pad(cache_bias, (0, x.shape[1]))  # own-frame keys always visible
-        attn = F.scaled_dot_product_attention(q, keys, values, attn_mask=bias)
-        return self._out(attn), k, v
-
-    def step_readout(
-        self,
-        x: Tensor,
-        cos: Tensor,
-        sin: Tensor,
-        past_k: Tensor,
-        past_v: Tensor,
-        cache_bias: Tensor,
-    ) -> tuple[Tensor, Tensor, Tensor]:
-        """`step`, but only the LAST query position's output is computed.
-
-        The head reads a single token per frame (§3.3 of the hand-off), so in the
-        final block the attention output and MLP for the other
-        `tokens_per_frame - 1` positions are discarded. K/V are still produced
-        for all positions -- future frames attend to them.
-        """
-        q, k, v = self._qkv(x)
-        q, k = apply_rope(q, cos, sin), apply_rope(k, cos, sin)
-        keys = torch.cat((past_k, k), dim=-2)
-        values = torch.cat((past_v, v), dim=-2)
-        bias = F.pad(cache_bias, (0, x.shape[1]))
         attn = F.scaled_dot_product_attention(
-            q[:, :, -1:], keys, values, attn_mask=bias
+            q[:, :, -1:] if readout_only else q, keys, values, attn_mask=bias
         )
         return self._out(attn), k, v
 
@@ -301,7 +281,7 @@ class CausalFrameTransformerBlock(nn.Module):
         h = x + self.resid_drop(attn_out)
         return h + self.mlp(self.mlp_norm(h))
 
-    def step(  # noqa: PLR0913
+    def step(  # noqa: PLR0913, PLR0917
         self,
         x: Tensor,
         cos: Tensor,
@@ -312,8 +292,15 @@ class CausalFrameTransformerBlock(nn.Module):
         *,
         readout_only: bool = False,
     ) -> tuple[Tensor, Tensor, Tensor]:
-        fn = self.attn.step_readout if readout_only else self.attn.step
-        attn_out, k, v = fn(self.attn_norm(x), cos, sin, past_k, past_v, cache_bias)
+        attn_out, k, v = self.attn.step(
+            self.attn_norm(x),
+            cos,
+            sin,
+            past_k,
+            past_v,
+            cache_bias,
+            readout_only=readout_only,
+        )
         if readout_only:
             x = x[:, -1:]
         h = x + attn_out
@@ -339,12 +326,29 @@ class CausalFrameTransformer(nn.Module):
         tokens_per_frame: int,
         window: int | None = None,
         rope_base: float = 1000.0,
+        max_sequence_length: int | None = None,
         attn_dropout: float = 0.1,
         resid_dropout: float = 0.1,
         mlp_dropout: float = 0.1,
         hidden_layer_multiplier: int = 4,
     ) -> None:
         super().__init__()
+        # There is no learned positional table over the flattened sequence any
+        # more, so this trunk has no intrinsic maximum length. The argument
+        # exists so the hydra `encoder` node can be overridden in place (the
+        # block-causal trunk in config/model/yaak/patch_policy/raw.yaml sets
+        # `max_sequence_length: episode_length * (num_patches + 1)`), and it is
+        # cross-checked rather than ignored.
+        if max_sequence_length is not None:
+            expected = (window or 0) * tokens_per_frame
+            if max_sequence_length != expected:
+                msg = (
+                    f"max_sequence_length {max_sequence_length} != window * "
+                    f"tokens_per_frame {expected}; the training window and the "
+                    "serving cache capacity must agree (hand-off §6)"
+                )
+                raise ValueError(msg)
+
         self.dim_model = dim_model
         self.num_layers = num_layers
         self.num_heads = num_heads
@@ -378,16 +382,17 @@ class CausalFrameTransformer(nn.Module):
         return self.intra_position_embedding(idx).repeat(num_frames, 1)
 
     @override
-    def forward(
-        self, src: Tensor, *, num_frames: int, frame_offset: int = 0
-    ) -> Tensor:
+    def forward(self, src: Tensor, *, num_frames: int, frame_offset: int = 0) -> Tensor:
         """Full-sequence forward over `num_frames * tokens_per_frame` tokens.
 
         `frame_offset` shifts the episode-absolute frame indices used by RoPE.
         The output must be invariant to it -- that is the property the old
         window-absolute embedding lacked, and it is asserted in the tests.
+
+        Raises:
+            ValueError: if `src` is not `num_frames * tokens_per_frame` long.
         """
-        b, seq_len, _ = src.shape
+        _b, seq_len, _ = src.shape
         k = self.tokens_per_frame
         if seq_len != num_frames * k:
             msg = f"expected {num_frames * k} tokens, got {seq_len}"
@@ -425,6 +430,9 @@ class CausalFrameTransformer(nn.Module):
         K/V are `(num_layers, batch, num_heads, cache_frames * tokens_per_frame,
         head_dim)`; `cache_bias` is `(1, 1, 1, cache_frames * tokens_per_frame)`
         filled with `MASK_BIAS` (nothing valid yet).
+
+        Raises:
+            ValueError: if neither `cache_frames` nor `window` is set.
         """
         n = cache_frames
         if n is None and self.window is not None:
@@ -441,10 +449,7 @@ class CausalFrameTransformer(nn.Module):
         )
         zeros = torch.zeros(shape, device=device, dtype=dtype)
         bias = torch.full(
-            (1, 1, 1, n * self.tokens_per_frame),
-            MASK_BIAS,
-            device=device,
-            dtype=dtype,
+            (1, 1, 1, n * self.tokens_per_frame), MASK_BIAS, device=device, dtype=dtype
         )
         return zeros, zeros.clone(), bias
 

--- a/src/rmind/components/transformer/causal_frame.py
+++ b/src/rmind/components/transformer/causal_frame.py
@@ -76,11 +76,18 @@ picks how the mask is realized:
 * `"flex"` -- the same mask as a `BlockMask` for `torch.nn.attention.
   flex_attention`, whose Triton kernel skips whole 128x128 blocks. Cost becomes
   proportional to the *unmasked* area, `O(F * window * 257^2)`, i.e. linear in
-  context length at fixed window. Measured on a 5090 (bf16, fwd+bwd, one layer,
-  batch 4, 512-d/8-head): 6 frames 1.06 -> 0.69 ms, 32 frames/window 16
-  23.7 -> 5.3 ms (4.5x), 64 frames/window 16 93.6 -> 11.8 ms (7.9x). Numerically
-  identical to `"sdpa"` to ~4e-6 in fp32, forward and backward
-  (`tests/test_causal_frame.py`).
+  context length at fixed window. Measured on a 5090 (bf16, fwd+bwd, one attention
+  layer, batch 16, 512-d/8-head, `tests/bench_causal_frame.py`): 6 frames
+  4.2 -> 2.1 ms, 32 frames/window 16 95.0 -> 24.4 ms (3.9x), 64 frames/window 16
+  377.4 -> 54.7 ms (6.9x). Over the whole trunk at a constant 768 frame-slots per
+  step, 32-frame/window-16 training costs 1.08x today's 6-frame dense step
+  (dense SDPA would be 2.74x) -- see §11 of docs/decoder_only_kv_cache.md.
+  Numerically identical to `"sdpa"` to <=1.5e-6 scale-relative in fp32, forward and
+  backward (`tests/test_causal_frame.py`).
+
+  It is NOT a free win at small shapes: at batch 4 / 6 frames flex is slower than
+  sdpa (the mask has 13 kv blocks and cannot fill the GPU). The crossover is around
+  1000 frame-slots per step, which is why `"sdpa"` remains the default.
 
 Two constraints on `"flex"`, both deliberate rather than incidental:
 `attn_dropout` must be 0 (FlexAttention has no `dropout_p`, and the constructor

--- a/src/rmind/components/transformer/causal_frame.py
+++ b/src/rmind/components/transformer/causal_frame.py
@@ -444,6 +444,32 @@ class CausalSelfAttention(nn.Module):
 
 
 @final
+class DropPath(nn.Module):
+    """Stochastic depth (https://arxiv.org/abs/1603.09382): drop the whole
+    residual branch per sample with probability `drop_prob` during training,
+    rescaling survivors by `1/keep`; exact identity in eval, so the streaming
+    equivalence gate and the export `step` path are untouched.
+    """
+
+    def __init__(self, drop_prob: float = 0.0) -> None:
+        super().__init__()
+        if not 0.0 <= drop_prob < 1.0:
+            msg = f"drop_prob must be in [0, 1), got {drop_prob}"
+            raise ValueError(msg)
+        self.drop_prob = drop_prob
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        if not self.drop_prob or not self.training:
+            return x
+        keep = 1.0 - self.drop_prob
+        # fresh tensor, filled in place before entering the autograd graph --
+        # no in-place ops on the residual stream (checkpointing)
+        gate = x.new_empty((x.shape[0],) + (1,) * (x.ndim - 1)).bernoulli_(keep)
+        return x * (gate / keep)
+
+
+@final
 class CausalFrameTransformerBlock(nn.Module):
     """Pre-LN GPT block, structurally identical to `patch_policy.TransformerBlock`."""
 
@@ -457,8 +483,10 @@ class CausalFrameTransformerBlock(nn.Module):
         mlp_dropout: float = 0.1,
         hidden_layer_multiplier: int = 4,
         attention_impl: AttentionImpl = "sdpa",
+        drop_path: float = 0.0,
     ) -> None:
         super().__init__()
+        self.drop_path = DropPath(drop_path)
         self.attn_norm = nn.LayerNorm(dim_model)
         self.attn = CausalSelfAttention(
             dim_model=dim_model,
@@ -481,8 +509,8 @@ class CausalFrameTransformerBlock(nn.Module):
     ) -> Tensor:
         attn_out = self.attn(self.attn_norm(x), cos, sin, mask)
         # NOTE: no in-place ops on the residual stream (autograd + checkpointing)
-        h = x + self.resid_drop(attn_out)
-        return h + self.mlp(self.mlp_norm(h))
+        h = x + self.drop_path(self.resid_drop(attn_out))
+        return h + self.drop_path(self.mlp(self.mlp_norm(h)))
 
     def step(  # noqa: PLR0913, PLR0917
         self,
@@ -535,6 +563,7 @@ class CausalFrameTransformer(nn.Module):
         mlp_dropout: float = 0.1,
         hidden_layer_multiplier: int = 4,
         attention_impl: AttentionImpl = "sdpa",
+        drop_path_rate: float = 0.0,
     ) -> None:
         super().__init__()
         # There is no learned positional table over the flattened sequence any
@@ -577,6 +606,9 @@ class CausalFrameTransformer(nn.Module):
         nn.init.trunc_normal_(
             self.intra_position_embedding.weight, mean=0.0, std=0.02, a=-0.04, b=0.04
         )
+        # stochastic depth: timm-style linear ramp, 0 at the first layer up to
+        # drop_path_rate at the last (deeper layers are the more redundant ones)
+        self.drop_path_rate = drop_path_rate
         self.layers = nn.ModuleList([
             CausalFrameTransformerBlock(
                 dim_model=dim_model,
@@ -586,8 +618,9 @@ class CausalFrameTransformer(nn.Module):
                 mlp_dropout=mlp_dropout,
                 hidden_layer_multiplier=hidden_layer_multiplier,
                 attention_impl=attention_impl,
+                drop_path=drop_path_rate * i / max(num_layers - 1, 1),
             )
-            for _ in range(num_layers)
+            for i in range(num_layers)
         ])
         self.norm = nn.LayerNorm(dim_model)
 

--- a/src/rmind/components/transformer/causal_frame.py
+++ b/src/rmind/components/transformer/causal_frame.py
@@ -169,6 +169,14 @@ def frame_block_causal_mask_mod(
     Note the inverted convention: `frame_block_causal_mask` returns True for
     *blocked*, a `mask_mod` returns True for *keep*. The predicate is the same
     frame-delta comparison, evaluated on index tensors instead of materialized.
+
+    ⚠️ Every operation here must be OUT-OF-PLACE. Inductor lowers a `mask_mod` as a
+    pointwise subgraph, and an in-place op inside one fails to compile with
+    "SubgraphLoweringException: Buffers cannot be created while lowering a pointwise
+    subgraph" -- for every shape, so the flex path is simply dead. This is a live
+    hazard rather than a hypothetical: `ruff check` (this repo runs it with
+    `fix = true, unsafe-fixes = true`) rewrites `keep = keep & x` into `keep &= x`
+    under PLR6104 and thereby breaks it, hence the `noqa` below.
     """
 
     def mask_mod(b: Tensor, h: Tensor, q_idx: Tensor, kv_idx: Tensor) -> Tensor:
@@ -176,7 +184,7 @@ def frame_block_causal_mask_mod(
         delta = q_idx // tokens_per_frame - kv_idx // tokens_per_frame
         keep = delta >= 0
         if window is not None:
-            keep &= delta <= window - 1
+            keep = keep & (delta <= window - 1)  # noqa: PLR6104
         return keep
 
     return mask_mod
@@ -231,7 +239,7 @@ def _compiled_flex_attention() -> Callable[..., Tensor]:
     Compiled lazily so importing this module (which the ONNX export path does)
     never pays for it.
     """
-    return torch.compile(flex_attention, dynamic=False)
+    return torch.compile(flex_attention, dynamic=False)  # ty:ignore[no-matching-overload]
 
 
 def flex_frame_attention(

--- a/src/rmind/components/transformer/causal_frame.py
+++ b/src/rmind/components/transformer/causal_frame.py
@@ -1,0 +1,496 @@
+"""Causal-over-frames transformer trunk with a reusable, bounded KV cache.
+
+This is the decoder-only reformulation of `rmind.models.patch_policy.
+BlockCausalTransformer`. Same pre-LN GPT blocks, same widths, same
+`nn.MultiheadAttention` parameter layout -- the only architectural change is the
+positional encoding, and that change is what makes a KV cache *valid*.
+
+Why the original cannot cache
+-----------------------------
+`BlockCausalTransformer` adds a learned 1D embedding over the flattened
+`num_frames * tokens_per_frame` sequence. That index is **window-absolute**:
+slot 0 always means "oldest frame currently in the sliding window". When the
+window slides, every frame's positional input changes, so every cached key is
+stale. Nothing is reusable even though most frames are unchanged.
+
+The replacement is factorized, and each factor is chosen to be stable under a
+sliding window:
+
+* **intra-frame position: a learned `tokens_per_frame`-slot embedding**, tiled
+  identically onto every frame. Token *k* of frame *f* always gets
+  `intra_position_embedding[k]`, for every *f*. Frame-relative by construction,
+  so it never goes stale. This preserves exactly the intra-frame capacity the
+  1542-slot embedding had (patch identity, and speed-token vs patch-token
+  identity) -- nothing is dropped.
+* **inter-frame position: RoPE at *frame* granularity** applied to q and k in
+  every layer. All `tokens_per_frame` tokens of a frame share one rotation
+  `R_f`, so:
+
+  - intra-frame attention is **exactly unrotated** -- `(R_f q)ᵀ(R_f k) = qᵀk` --
+    hence still fully bidirectional and ordered only by the intra-frame
+    embedding above;
+  - inter-frame attention depends only on `f_q - f_k`, so a key rotated with its
+    own absolute frame index stays valid forever, at any future window position.
+    That is precisely the cache-safety property.
+
+RoPE is applied with the frame's **episode-absolute** index. Any monotone
+counter works (only differences matter); reset it at episode boundaries. The
+per-tick `cos`/`sin` are *inputs* to `step`, not computed in-graph, so an
+exported engine contains **no `Sin`/`Cos` nodes** (see
+`/nasa/max/skills/trt-export/SKILL.md` §2 -- trigonometric ops are the most
+fp16-fragile part of the DINOv3 family) and the host keeps the counter in fp64.
+
+Cache contract
+--------------
+`step` takes `past_k`/`past_v` **read-only** and returns only the *new* frame's
+K/V. The ring buffer lives in the host, not the graph: no in-graph scatter, no
+`ScatterElements` in TRT, and the cache tensors are plain engine I/O. Layout is
+a single stacked tensor per side:
+
+    (num_layers, batch, num_heads, cache_frames * tokens_per_frame, head_dim)
+
+Slot validity is a host-supplied additive `cache_bias` of shape
+`(1, 1, 1, cache_frames * tokens_per_frame)` -- `0` for a filled slot, a large
+negative value for an empty one. A cold cache is therefore the same graph, and
+the same cost, as a warm one.
+
+Streaming/recompute equivalence
+-------------------------------
+Streaming one frame per tick against a ring of capacity `N` frames is
+**exactly** a single full forward over the whole episode under
+`frame_block_causal_mask(..., window=N)`: in both, frame *f*'s layer-*l* input
+attends to frames `[f-N+1 .. f]`. That equivalence is the correctness gate (see
+`tests/test_causal_frame.py`) and it is also the statement "train the way you
+infer" -- train with `window=N`, serve with a ring of `N`.
+
+Note what is *not* equal, and cannot be for any bounded window with more than
+one layer: re-running frames `[1..6]` as a fresh isolated 6-frame episode. There
+frame 5 never saw frame 0, whereas in the stream its layer-2+ K/V were produced
+with frame 0 in context. That is a property of bounded attention, not a cache
+defect.
+"""
+
+from typing import final, override
+
+import torch
+from torch import Tensor, nn
+from torch.nn import functional as F
+
+from rmind.components.transformer.utils import run_layer_stack
+
+__all__ = [
+    "CausalFrameTransformer",
+    "CausalFrameTransformerBlock",
+    "CausalSelfAttention",
+    "frame_block_causal_mask",
+    "frame_rope_cos_sin",
+]
+
+# additive bias for a masked-out position; finite so an fp16 engine cannot
+# produce NaN from -inf * 0 in a fused softmax
+MASK_BIAS: float = -1e4
+
+
+def frame_block_causal_mask(
+    num_frames: int,
+    tokens_per_frame: int,
+    *,
+    window: int | None = None,
+    device: torch.device | None = None,
+) -> Tensor:
+    """Bool mask (True = blocked) over the flattened sequence.
+
+    Bidirectional within a frame, causal across frames -- identical to
+    `rmind.models.patch_policy.block_causal_mask` when `window is None`.
+
+    `window=N` additionally blocks frames more than `N - 1` older than the
+    query's frame, i.e. every frame attends to itself plus the `N - 1` frames
+    before it. That is the exact full-sequence equivalent of streaming against a
+    KV ring buffer of capacity `N` frames.
+    """
+    frames = (
+        torch.arange(num_frames * tokens_per_frame, device=device) // tokens_per_frame
+    )
+    delta = frames[:, None] - frames[None, :]  # query frame - key frame
+    blocked = delta < 0  # future frames
+    if window is not None:
+        blocked = blocked | (delta > window - 1)  # evicted frames
+    return blocked
+
+
+def frame_rope_cos_sin(
+    frame_index: Tensor,
+    *,
+    head_dim: int,
+    base: float = 1000.0,
+    dtype: torch.dtype = torch.float32,
+) -> tuple[Tensor, Tensor]:
+    """`cos`/`sin` of shape `(*frame_index.shape, head_dim)` for frame RoPE.
+
+    Computed in float64 so a long-episode absolute frame counter stays exact,
+    then cast to `dtype` -- float32 by default, which is the serving contract
+    (drivr computes these host-side and feeds them as engine inputs). `head_dim`
+    must be even; the half-split (GPT-NeoX/Llama) pairing is used, matching every
+    mainstream `torch.export`-friendly RoPE implementation.
+
+    Note the intra-frame cancellation `(Rq)ᵀ(Rk) = qᵀk` is algebraically exact but
+    numerically only as exact as `cos² + sin² = 1` in `dtype`; at float32 that is
+    ~1e-7 relative, well inside the 1e-6 cache gate.
+    """
+    if head_dim % 2:
+        msg = f"head_dim must be even for RoPE, got {head_dim}"
+        raise ValueError(msg)
+    inv_freq = base ** (
+        -torch.arange(0, head_dim, 2, dtype=torch.float64, device=frame_index.device)
+        / head_dim
+    )
+    angle = frame_index.to(torch.float64)[..., None] * inv_freq
+    return (
+        torch.cat((angle.cos(), angle.cos()), dim=-1).to(dtype),
+        torch.cat((angle.sin(), angle.sin()), dim=-1).to(dtype),
+    )
+
+
+def apply_rope(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    """Rotate `x` `(b, h, s, head_dim)` by `cos`/`sin` broadcast over `(s, head_dim)`."""
+    x1, x2 = x.chunk(2, dim=-1)
+    return x * cos + torch.cat((-x2, x1), dim=-1) * sin
+
+
+@final
+class CausalSelfAttention(nn.Module):
+    """Multi-head self-attention with frame RoPE and an optional read-only KV cache.
+
+    Parameter layout is **identical to `nn.MultiheadAttention(batch_first=True)`**
+    (`in_proj_weight`, `in_proj_bias`, `out_proj.{weight,bias}`), so a trunk
+    trained with `BlockCausalTransformer` loads into this one 1:1 -- only the
+    positional embedding differs, and that is the intended change.
+    """
+
+    def __init__(
+        self, *, dim_model: int, num_heads: int, dropout: float = 0.1
+    ) -> None:
+        super().__init__()
+        if dim_model % num_heads:
+            msg = f"dim_model {dim_model} not divisible by num_heads {num_heads}"
+            raise ValueError(msg)
+        self.dim_model = dim_model
+        self.num_heads = num_heads
+        self.head_dim = dim_model // num_heads
+        self.dropout = dropout
+
+        # nn.MultiheadAttention's own initialization, so a randomly-initialized
+        # CausalFrameTransformer is distributionally identical to the reference
+        self.in_proj_weight = nn.Parameter(torch.empty(3 * dim_model, dim_model))
+        self.in_proj_bias = nn.Parameter(torch.zeros(3 * dim_model))
+        nn.init.xavier_uniform_(self.in_proj_weight)
+        self.out_proj = nn.Linear(dim_model, dim_model)
+        nn.init.constant_(self.out_proj.bias, 0.0)
+
+    def _qkv(self, x: Tensor) -> tuple[Tensor, Tensor, Tensor]:
+        b, s, _ = x.shape
+        qkv = F.linear(x, self.in_proj_weight, self.in_proj_bias)
+        return tuple(  # ty:ignore[invalid-return-type]
+            t.view(b, s, self.num_heads, self.head_dim).transpose(1, 2)
+            for t in qkv.chunk(3, dim=-1)
+        )
+
+    def _out(self, attn: Tensor) -> Tensor:
+        b, _, s, _ = attn.shape
+        return self.out_proj(attn.transpose(1, 2).reshape(b, s, self.dim_model))
+
+    @override
+    def forward(self, x: Tensor, cos: Tensor, sin: Tensor, mask: Tensor) -> Tensor:
+        """Full-sequence forward. `mask` is the bool block-causal mask."""
+        q, k, v = self._qkv(x)
+        q, k = apply_rope(q, cos, sin), apply_rope(k, cos, sin)
+        attn = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=~mask,
+            dropout_p=self.dropout if self.training else 0.0,
+        )
+        return self._out(attn)
+
+    def step(
+        self,
+        x: Tensor,
+        cos: Tensor,
+        sin: Tensor,
+        past_k: Tensor,
+        past_v: Tensor,
+        cache_bias: Tensor,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """One frame's `tokens_per_frame` queries against the cache plus itself.
+
+        No causal mask is needed: every cached key is in the past (causal by
+        construction) and every own-frame key is visible (bidirectional within a
+        frame). The only masking is `cache_bias`, which zeroes out unfilled ring
+        slots.
+
+        Returns `(out, new_k, new_v)` where the K/V are for the new frame only.
+        """
+        q, k, v = self._qkv(x)
+        q, k = apply_rope(q, cos, sin), apply_rope(k, cos, sin)
+        keys = torch.cat((past_k, k), dim=-2)
+        values = torch.cat((past_v, v), dim=-2)
+        bias = F.pad(cache_bias, (0, x.shape[1]))  # own-frame keys always visible
+        attn = F.scaled_dot_product_attention(q, keys, values, attn_mask=bias)
+        return self._out(attn), k, v
+
+    def step_readout(
+        self,
+        x: Tensor,
+        cos: Tensor,
+        sin: Tensor,
+        past_k: Tensor,
+        past_v: Tensor,
+        cache_bias: Tensor,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """`step`, but only the LAST query position's output is computed.
+
+        The head reads a single token per frame (§3.3 of the hand-off), so in the
+        final block the attention output and MLP for the other
+        `tokens_per_frame - 1` positions are discarded. K/V are still produced
+        for all positions -- future frames attend to them.
+        """
+        q, k, v = self._qkv(x)
+        q, k = apply_rope(q, cos, sin), apply_rope(k, cos, sin)
+        keys = torch.cat((past_k, k), dim=-2)
+        values = torch.cat((past_v, v), dim=-2)
+        bias = F.pad(cache_bias, (0, x.shape[1]))
+        attn = F.scaled_dot_product_attention(
+            q[:, :, -1:], keys, values, attn_mask=bias
+        )
+        return self._out(attn), k, v
+
+
+@final
+class CausalFrameTransformerBlock(nn.Module):
+    """Pre-LN GPT block, structurally identical to `patch_policy.TransformerBlock`."""
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        dim_model: int,
+        num_heads: int,
+        attn_dropout: float = 0.1,
+        resid_dropout: float = 0.1,
+        mlp_dropout: float = 0.1,
+        hidden_layer_multiplier: int = 4,
+    ) -> None:
+        super().__init__()
+        self.attn_norm = nn.LayerNorm(dim_model)
+        self.attn = CausalSelfAttention(
+            dim_model=dim_model, num_heads=num_heads, dropout=attn_dropout
+        )
+        self.resid_drop = nn.Dropout(resid_dropout)
+        self.mlp_norm = nn.LayerNorm(dim_model)
+        self.mlp = nn.Sequential(
+            nn.Linear(dim_model, hidden_layer_multiplier * dim_model),
+            nn.GELU(),
+            nn.Linear(hidden_layer_multiplier * dim_model, dim_model),
+            nn.Dropout(mlp_dropout),
+        )
+
+    @override
+    def forward(self, x: Tensor, cos: Tensor, sin: Tensor, mask: Tensor) -> Tensor:
+        attn_out = self.attn(self.attn_norm(x), cos, sin, mask)
+        # NOTE: no in-place ops on the residual stream (autograd + checkpointing)
+        h = x + self.resid_drop(attn_out)
+        return h + self.mlp(self.mlp_norm(h))
+
+    def step(  # noqa: PLR0913
+        self,
+        x: Tensor,
+        cos: Tensor,
+        sin: Tensor,
+        past_k: Tensor,
+        past_v: Tensor,
+        cache_bias: Tensor,
+        *,
+        readout_only: bool = False,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        fn = self.attn.step_readout if readout_only else self.attn.step
+        attn_out, k, v = fn(self.attn_norm(x), cos, sin, past_k, past_v, cache_bias)
+        if readout_only:
+            x = x[:, -1:]
+        h = x + attn_out
+        return h + self.mlp(self.mlp_norm(h)), k, v
+
+
+@final
+class CausalFrameTransformer(nn.Module):
+    """Decoder over frame blocks: bidirectional intra-frame, causal inter-frame.
+
+    Drop-in for `BlockCausalTransformer` on the training path -- same
+    `forward(src, *, num_frames)` signature -- plus a `step` that consumes and
+    extends a KV cache. See the module docstring for the positional scheme and
+    the cache contract.
+    """
+
+    def __init__(  # noqa: PLR0913
+        self,
+        *,
+        dim_model: int,
+        num_layers: int,
+        num_heads: int,
+        tokens_per_frame: int,
+        window: int | None = None,
+        rope_base: float = 1000.0,
+        attn_dropout: float = 0.1,
+        resid_dropout: float = 0.1,
+        mlp_dropout: float = 0.1,
+        hidden_layer_multiplier: int = 4,
+    ) -> None:
+        super().__init__()
+        self.dim_model = dim_model
+        self.num_layers = num_layers
+        self.num_heads = num_heads
+        self.head_dim = dim_model // num_heads
+        self.tokens_per_frame = tokens_per_frame
+        self.window = window
+        self.rope_base = rope_base
+
+        # frame-RELATIVE intra-frame position: tiled onto every frame, so it is
+        # invariant to where the frame sits in the window (unlike the 1542-slot
+        # window-absolute embedding it replaces)
+        self.intra_position_embedding = nn.Embedding(tokens_per_frame, dim_model)
+        nn.init.trunc_normal_(
+            self.intra_position_embedding.weight, mean=0.0, std=0.02, a=-0.04, b=0.04
+        )
+        self.layers = nn.ModuleList([
+            CausalFrameTransformerBlock(
+                dim_model=dim_model,
+                num_heads=num_heads,
+                attn_dropout=attn_dropout,
+                resid_dropout=resid_dropout,
+                mlp_dropout=mlp_dropout,
+                hidden_layer_multiplier=hidden_layer_multiplier,
+            )
+            for _ in range(num_layers)
+        ])
+        self.norm = nn.LayerNorm(dim_model)
+
+    def _intra(self, num_frames: int, device: torch.device) -> Tensor:
+        idx = torch.arange(self.tokens_per_frame, device=device)
+        return self.intra_position_embedding(idx).repeat(num_frames, 1)
+
+    @override
+    def forward(
+        self, src: Tensor, *, num_frames: int, frame_offset: int = 0
+    ) -> Tensor:
+        """Full-sequence forward over `num_frames * tokens_per_frame` tokens.
+
+        `frame_offset` shifts the episode-absolute frame indices used by RoPE.
+        The output must be invariant to it -- that is the property the old
+        window-absolute embedding lacked, and it is asserted in the tests.
+        """
+        b, seq_len, _ = src.shape
+        k = self.tokens_per_frame
+        if seq_len != num_frames * k:
+            msg = f"expected {num_frames * k} tokens, got {seq_len}"
+            raise ValueError(msg)
+
+        x = src + self._intra(num_frames, src.device)
+        frames = torch.arange(seq_len, device=src.device) // k + frame_offset
+        cos, sin = frame_rope_cos_sin(
+            frames, head_dim=self.head_dim, base=self.rope_base
+        )
+        cos, sin = cos.to(src.dtype), sin.to(src.dtype)
+        mask = frame_block_causal_mask(
+            num_frames, k, window=self.window, device=src.device
+        )
+
+        x = run_layer_stack(self.layers, x, cos, sin, mask, training=self.training)
+        return self.norm(x)
+
+    def empty_cache(
+        self,
+        *,
+        batch_size: int = 1,
+        cache_frames: int | None = None,
+        device: torch.device | None = None,
+        dtype: torch.dtype = torch.float32,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """`(past_k, past_v, cache_bias)` for a cold cache.
+
+        `cache_frames` is the number of PAST frames held; it defaults to
+        `window - 1`, since a context of `window` frames is the current frame
+        plus `window - 1` cached ones. For `window=6` that is 5 * 257 = 1285
+        cached keys against 257 queries -- 1542 keys in total, exactly the
+        baseline's flattened sequence length.
+
+        K/V are `(num_layers, batch, num_heads, cache_frames * tokens_per_frame,
+        head_dim)`; `cache_bias` is `(1, 1, 1, cache_frames * tokens_per_frame)`
+        filled with `MASK_BIAS` (nothing valid yet).
+        """
+        n = cache_frames
+        if n is None and self.window is not None:
+            n = self.window - 1
+        if n is None:
+            msg = "cache_frames required when window is None"
+            raise ValueError(msg)
+        shape = (
+            self.num_layers,
+            batch_size,
+            self.num_heads,
+            n * self.tokens_per_frame,
+            self.head_dim,
+        )
+        zeros = torch.zeros(shape, device=device, dtype=dtype)
+        bias = torch.full(
+            (1, 1, 1, n * self.tokens_per_frame),
+            MASK_BIAS,
+            device=device,
+            dtype=dtype,
+        )
+        return zeros, zeros.clone(), bias
+
+    def step(  # noqa: PLR0913
+        self,
+        src: Tensor,
+        *,
+        past_k: Tensor,
+        past_v: Tensor,
+        cos: Tensor,
+        sin: Tensor,
+        cache_bias: Tensor,
+        readout_only_final_block: bool = False,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """Decode ONE frame against a read-only cache.
+
+        `src` is `(b, tokens_per_frame, d)`. `cos`/`sin` are `(1, head_dim)` or
+        `(head_dim,)` -- the current frame's rotation, computed host-side from
+        the episode frame counter (`frame_rope_cos_sin`) so the graph has no
+        trigonometric nodes.
+
+        Returns `(out, new_k, new_v)`. `out` is the normed trunk output for the
+        frame -- all `tokens_per_frame` positions, or just the readout position
+        when `readout_only_final_block`. `new_k`/`new_v` are
+        `(num_layers, b, num_heads, tokens_per_frame, head_dim)`: the host writes
+        them into its ring buffer.
+        """
+        x = src + self.intra_position_embedding(
+            torch.arange(src.shape[1], device=src.device)
+        )
+        cos = cos.reshape(1, 1, 1, self.head_dim).to(x.dtype)
+        sin = sin.reshape(1, 1, 1, self.head_dim).to(x.dtype)
+
+        new_k: list[Tensor] = []
+        new_v: list[Tensor] = []
+        last = self.num_layers - 1
+        for i, layer in enumerate(self.layers):
+            x, k, v = layer.step(
+                x,
+                cos,
+                sin,
+                past_k[i],
+                past_v[i],
+                cache_bias,
+                readout_only=readout_only_final_block and i == last,
+            )
+            new_k.append(k)
+            new_v.append(v)
+        return self.norm(x), torch.stack(new_k), torch.stack(new_v)

--- a/src/rmind/components/transformer/causal_frame.py
+++ b/src/rmind/components/transformer/causal_frame.py
@@ -339,13 +339,21 @@ class CausalFrameTransformer(nn.Module):
         # block-causal trunk in config/model/yaak/patch_policy/raw.yaml sets
         # `max_sequence_length: episode_length * (num_patches + 1)`), and it is
         # cross-checked rather than ignored.
-        if max_sequence_length is not None:
-            expected = (window or 0) * tokens_per_frame
-            if max_sequence_length != expected:
+        #
+        # The check is `>=`, not `==`, deliberately: a clip LONGER than the window is
+        # the configuration sliding-window attention exists for (e.g. train on
+        # 64-frame clips with a 32-frame window, so most readouts see a full window).
+        # A clip SHORTER than the window is the error -- it silently trains a
+        # narrower context than will be served, which is the train/infer mismatch
+        # the hand-off warns about in §6.
+        if max_sequence_length is not None and window is not None:
+            minimum = window * tokens_per_frame
+            if max_sequence_length < minimum:
                 msg = (
-                    f"max_sequence_length {max_sequence_length} != window * "
-                    f"tokens_per_frame {expected}; the training window and the "
-                    "serving cache capacity must agree (hand-off §6)"
+                    f"max_sequence_length {max_sequence_length} < window * "
+                    f"tokens_per_frame {minimum}: the clip is shorter than the "
+                    "attention window, so training would never see a full window "
+                    "while serving always will (hand-off §6)"
                 )
                 raise ValueError(msg)
 

--- a/src/rmind/components/transformer/causal_frame.py
+++ b/src/rmind/components/transformer/causal_frame.py
@@ -63,6 +63,30 @@ attends to frames `[f-N+1 .. f]`. That equivalence is the correctness gate (see
 `tests/test_causal_frame.py`) and it is also the statement "train the way you
 infer" -- train with `window=N`, serve with a ring of `N`.
 
+Training cost: the mask is block-sparse, so use a block-sparse kernel
+------------------------------------------------------------------------
+The KV cache makes *serving* cost independent of the window; it does nothing for
+training, which is still one dense forward over the whole clip. `attention_impl`
+picks how the mask is realized:
+
+* `"sdpa"` (default, unchanged behaviour) -- a materialized bool mask handed to
+  `F.scaled_dot_product_attention`. Any `attn_mask` disqualifies the flash
+  backend, so every masked position is still computed: cost is `O((F*257)^2)`
+  regardless of `window`.
+* `"flex"` -- the same mask as a `BlockMask` for `torch.nn.attention.
+  flex_attention`, whose Triton kernel skips whole 128x128 blocks. Cost becomes
+  proportional to the *unmasked* area, `O(F * window * 257^2)`, i.e. linear in
+  context length at fixed window. Measured on a 5090 (bf16, fwd+bwd, one layer,
+  batch 4, 512-d/8-head): 6 frames 1.06 -> 0.69 ms, 32 frames/window 16
+  23.7 -> 5.3 ms (4.5x), 64 frames/window 16 93.6 -> 11.8 ms (7.9x). Numerically
+  identical to `"sdpa"` to ~4e-6 in fp32, forward and backward
+  (`tests/test_causal_frame.py`).
+
+Two constraints on `"flex"`, both deliberate rather than incidental:
+`attn_dropout` must be 0 (FlexAttention has no `dropout_p`, and the constructor
+raises rather than silently dropping it), and the decode `step` is unaffected --
+it stays SDPA, because it is the export target and has nothing to skip anyway.
+
 Note what is *not* equal, and cannot be for any bounded window with more than
 one layer: re-running frames `[1..6]` as a fresh isolated 6-frame episode. There
 frame 5 never saw frame 0, whereas in the stream its layer-2+ K/V were produced
@@ -70,18 +94,27 @@ with frame 0 in context. That is a property of bounded attention, not a cache
 defect.
 """
 
-from typing import final, override
+from collections.abc import Callable
+from functools import cache
+from typing import Literal, final, get_args, override
 
 import torch
 from torch import Tensor, nn
 from torch.nn import functional as F
+from torch.nn.attention.flex_attention import (
+    BlockMask,
+    create_block_mask,
+    flex_attention,
+)
 
 from rmind.components.transformer.utils import run_layer_stack
 
 __all__ = [
+    "AttentionImpl",
     "CausalFrameTransformer",
     "CausalFrameTransformerBlock",
     "CausalSelfAttention",
+    "frame_block_causal_block_mask",
     "frame_block_causal_mask",
     "frame_rope_cos_sin",
 ]
@@ -89,6 +122,16 @@ __all__ = [
 # additive bias for a masked-out position; finite so an fp16 engine cannot
 # produce NaN from -inf * 0 in a fused softmax
 MASK_BIAS: float = -1e4
+
+AttentionImpl = Literal["sdpa", "flex"]
+
+# FlexAttention's Triton kernels only accept a 128-element block on the shapes
+# this trunk uses (`BLOCK_SIZE=64` raises "Q and KV block size must be divisible
+# by BLOCK_M and BLOCK_N" from inductor on sm_120/torch 2.12), so the frame block
+# of 257 tokens can never tile exactly. See §11 of docs/decoder_only_kv_cache.md
+# for the measured cost of that misalignment (6-29% extra computed area, and
+# padding the frame to 384 to align it is 2.23x -- strictly worse).
+FLEX_BLOCK_SIZE: int = 128
 
 
 def frame_block_causal_mask(
@@ -116,6 +159,94 @@ def frame_block_causal_mask(
     if window is not None:
         blocked |= delta > window - 1  # evicted frames
     return blocked
+
+
+def frame_block_causal_mask_mod(
+    tokens_per_frame: int, window: int | None
+) -> Callable[[Tensor, Tensor, Tensor, Tensor], Tensor]:
+    """FlexAttention `mask_mod` for `frame_block_causal_mask`.
+
+    Note the inverted convention: `frame_block_causal_mask` returns True for
+    *blocked*, a `mask_mod` returns True for *keep*. The predicate is the same
+    frame-delta comparison, evaluated on index tensors instead of materialized.
+    """
+
+    def mask_mod(b: Tensor, h: Tensor, q_idx: Tensor, kv_idx: Tensor) -> Tensor:
+        del b, h
+        delta = q_idx // tokens_per_frame - kv_idx // tokens_per_frame
+        keep = delta >= 0
+        if window is not None:
+            keep &= delta <= window - 1
+        return keep
+
+    return mask_mod
+
+
+@cache
+def frame_block_causal_block_mask(
+    num_frames: int,
+    tokens_per_frame: int,
+    *,
+    window: int | None = None,
+    device: torch.device | None = None,
+) -> BlockMask:
+    """`BlockMask` equivalent of `frame_block_causal_mask`, for FlexAttention.
+
+    Memoized: building one costs 3-9 ms of launch-bound work (measured on a
+    5090), which is per-*layer*-per-*step* if you let it happen naively -- 25 ms
+    a step at 8 layers, more than the attention itself. The cache key is the mask
+    geometry plus the device, and a `BlockMask` at 64 frames is ~66 KiB, so
+    holding them all costs nothing.
+
+    Broadcast over batch and head (`B = H = None`): the mask is the same for every
+    sequence in the batch, which is what makes it cheap.
+
+    `device=None` means CPU, matching `frame_block_causal_mask` -- note that
+    `create_block_mask`'s own default is `"cuda"`, which would make a CPU-only
+    caller fail with "Torch not compiled with CUDA enabled".
+    """
+    seq_len = num_frames * tokens_per_frame
+    return create_block_mask(
+        frame_block_causal_mask_mod(tokens_per_frame, window),
+        B=None,
+        H=None,
+        Q_LEN=seq_len,
+        KV_LEN=seq_len,
+        device=torch.device("cpu") if device is None else device,
+        BLOCK_SIZE=FLEX_BLOCK_SIZE,
+    )
+
+
+@cache
+def _compiled_flex_attention() -> Callable[..., Tensor]:
+    """`torch.compile`d `flex_attention` -- the only form that is block-sparse.
+
+    Eager `flex_attention` is a correctness reference that materializes the score
+    matrix; the Triton kernel that actually skips masked blocks only exists after
+    `torch.compile`. `dynamic=False` keeps static shapes (one specialization per
+    `(batch, seq_len, heads, dtype)`); the trunk sees at most a couple of those,
+    but if you vary batch size a lot, raise `torch._dynamo.config.cache_size_limit`
+    or dynamo will silently fall back to eager after 8 recompiles.
+
+    Compiled lazily so importing this module (which the ONNX export path does)
+    never pays for it.
+    """
+    return torch.compile(flex_attention, dynamic=False)
+
+
+def flex_frame_attention(
+    q: Tensor, k: Tensor, v: Tensor, block_mask: BlockMask
+) -> Tensor:
+    """Block-sparse attention on CUDA, eager FlexAttention elsewhere.
+
+    FlexAttention has no CPU backward (`NotImplementedError` in
+    `_validate_device`), and there is no Triton kernel to gain on CPU anyway, so
+    the CPU path is deliberately the eager reference implementation: it exists so
+    the parity test can run without a GPU, not to be fast.
+    """
+    if q.is_cuda:
+        return _compiled_flex_attention()(q, k, v, block_mask=block_mask)
+    return flex_attention(q, k, v, block_mask=block_mask)
 
 
 def frame_rope_cos_sin(
@@ -170,15 +301,36 @@ class CausalSelfAttention(nn.Module):
     positional embedding differs, and that is the intended change.
     """
 
-    def __init__(self, *, dim_model: int, num_heads: int, dropout: float = 0.1) -> None:
+    def __init__(
+        self,
+        *,
+        dim_model: int,
+        num_heads: int,
+        dropout: float = 0.1,
+        attention_impl: AttentionImpl = "sdpa",
+    ) -> None:
         super().__init__()
         if dim_model % num_heads:
             msg = f"dim_model {dim_model} not divisible by num_heads {num_heads}"
+            raise ValueError(msg)
+        if attention_impl not in get_args(AttentionImpl):
+            msg = f"attention_impl must be one of {get_args(AttentionImpl)}"
+            raise ValueError(msg)
+        # FlexAttention has no `dropout_p`. Failing loudly beats silently
+        # dropping the trunk's attention dropout when someone flips the impl.
+        if attention_impl == "flex" and dropout:
+            msg = (
+                f"attention_impl='flex' cannot apply attention dropout "
+                f"(got attn_dropout={dropout}): FlexAttention has no dropout_p. "
+                "Set attn_dropout: 0.0 explicitly (resid_dropout/mlp_dropout are "
+                "unaffected) or use attention_impl='sdpa'."
+            )
             raise ValueError(msg)
         self.dim_model = dim_model
         self.num_heads = num_heads
         self.head_dim = dim_model // num_heads
         self.dropout = dropout
+        self.attention_impl = attention_impl
 
         # nn.MultiheadAttention's own initialization, so a randomly-initialized
         # CausalFrameTransformer is distributionally identical to the reference
@@ -201,13 +353,38 @@ class CausalSelfAttention(nn.Module):
         return self.out_proj(attn.transpose(1, 2).reshape(b, s, self.dim_model))
 
     @override
-    def forward(self, x: Tensor, cos: Tensor, sin: Tensor, mask: Tensor) -> Tensor:
-        """Full-sequence forward. `mask` is the bool block-causal mask."""
+    def forward(
+        self, x: Tensor, cos: Tensor, sin: Tensor, mask: Tensor | BlockMask
+    ) -> Tensor:
+        """Full-sequence forward.
+
+        `mask` is the bool block-causal mask (`attention_impl='sdpa'`) or the
+        equivalent `BlockMask` (`attention_impl='flex'`). RoPE is applied to q/k
+        *before* attention either way, so the positional scheme is orthogonal to
+        the kernel choice -- the frame-granular rotation is already baked into the
+        vectors the kernel sees.
+
+        Raises:
+            TypeError: if `mask` is not the type `attention_impl` requires.
+        """
         q, k, v = self._qkv(x)
         q, k = apply_rope(q, cos, sin), apply_rope(k, cos, sin)
-        attn = F.scaled_dot_product_attention(
-            q, k, v, attn_mask=~mask, dropout_p=self.dropout if self.training else 0.0
-        )
+        if self.attention_impl == "flex":
+            if not isinstance(mask, BlockMask):
+                msg = f"attention_impl='flex' needs a BlockMask, got {type(mask)}"
+                raise TypeError(msg)
+            attn = flex_frame_attention(q, k, v, mask)
+        else:
+            if isinstance(mask, BlockMask):
+                msg = "attention_impl='sdpa' needs a bool mask, got a BlockMask"
+                raise TypeError(msg)
+            attn = F.scaled_dot_product_attention(
+                q,
+                k,
+                v,
+                attn_mask=~mask,
+                dropout_p=self.dropout if self.training else 0.0,
+            )
         return self._out(attn)
 
     def step(  # noqa: PLR0913, PLR0917
@@ -227,6 +404,11 @@ class CausalSelfAttention(nn.Module):
         construction) and every own-frame key is visible (bidirectional within a
         frame). The only masking is `cache_bias`, which zeroes out unfilled ring
         slots.
+
+        `attention_impl` deliberately does NOT apply here: the decode step is
+        always plain SDPA. It has 257 queries against a dense, fully-visible
+        cache -- there is no sparsity to exploit -- and it is the ONNX/TRT export
+        target, which a `torch.compile`d Triton kernel could not be.
 
         `readout_only` computes the attention output for the LAST query position
         only -- the head reads a single token per frame (§3.3 of the hand-off), so
@@ -259,11 +441,15 @@ class CausalFrameTransformerBlock(nn.Module):
         resid_dropout: float = 0.1,
         mlp_dropout: float = 0.1,
         hidden_layer_multiplier: int = 4,
+        attention_impl: AttentionImpl = "sdpa",
     ) -> None:
         super().__init__()
         self.attn_norm = nn.LayerNorm(dim_model)
         self.attn = CausalSelfAttention(
-            dim_model=dim_model, num_heads=num_heads, dropout=attn_dropout
+            dim_model=dim_model,
+            num_heads=num_heads,
+            dropout=attn_dropout,
+            attention_impl=attention_impl,
         )
         self.resid_drop = nn.Dropout(resid_dropout)
         self.mlp_norm = nn.LayerNorm(dim_model)
@@ -275,7 +461,9 @@ class CausalFrameTransformerBlock(nn.Module):
         )
 
     @override
-    def forward(self, x: Tensor, cos: Tensor, sin: Tensor, mask: Tensor) -> Tensor:
+    def forward(
+        self, x: Tensor, cos: Tensor, sin: Tensor, mask: Tensor | BlockMask
+    ) -> Tensor:
         attn_out = self.attn(self.attn_norm(x), cos, sin, mask)
         # NOTE: no in-place ops on the residual stream (autograd + checkpointing)
         h = x + self.resid_drop(attn_out)
@@ -331,6 +519,7 @@ class CausalFrameTransformer(nn.Module):
         resid_dropout: float = 0.1,
         mlp_dropout: float = 0.1,
         hidden_layer_multiplier: int = 4,
+        attention_impl: AttentionImpl = "sdpa",
     ) -> None:
         super().__init__()
         # There is no learned positional table over the flattened sequence any
@@ -364,6 +553,7 @@ class CausalFrameTransformer(nn.Module):
         self.tokens_per_frame = tokens_per_frame
         self.window = window
         self.rope_base = rope_base
+        self.attention_impl = attention_impl
 
         # frame-RELATIVE intra-frame position: tiled onto every frame, so it is
         # invariant to where the frame sits in the window (unlike the 1542-slot
@@ -380,6 +570,7 @@ class CausalFrameTransformer(nn.Module):
                 resid_dropout=resid_dropout,
                 mlp_dropout=mlp_dropout,
                 hidden_layer_multiplier=hidden_layer_multiplier,
+                attention_impl=attention_impl,
             )
             for _ in range(num_layers)
         ])
@@ -412,8 +603,14 @@ class CausalFrameTransformer(nn.Module):
             frames, head_dim=self.head_dim, base=self.rope_base
         )
         cos, sin = cos.to(src.dtype), sin.to(src.dtype)
-        mask = frame_block_causal_mask(
-            num_frames, k, window=self.window, device=src.device
+        mask: Tensor | BlockMask = (
+            frame_block_causal_block_mask(
+                num_frames, k, window=self.window, device=src.device
+            )
+            if self.attention_impl == "flex"
+            else frame_block_causal_mask(
+                num_frames, k, window=self.window, device=src.device
+            )
         )
 
         x = run_layer_stack(self.layers, x, cos, sin, mask, training=self.training)

--- a/src/rmind/components/transformer/utils.py
+++ b/src/rmind/components/transformer/utils.py
@@ -6,8 +6,15 @@ from torch.utils.checkpoint import checkpoint
 
 
 def run_layer_stack(
-    layers: Iterable[Module], x: Tensor, *extra_args: Tensor, training: bool
+    layers: Iterable[Module], x: Tensor, *extra_args: object, training: bool
 ) -> Tensor:
+    """Run `layers` in sequence, checkpointing each one while training.
+
+    `extra_args` are forwarded unchanged and are not required to be tensors: the
+    FlexAttention path passes a `BlockMask` here, which `checkpoint` treats as an
+    ordinary non-differentiable argument (it is stored by reference and re-passed
+    on recompute, exactly like the bool mask it replaces).
+    """
     for layer in layers:
         if training:
             x = checkpoint(layer, x, *extra_args, use_reentrant=False)

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -154,8 +154,10 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
         patch_projection: HydraConfig[Module] | InstanceOf[Module],
         speed_tokenizer: HydraConfig[Module] | InstanceOf[Module],
         speed_embedding: HydraConfig[Module] | InstanceOf[Module],
-        encoder: HydraConfig[BlockCausalTransformer]
-        | InstanceOf[BlockCausalTransformer],
+        # BlockCausalTransformer, or the decoder-only
+        # components.transformer.causal_frame.CausalFrameTransformer (same
+        # `forward(src, *, num_frames)` contract, plus a KV-cached `step`)
+        encoder: HydraConfig[Module] | InstanceOf[Module],
         tokenizer: HydraConfig[Module] | InstanceOf[Module],
         code_head: HydraConfig[Module] | InstanceOf[Module],
         offset_head: HydraConfig[Module] | InstanceOf[Module],
@@ -208,9 +210,7 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
         self.speed_embedding = init_hydra_param(
             hparams, "speed_embedding", speed_embedding
         )
-        self.encoder: BlockCausalTransformer = init_hydra_param(
-            hparams, "encoder", encoder
-        )
+        self.encoder: Module = init_hydra_param(hparams, "encoder", encoder)
         self.code_head = init_hydra_param(hparams, "code_head", code_head)
         self.offset_head = init_hydra_param(hparams, "offset_head", offset_head)
         self.losses: ModuleDict = init_hydra_param(hparams, "losses", losses)
@@ -308,22 +308,16 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
             raise KeyError(msg)
         return value
 
-    def _features(
-        self, batch: Any, *, require_chunk: bool = True
-    ) -> tuple[Tensor, Tensor | None]:
-        """Per-frame readout features `(b, t, d)` and the action chunks `(b, t, h, a)`.
+    def _frame_tokens(
+        self, images: Tensor, speed: Tensor, waypoints: Tensor
+    ) -> Tensor:
+        """Per-frame token blocks `(b, t, p + 1, d)` -- everything below the trunk.
 
-        The chunk is only a TARGET (and never feeds the features), so callers on
-        the inference path (`forward`, ONNX export) pass `require_chunk=False`
-        and may omit the action series from the batch entirely.
+        Factored out of `_features` so the KV-cached decode step
+        (`rmind.models.patch_policy_decoder.PatchPolicyDecoderStep`) runs the
+        identical per-frame pipeline on ONE frame. Nothing here is temporal, which
+        is exactly why one new frame per tick is sufficient.
         """
-        inputs = self.input_transform(batch)
-
-        images = self._get(inputs, self.image)  # (b, t, c, h, w)
-        speed = self._get(inputs, self.speed)  # (b, t, 1)
-        waypoints = self._get(inputs, self.waypoints)  # (b, t, n, 2)
-        chunk = self._get(inputs, self.chunk, required=require_chunk)
-
         with torch.no_grad():
             patches = self.image_encoder(images)  # (b, t, p, d_img)
             goal = self.goal_encoder.encode(waypoints)  # (b, t, g)
@@ -343,7 +337,25 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
         speed_token = self.speed_embedding(self.speed_tokenizer(speed))  # (b, t, 1, d)
 
         # speed first so the frame block ends on a patch token (the readout position)
-        tokens = torch.cat([speed_token, patches], dim=-2)  # (b, t, p + 1, d)
+        return torch.cat([speed_token, patches], dim=-2)  # (b, t, p + 1, d)
+
+    def _features(
+        self, batch: Any, *, require_chunk: bool = True
+    ) -> tuple[Tensor, Tensor | None]:
+        """Per-frame readout features `(b, t, d)` and the action chunks `(b, t, h, a)`.
+
+        The chunk is only a TARGET (and never feeds the features), so callers on
+        the inference path (`forward`, ONNX export) pass `require_chunk=False`
+        and may omit the action series from the batch entirely.
+        """
+        inputs = self.input_transform(batch)
+
+        images = self._get(inputs, self.image)  # (b, t, c, h, w)
+        speed = self._get(inputs, self.speed)  # (b, t, 1)
+        waypoints = self._get(inputs, self.waypoints)  # (b, t, n, 2)
+        chunk = self._get(inputs, self.chunk, required=require_chunk)
+
+        tokens = self._frame_tokens(images, speed, waypoints)
         _, num_frames, _, _ = tokens.shape
 
         embedding = self.encoder(

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -472,6 +472,33 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
                 sampled_chunk[:, -1].detach(), target[:, -1]
             )
 
+            # context-depth localizer for windowed causal trunks: readouts at
+            # positions < window-1 train under a PARTIAL window, positions
+            # >= window-1 under the FULL window served at inference. A gap
+            # between the two buckets says WHERE a causal arm is failing:
+            # full-window >> partial-window means long-context conditioning
+            # itself is the problem, not the heads or the features.
+            window = getattr(self.encoder, "window", None)
+            num_frames = code_logits.shape[1]
+            if window is not None and num_frames > window - 1:
+                buckets = {
+                    "partial_window": slice(None, window - 1),
+                    "full_window": slice(window - 1, None),
+                }
+                for bucket, sl in buckets.items():
+                    if code_logits[:, sl].shape[1] == 0:
+                        continue
+                    metrics[f"code_{bucket}"] = torch.stack([
+                        self.losses["code"](
+                            rearrange(code_logits[:, sl, q, :], "b t c -> (b t) c"),
+                            rearrange(target_codes[:, sl, q], "b t -> (b t)"),
+                        )
+                        for q in range(tokenizer.quantizer.num_quantizers)
+                    ]).mean()
+                    metrics[f"offset_{bucket}"] = self.losses["offset"](
+                        predicted_chunk[:, sl], target[:, sl]
+                    )
+
         return TensorDict({"policy": {"loss": losses, "metric": metrics}})
 
     def _step(self, batch: Any, prefix: str) -> STEP_OUTPUT:

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -418,7 +418,7 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
             (-1, self.tokenizer._action_features),  # noqa: SLF001
         )
 
-    def _compute_metrics(self, batch: Any) -> TensorDict:
+    def _compute_metrics(self, batch: Any) -> TensorDict:  # noqa: PLR0914
         features, chunk = self._features(batch)  # (b, t, d), (b, t, h, a)
         tokenizer = self.tokenizer
 

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -171,6 +171,7 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
         teacher_force_offset: bool = True,
         offset_scale: float | None = None,
         fusion_norm: bool = False,
+        fusion_goal_rms: float | None = None,
         optimizer: HydraConfig[Optimizer] | None = None,
         lr_scheduler: LRSchedulerHydraConfig | None = None,
         prediction_config: Annotated[
@@ -247,31 +248,39 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
             self.fusion_patch_gain: nn.Parameter | None = nn.Parameter(
                 torch.tensor(1.0)
             )
-            with torch.no_grad():
-                quantizer = self.goal_encoder.quantizer
-                generator = torch.Generator().manual_seed(0)
-                codes = torch.stack(
-                    [
-                        torch.randint(
-                            0, quantizer.codebook_size, (1024,), generator=generator
-                        )
-                        for _ in range(quantizer.num_quantizers)
-                    ],
-                    dim=-1,
-                )
-                # the CPU generator fixes the seed sequence; lookup must run on
-                # whatever device the loaded codebooks landed on
-                quantizer_device = next(
-                    chain(quantizer.parameters(), quantizer.buffers())
-                ).device
-                rms = (
-                    quantizer
-                    .lookup(codes.to(quantizer_device))
-                    .pow(2)
-                    .mean()
-                    .sqrt()
-                    .cpu()
-                )
+            if fusion_goal_rms is not None:
+                # data-measured element-RMS of z_q. The uniform-random-code MC
+                # below overestimates it (real codebook usage is non-uniform:
+                # measured 1.86x on gzxgumtf — 0.143 MC vs 0.077 real), landing
+                # the goal stream ~2x quieter than intended. Prefer the
+                # measured value when known (H3 eval, 2026-08-06).
+                rms = torch.tensor(fusion_goal_rms)
+            else:
+                with torch.no_grad():
+                    quantizer = self.goal_encoder.quantizer
+                    generator = torch.Generator().manual_seed(0)
+                    codes = torch.stack(
+                        [
+                            torch.randint(
+                                0, quantizer.codebook_size, (1024,), generator=generator
+                            )
+                            for _ in range(quantizer.num_quantizers)
+                        ],
+                        dim=-1,
+                    )
+                    # the CPU generator fixes the seed sequence; lookup must run
+                    # on whatever device the loaded codebooks landed on
+                    quantizer_device = next(
+                        chain(quantizer.parameters(), quantizer.buffers())
+                    ).device
+                    rms = (
+                        quantizer
+                        .lookup(codes.to(quantizer_device))
+                        .pow(2)
+                        .mean()
+                        .sqrt()
+                        .cpu()
+                    )
             self.fusion_goal_gain: nn.Parameter | None = nn.Parameter(1.0 / rms)
         else:
             self.fusion_patch_norm = None

--- a/src/rmind/models/patch_policy.py
+++ b/src/rmind/models/patch_policy.py
@@ -308,9 +308,7 @@ class PatchPolicy(pl.LightningModule, LoadableFromArtifact):
             raise KeyError(msg)
         return value
 
-    def _frame_tokens(
-        self, images: Tensor, speed: Tensor, waypoints: Tensor
-    ) -> Tensor:
+    def _frame_tokens(self, images: Tensor, speed: Tensor, waypoints: Tensor) -> Tensor:
         """Per-frame token blocks `(b, t, p + 1, d)` -- everything below the trunk.
 
         Factored out of `_features` so the KV-cached decode step

--- a/src/rmind/models/patch_policy_decoder.py
+++ b/src/rmind/models/patch_policy_decoder.py
@@ -1,0 +1,172 @@
+"""KV-cached one-tick decode step for `PatchPolicy` -- the deployment export target.
+
+Per tick the graph encodes exactly ONE new frame (1 speed token prepended to 256
+goal-fused patch tokens = 257 queries), runs those 257 queries against the cached
+K/V of the past frames, and returns the action chunk plus the new frame's K/V.
+Old frames are never re-encoded and never re-attended to each other.
+
+Runtime contract (drivr)
+------------------------
+Inputs, all bound **by name**:
+
+| name | shape | notes |
+| --- | --- | --- |
+| `image` | `(1, 1, 3, H, W)` | ONE frame, `[0, 1]` float. ImageNet norm is in-graph, so serve with `--image-norm unit`. `H = W = 224` (dinov2) / `256` (dinov3) -- `Resize=0`, a wrong size is silently sheared. |
+| `speed` | `(1, 1, 1)` | km/h |
+| `waypoints` | `(1, 1, 10, 2)` | ego-frame, /100 |
+| `past_k`, `past_v` | `(L, 1, heads, cache_frames * 257, head_dim)` | read-only |
+| `cache_bias` | `(1, 1, 1, cache_frames * 257)` | `0` = filled slot, `-1e4` = empty |
+| `rope_cos`, `rope_sin` | `(1, head_dim)` | this frame's rotation, from the episode frame counter |
+
+Outputs: `policy.joint_actions` `(1, horizon, action_features)`, and `new_k` /
+`new_v` `(L, 1, heads, 257, head_dim)`.
+
+The host owns the ring buffer: it shifts `new_k`/`new_v` into `past_k`/`past_v`
+and appends `257` zeros to the filled region of `cache_bias`. Nothing is written
+inside the graph -- no `ScatterElements`, and the cache tensors are ordinary
+engine I/O.
+
+⚠️ `TRTEngine.run` binds via `set_tensor_address`, a raw pointer with **no size
+validation** (hand-off §3.4). A cache allocated for a different `cache_frames`,
+`L`, `heads` or dtype is *not* an error: TRT reinterprets the buffer and the model
+merely looks weak. Validate every binding's shape against
+`engine.get_tensor_shape(name)` before the first `run`.
+
+⚠️ Reset `past_k`/`past_v` (i.e. set `cache_bias` fully to `-1e4`) and restart the
+frame counter on every episode boundary -- engage, disengage and manual override.
+drivr already clears the action plan on those transitions; hook the same paths.
+
+Why `rope_cos`/`rope_sin` are inputs
+------------------------------------
+They are the only positional state, they are two `head_dim` vectors, and computing
+them host-side in float64 keeps a long-episode absolute frame counter exact while
+leaving the TRT graph with **zero `Sin`/`Cos` nodes` -- trigonometric ops are the
+most fp16-fragile part of this model family (see the trt-export skill §2).
+"""
+
+from collections.abc import Mapping
+from typing import final, override
+
+import torch
+from tensordict import TensorDict
+from torch import Tensor, nn
+
+from rmind.components.transformer.causal_frame import (
+    CausalFrameTransformer,
+    frame_rope_cos_sin,
+)
+from rmind.models.patch_policy import PatchPolicy
+
+__all__ = ["PatchPolicyDecoderStep"]
+
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+
+
+@final
+class PatchPolicyDecoderStep(nn.Module):
+    """Export wrapper around a `PatchPolicy` whose trunk is a `CausalFrameTransformer`.
+
+    Everything except the trunk is reused unchanged: the frozen ViT encoder, the
+    frozen goal encoder and its RVQ, the fusion, `patch_projection`,
+    `speed_embedding`, `norm`, and the VQ-BeT `code_head`/`offset_head`/tokenizer.
+    """
+
+    def __init__(
+        self, *, policy: PatchPolicy, readout_only_final_block: bool = True
+    ) -> None:
+        super().__init__()
+        if not isinstance(policy.encoder, CausalFrameTransformer):
+            msg = (
+                "policy.encoder must be a CausalFrameTransformer; "
+                f"got {type(policy.encoder).__name__}"
+            )
+            raise TypeError(msg)
+        self.policy = policy.eval()
+        self.trunk: CausalFrameTransformer = policy.encoder
+        # §3.3: the head reads one token per frame, so the final block's attention
+        # output and MLP for the other 256 positions are discarded. K/V are still
+        # produced for all 257 -- future frames attend to them.
+        self.readout_only_final_block = readout_only_final_block
+        self.register_buffer(
+            "image_mean", torch.tensor(IMAGENET_MEAN).reshape(1, 1, 3, 1, 1)
+        )
+        self.register_buffer(
+            "image_std", torch.tensor(IMAGENET_STD).reshape(1, 1, 3, 1, 1)
+        )
+
+    # ---------------------------------------------------------------- host side
+
+    def empty_cache(
+        self,
+        *,
+        cache_frames: int,
+        batch_size: int = 1,
+        device: torch.device | None = None,
+        dtype: torch.dtype = torch.float32,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """`(past_k, past_v, cache_bias)` for a cold cache -- the engage-time state."""
+        return self.trunk.empty_cache(
+            batch_size=batch_size,
+            cache_frames=cache_frames,
+            device=device,
+            dtype=dtype,
+        )
+
+    def rope(self, frame_index: int) -> tuple[Tensor, Tensor]:
+        """`(rope_cos, rope_sin)` `(1, head_dim)` for the episode-absolute frame index."""
+        cos, sin = frame_rope_cos_sin(
+            torch.tensor(frame_index),
+            head_dim=self.trunk.head_dim,
+            base=self.trunk.rope_base,
+        )
+        return cos.reshape(1, -1), sin.reshape(1, -1)
+
+    @staticmethod
+    def advance(
+        past: tuple[Tensor, Tensor, Tensor], new_k: Tensor, new_v: Tensor
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        """Ring-buffer update, i.e. what drivr does between ticks.
+
+        Shift left by one frame block and write the new K/V into the freed tail.
+        In the runtime this is a device-to-device copy of `257` tokens per layer,
+        not of the whole cache.
+        """
+        past_k, past_v, bias = past
+        k = new_k.shape[-2]
+        return (
+            torch.cat((past_k[..., k:, :], new_k), dim=-2),
+            torch.cat((past_v[..., k:, :], new_v), dim=-2),
+            torch.cat((bias[..., k:], torch.zeros_like(bias[..., :k])), dim=-1),
+        )
+
+    # -------------------------------------------------------------------- graph
+
+    @override
+    def forward(self, inputs: Mapping[str, Tensor]) -> TensorDict:
+        policy = self.policy
+        image = (inputs["image"] - self.image_mean) / self.image_std
+
+        tokens = policy._frame_tokens(  # noqa: SLF001
+            image, inputs["speed"], inputs["waypoints"]
+        )  # (b, 1, 257, d)
+
+        out, new_k, new_v = self.trunk.step(
+            tokens[:, 0],
+            past_k=inputs["past_k"],
+            past_v=inputs["past_v"],
+            cos=inputs["rope_cos"],
+            sin=inputs["rope_sin"],
+            cache_bias=inputs["cache_bias"],
+            readout_only_final_block=self.readout_only_final_block,
+        )
+
+        features = out[:, -1]  # the frame's last patch token = the readout position
+        if policy.norm is not None:
+            features = policy.norm(features)
+
+        return TensorDict({
+            "policy": {"joint_actions": policy._predict_chunk(features)},  # noqa: SLF001
+            "new_k": new_k,
+            "new_v": new_v,
+        })

--- a/src/rmind/models/patch_policy_decoder.py
+++ b/src/rmind/models/patch_policy_decoder.py
@@ -40,7 +40,7 @@ Why `rope_cos`/`rope_sin` are inputs
 ------------------------------------
 They are the only positional state, they are two `head_dim` vectors, and computing
 them host-side in float64 keeps a long-episode absolute frame counter exact while
-leaving the TRT graph with **zero `Sin`/`Cos` nodes` -- trigonometric ops are the
+leaving the TRT graph with **zero `Sin`/`Cos` nodes** -- trigonometric ops are the
 most fp16-fragile part of this model family (see the trt-export skill §2).
 """
 
@@ -107,10 +107,7 @@ class PatchPolicyDecoderStep(nn.Module):
     ) -> tuple[Tensor, Tensor, Tensor]:
         """`(past_k, past_v, cache_bias)` for a cold cache -- the engage-time state."""
         return self.trunk.empty_cache(
-            batch_size=batch_size,
-            cache_frames=cache_frames,
-            device=device,
-            dtype=dtype,
+            batch_size=batch_size, cache_frames=cache_frames, device=device, dtype=dtype
         )
 
     def rope(self, frame_index: int) -> tuple[Tensor, Tensor]:

--- a/src/rmind/scripts/decoder_only_export.py
+++ b/src/rmind/scripts/decoder_only_export.py
@@ -1,0 +1,229 @@
+"""Export the PatchPolicy baseline and the KV-cached decoder step to ONNX.
+
+Both graphs come from the same hydra experiment config with a **randomly
+initialized** trunk and heads (the frozen goal encoder and action tokenizer are
+their real wandb artifacts; the ViT is its pretrained timm checkpoint). Shapes,
+op counts and layer counts are therefore exactly the deployment graph's -- only
+the weight VALUES are arbitrary, which is irrelevant for latency and memory and
+is what makes this an *architecture* measurement rather than a checkpoint one.
+
+Exporting both from one script is deliberate: the baseline reproduction is gate
+zero for the comparison, and it is only a valid control if it differs from the
+decoder graph in nothing but the trunk formulation.
+
+    python -m rmind.scripts.decoder_only_export \
+        --arm small --mode baseline --context 6 --out baseline_small_n6.onnx
+    python -m rmind.scripts.decoder_only_export \
+        --arm big --mode decoder --context 32 --out decoder_big_n32.onnx
+
+Measuring the results (delta-dev1, AGX Orin, TRT 10.7) -- see
+`/nasa/max/skills/trt-export/SKILL.md` and docs/decoder_only_kv_cache.md:
+
+    # pin the GPU clock, or every number is ~55 ms pessimistic
+    sudo sh -c 'echo performance > $DEVFREQ/governor'
+    sudo sh -c 'echo 918000000 > $DEVFREQ/min_freq'
+    # ... and confirm by sampling cur_freq THROUGH an idle gap, not after a run
+
+    # build fp32 only: the reference baseline is fp32 and fp32 is the only
+    # precision that has ever reached 0/200 on parity
+    /home/max/Code/drivr/.venv/bin/python \
+        /home/max/Code/drivr/scripts/build_trt_engine.py \
+        --onnx MODEL.onnx --precision fp32 --workspace-gb 6
+
+    /usr/src/tensorrt/bin/trtexec --loadEngine=MODEL.trt \
+        --iterations=60 --avgRuns=20 --useSpinWait --warmUp=1000
+"""
+
+import argparse
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.fx.experimental._config as _fx_config  # noqa: PLC2701
+from hydra import compose, initialize_config_dir
+from hydra.utils import instantiate
+from omegaconf import OmegaConf
+from structlog import get_logger
+from torch import Tensor
+from torch.nn import Module
+from torch.utils._pytree import tree_flatten_with_path  # noqa: PLC2701
+
+from rmind.components.transformer.causal_frame import CausalFrameTransformer
+from rmind.models.patch_policy_decoder import PatchPolicyDecoderStep
+from rmind.utils.patch import monkeypatched
+
+# tensordict's global dicts mutated during export tracing cause a spurious
+# "pending unbacked symbol u0" error even though the exported graph is valid
+# (same workaround as rmind.scripts.export_onnx).
+_fx_config.soft_pending_unbacked_not_found_error = True  # ty:ignore[invalid-assignment]
+
+logger = get_logger(__name__)
+
+# (experiment, trunk width, layers, heads). `_big` is 12L/768d/12H -- note the
+# hand-off §7 says "8 layers, 512-d; 768-d in the `_big` arm", which understates
+# the depth; dinov2_dinowm_big.yaml sets num_layers: 12.
+ARMS = {
+    "small": ("yaak/patch_policy/dinov2_dinowm", 512, 8, 8),
+    "big": ("yaak/patch_policy/dinov2_dinowm_big", 768, 12, 12),
+}
+IMAGE_HW = 224  # dinov2 arms; 256 for dinov3
+NUM_PATCHES = 256
+TOKENS_PER_FRAME = NUM_PATCHES + 1  # speed token prepended
+NUM_WAYPOINTS = 10
+CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
+
+
+def build_policy(arm: str, *, episode_length: int) -> tuple[Any, int, int, int]:
+    """Instantiate the arm's `PatchPolicy` with the deployment input transform."""
+    from torchvision.transforms.v2 import Normalize  # noqa: PLC0415
+
+    experiment, dim, layers, heads = ARMS[arm]
+    with initialize_config_dir(config_dir=str(CONFIG_DIR), version_base=None):
+        cfg = compose(
+            config_name="train",
+            overrides=[f"experiment={experiment}", f"episode_length={episode_length}"],
+        )
+    model = instantiate(OmegaConf.to_container(cfg.model, resolve=True))
+    model.sample_codes = False  # argmax decoding, as `load_for_export` does
+    # deployment supplies already-cropped/resized [0,1] frames; ImageNet norm only
+    model.input_transform[2]["image"] = Normalize(
+        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+    )
+    # the frozen artifacts were checkpointed on cuda and raw.yaml passes no
+    # map_location; export is CPU-side
+    return model.cpu().eval(), dim, layers, heads
+
+
+def baseline_args(episode_length: int) -> tuple[dict[str, Any]]:
+    """The current serving interface: `episode_length` frames re-encoded per tick."""
+    return (
+        {
+            "data": {
+                "cam_front_left": torch.rand(1, episode_length, 3, IMAGE_HW, IMAGE_HW),
+                "meta/VehicleMotion/speed": torch.rand(1, episode_length, 1) * 130,
+                "waypoints/xy_normalized": torch.rand(
+                    1, episode_length, NUM_WAYPOINTS, 2
+                )
+                * 2
+                - 1,
+            }
+        },
+    )
+
+
+def decoder_model_and_args(
+    arm: str, context: int
+) -> tuple[Module, tuple[dict[str, Tensor]], tuple[int, int, int, int]]:
+    """The decoder step: ONE new frame against a cache of `context - 1` frames."""
+    policy, dim, layers, heads = build_policy(arm, episode_length=1)
+    policy.encoder = CausalFrameTransformer(
+        dim_model=dim,
+        num_layers=layers,
+        num_heads=heads,
+        tokens_per_frame=TOKENS_PER_FRAME,
+        window=context,
+    ).eval()
+    step = PatchPolicyDecoderStep(policy=policy).eval()
+
+    cache_frames = context - 1
+    past_k, past_v, cache_bias = step.empty_cache(cache_frames=cache_frames)
+    # export against a WARM cache -- the steady state. The graph is identical for a
+    # cold cache and costs the same; only `cache_bias` differs.
+    generator = torch.Generator().manual_seed(0)
+    past_k = torch.randn(past_k.shape, generator=generator)
+    past_v = torch.randn(past_v.shape, generator=generator)
+    cache_bias = torch.zeros_like(cache_bias)
+    rope_cos, rope_sin = step.rope(context - 1)
+
+    args = (
+        {
+            "image": torch.rand(1, 1, 3, IMAGE_HW, IMAGE_HW),
+            "speed": torch.rand(1, 1, 1) * 130,
+            "waypoints": torch.rand(1, 1, NUM_WAYPOINTS, 2) * 2 - 1,
+            "past_k": past_k,
+            "past_v": past_v,
+            "cache_bias": cache_bias,
+            "rope_cos": rope_cos,
+            "rope_sin": rope_sin,
+        },
+    )
+    return step, args, (layers, heads, dim // heads, cache_frames)
+
+
+def export(model: Module, args: tuple[Any, ...], out: Path, *, verify: bool) -> None:
+    eager_out: Any = None
+    for patch in (False, True):
+        with monkeypatched(obj=torch.compiler, name="_is_exporting_flag", patch=patch):
+            eager_out = model(*args)
+    paths_and_leaves, _ = tree_flatten_with_path(eager_out)
+    output_names = [
+        ".".join(mk.key for mk in path)  # ty:ignore[unresolved-attribute]
+        for path, _ in paths_and_leaves
+    ]
+    logger.debug("inferred output_names", output_names=output_names)
+
+    exported = torch.export.export(mod=model, args=tuple(args), strict=True)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    torch.onnx.export(
+        model=exported,
+        f=out,
+        dynamo=True,
+        external_data=False,
+        optimize=True,
+        verify=verify,
+        report=False,
+        output_names=output_names,
+        artifacts_dir=out.parent,
+    )
+    logger.info("exported", path=out.as_posix(), mb=round(out.stat().st_size / 1e6, 1))
+
+
+@torch.inference_mode()
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--arm", choices=sorted(ARMS), required=True)
+    parser.add_argument("--mode", choices=["baseline", "decoder"], required=True)
+    parser.add_argument(
+        "--context",
+        type=int,
+        default=6,
+        help="frames attended in TOTAL (decoder: 1 new + context-1 cached)",
+    )
+    parser.add_argument("--out", type=Path, required=True)
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="ORT-vs-eager check; reports per-element RELATIVE error, which is "
+        "alarming and meaningless on near-zero K/V entries -- compare absolute "
+        "error against the tensor scale instead",
+    )
+    args = parser.parse_args()
+
+    if args.out.exists():
+        logger.info("exists, skipping", path=args.out.as_posix())
+        return
+
+    torch.manual_seed(1337)
+    if args.mode == "baseline":
+        model, *_ = build_policy(args.arm, episode_length=args.context)
+        export_args: tuple[Any, ...] = baseline_args(args.context)
+    else:
+        model, export_args, shapes = decoder_model_and_args(args.arm, args.context)
+        layers, heads, head_dim, cache_frames = shapes
+        logger.info(
+            "cache",
+            layers=layers,
+            heads=heads,
+            head_dim=head_dim,
+            cache_frames=cache_frames,
+            cached_keys=cache_frames * TOKENS_PER_FRAME,
+        )
+    logger.info(
+        "parameters",
+        millions=round(sum(p.numel() for p in model.parameters()) / 1e6, 2),
+    )
+    export(model, export_args, args.out, verify=args.verify)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rmind/scripts/decoder_only_export.py
+++ b/src/rmind/scripts/decoder_only_export.py
@@ -1,11 +1,12 @@
 """Export the PatchPolicy baseline and the KV-cached decoder step to ONNX.
 
-Both graphs come from the same hydra experiment config with a **randomly
-initialized** trunk and heads (the frozen goal encoder and action tokenizer are
-their real wandb artifacts; the ViT is its pretrained timm checkpoint). Shapes,
-op counts and layer counts are therefore exactly the deployment graph's -- only
-the weight VALUES are arbitrary, which is irrelevant for latency and memory and
-is what makes this an *architecture* measurement rather than a checkpoint one.
+Without `--artifact`/`--ckpt` both graphs come from the hydra experiment config
+with a **randomly initialized** trunk and heads (the frozen goal encoder and
+action tokenizer are their real wandb artifacts; the ViT is its pretrained timm
+checkpoint). Shapes, op counts and layer counts are therefore exactly the
+deployment graph's -- only the weight VALUES are arbitrary, which is irrelevant
+for latency and memory and is what makes that an *architecture* measurement
+rather than a checkpoint one.
 
 Exporting both from one script is deliberate: the baseline reproduction is gate
 zero for the comparison, and it is only a valid control if it differs from the
@@ -15,6 +16,24 @@ decoder graph in nothing but the trunk formulation.
         --arm small --mode baseline --context 6 --out baseline_small_n6.onnx
     python -m rmind.scripts.decoder_only_export \
         --arm big --mode decoder --context 32 --out decoder_big_n32.onnx
+
+**Trained weights** (`--artifact`, the parity/precision case). The architecture
+then comes from the CHECKPOINT's own hparams, not from `--arm`, and the trunk is
+used as trained instead of being replaced by a fresh one:
+
+    python -m rmind.scripts.decoder_only_export --mode decoder \
+        --artifact yaak/rmind/model-do8m9ot8:v0 --out decoder_do8m9ot8_n16.onnx
+
+`--context` then defaults to the trunk's own trained `window`, which is the only
+context the checkpoint is *valid* at: `step` reads the cache size off `past_k`'s
+shape and has no intrinsic maximum length, so a checkpoint will happily run
+against any cache and silently extrapolate (docs/decoder_only_kv_cache.md §10.3).
+Passing a different `--context` is legitimate for a LATENCY curve and nothing
+else -- such engines must not be served, and the script says so.
+
+`attention_impl` (`flex` in the causal training arm) is irrelevant here by
+construction: `CausalFrameTransformer.step` is always SDPA, because a
+`torch.compile`d Triton kernel is not exportable (§11.6.7).
 
 Measuring the results (delta-dev1, AGX Orin, TRT 10.7) -- see
 `/nasa/max/skills/trt-export/SKILL.md` and docs/decoder_only_kv_cache.md:
@@ -111,18 +130,92 @@ def baseline_args(episode_length: int) -> tuple[dict[str, Any]]:
     )
 
 
-def decoder_model_and_args(
-    arm: str, context: int
+def load_trained_policy(*, artifact: str | None, ckpt: str | None) -> Any:
+    """A TRAINED `PatchPolicy` with the deployment input transform.
+
+    `load_for_export` applies exactly the deployment conventions the random path
+    replicates by hand: `sample_codes=False` (argmax decoding, deterministic) and
+    the in-model crop/resize pipeline replaced by ImageNet `Normalize` only, so
+    the host owes an already-cropped `[0, 1]` frame.
+    """
+    from rmind.models.patch_policy import PatchPolicy  # noqa: PLC0415
+
+    if artifact is not None:
+        return PatchPolicy.load_for_export(artifact).cpu().eval()
+
+    from torchvision.transforms.v2 import Normalize  # noqa: PLC0415
+
+    model = PatchPolicy.load_from_checkpoint(
+        ckpt, map_location="cpu", weights_only=False
+    )
+    model.sample_codes = False
+    model.input_transform[2]["image"] = Normalize(
+        mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]
+    )
+    return model.cpu().eval()
+
+
+def decoder_model_and_args(  # noqa: PLR0914
+    arm: str,
+    context: int | None,
+    *,
+    artifact: str | None = None,
+    ckpt: str | None = None,
 ) -> tuple[Module, tuple[dict[str, Tensor]], tuple[int, int, int, int]]:
-    """The decoder step: ONE new frame against a cache of `context - 1` frames."""
-    policy, dim, layers, heads = build_policy(arm, episode_length=1)
-    policy.encoder = CausalFrameTransformer(
-        dim_model=dim,
-        num_layers=layers,
-        num_heads=heads,
-        tokens_per_frame=TOKENS_PER_FRAME,
-        window=context,
-    ).eval()
+    """The decoder step: ONE new frame against a cache of `context - 1` frames."""  # noqa: DOC501
+    if artifact is not None or ckpt is not None:
+        # Trained: the architecture comes from the checkpoint's hparams and the
+        # trunk is used AS TRAINED. Replacing it (the random path below) would
+        # silently discard every trained trunk weight.
+        policy = load_trained_policy(artifact=artifact, ckpt=ckpt)
+        trunk = policy.encoder
+        if not isinstance(trunk, CausalFrameTransformer):
+            msg = (
+                "checkpoint's encoder is a "
+                f"{type(trunk).__name__}, not a CausalFrameTransformer: this "
+                "checkpoint is not from a decoder-only (causal) arm and has no "
+                "cache-safe positional encoding to export"
+            )
+            raise TypeError(msg)
+        dim, layers, heads = trunk.dim_model, trunk.num_layers, trunk.num_heads
+        if context is None:
+            context = trunk.window
+            if context is None:
+                msg = "--context is required: the checkpoint's trunk has window=None"
+                raise ValueError(msg)
+        elif trunk.window is not None and context != trunk.window:
+            # Not fatal -- a latency curve legitimately wants other contexts --
+            # but the resulting engine is NOT servable with this checkpoint.
+            logger.warning(
+                "context != trained window: LATENCY ARTIFACT ONLY, do not serve "
+                "this engine -- the trunk has no intrinsic maximum length, so it "
+                "will run against this cache and silently extrapolate "
+                "(docs/decoder_only_kv_cache.md §10.3)",
+                context=context,
+                trained_window=trunk.window,
+            )
+        logger.info(
+            "trained trunk",
+            dim=dim,
+            layers=layers,
+            heads=heads,
+            trained_window=trunk.window,
+            rope_base=trunk.rope_base,
+            attention_impl=f"{trunk.attention_impl} (step is always sdpa)",
+        )
+    else:
+        if context is None:
+            msg = "--context is required for a randomly initialized export"
+            raise ValueError(msg)
+        policy, dim, layers, heads = build_policy(arm, episode_length=1)
+        policy.encoder = CausalFrameTransformer(
+            dim_model=dim,
+            num_layers=layers,
+            num_heads=heads,
+            tokens_per_frame=TOKENS_PER_FRAME,
+            window=context,
+        ).eval()
+
     step = PatchPolicyDecoderStep(policy=policy).eval()
 
     cache_frames = context - 1
@@ -181,13 +274,26 @@ def export(model: Module, args: tuple[Any, ...], out: Path, *, verify: bool) -> 
 @torch.inference_mode()
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--arm", choices=sorted(ARMS), required=True)
+    parser.add_argument(
+        "--arm",
+        choices=sorted(ARMS),
+        default="small",
+        help="architecture for a RANDOM export; ignored with --artifact/--ckpt, "
+        "where the architecture comes from the checkpoint's hparams",
+    )
     parser.add_argument("--mode", choices=["baseline", "decoder"], required=True)
+    weights = parser.add_mutually_exclusive_group()
+    weights.add_argument(
+        "--artifact", help="trained wandb model artifact, e.g. yaak/rmind/model-<id>:v0"
+    )
+    weights.add_argument("--ckpt", help="trained local checkpoint path")
     parser.add_argument(
         "--context",
         type=int,
-        default=6,
-        help="frames attended in TOTAL (decoder: 1 new + context-1 cached)",
+        default=None,
+        help="frames attended in TOTAL (decoder: 1 new + context-1 cached). "
+        "Defaults to the checkpoint trunk's trained `window`; required for a "
+        "random export. Any other value is a latency artifact -- not servable.",
     )
     parser.add_argument("--out", type=Path, required=True)
     parser.add_argument(
@@ -205,10 +311,19 @@ def main() -> None:
 
     torch.manual_seed(1337)
     if args.mode == "baseline":
-        model, *_ = build_policy(args.arm, episode_length=args.context)
+        if args.context is None:
+            msg = "--context is required in baseline mode"
+            raise ValueError(msg)
+        model = (
+            load_trained_policy(artifact=args.artifact, ckpt=args.ckpt)
+            if (args.artifact or args.ckpt)
+            else build_policy(args.arm, episode_length=args.context)[0]
+        )
         export_args: tuple[Any, ...] = baseline_args(args.context)
     else:
-        model, export_args, shapes = decoder_model_and_args(args.arm, args.context)
+        model, export_args, shapes = decoder_model_and_args(
+            args.arm, args.context, artifact=args.artifact, ckpt=args.ckpt
+        )
         layers, heads, head_dim, cache_frames = shapes
         logger.info(
             "cache",

--- a/src/rmind/scripts/decoder_only_trt_measure.sh
+++ b/src/rmind/scripts/decoder_only_trt_measure.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Build + benchmark + profile one decoder-step engine on delta-dev1 (AGX Orin).
+#
+#   dev1_measure.sh <onnx> <fp32|fp16|tf32> <outdir>
+#
+# Flag rationale (/nasa/max/skills/trt-export/SKILL.md):
+#  * --noTF32 for fp32. trtexec's DEFAULT "fp32" is the TF32 tensor-core path,
+#    which rounds matmul INPUTS to a 10-bit mantissa. That is a different numeric
+#    configuration and it scores 1/200, not 0/200; only the TF32-CLEARED build has
+#    ever been decision-exact. Omitting this flag would both inflate the fp32
+#    baseline's speed and silently break the parity control.
+#    (Equivalent to drivr build_trt_engine.py --precision fp32, which calls
+#     config.clear_flag(trt.BuilderFlag.TF32).)
+#  * --profilingVerbosity=detailed at BUILD time. Kernel/tactic names are baked
+#    into the engine; profiling an engine built at default verbosity returns
+#    stripped names, and absence-of-name would read as absence-of-kernel. That
+#    matters here because the _gemm_mha_v2 fused-MHA check is the critical one.
+#  * separate profile run: --dumpProfile inflates totals (46.2 vs 41.8 ms at N=6
+#    was measured) and inflates large-tensor kernels most, so latency and profile
+#    must not come from the same run.
+#  * clock sampled THROUGH the run: nvhost_podgov drops to 306 MHz between
+#    inferences. dev1 is pinned (governor=performance, min=max=918 MHz) but an
+#    earlier version of the skill got this backwards by sampling cur_freq only
+#    after each inference, so it is verified every time rather than assumed.
+set -uo pipefail
+
+ONNX="${1:?usage: dev1_measure.sh <onnx> <precision> <outdir>}"
+PREC="${2:?}"
+OUTDIR="${3:?}"
+
+TRTEXEC=/usr/src/tensorrt/bin/trtexec
+DEVFREQ=/sys/devices/platform/bus@0/17000000.gpu/devfreq/17000000.gpu
+BASE="$(basename "${ONNX%.onnx}")"
+TAG="$BASE.$PREC"
+mkdir -p "$OUTDIR"
+ENGINE="$OUTDIR/$TAG.trt"
+
+case "$PREC" in
+  fp32) FLAGS=(--noTF32) ;;
+  tf32) FLAGS=() ;;
+  fp16) FLAGS=(--fp16) ;;
+  *) echo "unknown precision $PREC" >&2; exit 2 ;;
+esac
+
+echo "===== $TAG ====="
+echo "-- host state before build (a mistimed engine is worse than no engine) --"
+uptime
+echo "clock: $(cat $DEVFREQ/cur_freq) governor=$(cat $DEVFREQ/governor)"
+
+if [ -s "$ENGINE" ]; then
+  echo "-- engine exists, skipping build --"
+else
+  echo "-- build --"
+  T0=$(date +%s)
+  "$TRTEXEC" --onnx="$ONNX" --saveEngine="$ENGINE" \
+    "${FLAGS[@]}" \
+    --memPoolSize=workspace:"${WORKSPACE_MB:-4096}" \
+    --profilingVerbosity=detailed \
+    --skipInference --verbose \
+    > "$OUTDIR/$TAG.build.log" 2>&1
+  echo "build rc=$? in $(( $(date +%s) - T0 ))s"
+  if [ ! -s "$ENGINE" ]; then
+    echo "!! BUILD PRODUCED NO ENGINE:" >&2
+    tail -30 "$OUTDIR/$TAG.build.log" >&2
+    exit 1
+  fi
+fi
+echo "engine: $(du -m "$ENGINE" | cut -f1) MiB"
+
+# Confirm the precision flags actually took rather than trusting they did.
+echo "-- builder precision state --"
+grep -aiE "TF32|FP16|BF16|INT8" "$OUTDIR/$TAG.build.log" \
+  | grep -aiE "disabl|enabl|precision" | sort -u | head -8
+
+echo "-- benchmark (clock sampled through the run) --"
+( while :; do cat $DEVFREQ/cur_freq; sleep 0.02; done ) > "$OUTDIR/$TAG.clock.txt" 2>/dev/null &
+CLOCK_PID=$!
+"$TRTEXEC" --loadEngine="$ENGINE" \
+  --iterations=60 --avgRuns=20 --useSpinWait --warmUp=1000 \
+  > "$OUTDIR/$TAG.bench.log" 2>&1
+kill $CLOCK_PID 2>/dev/null; wait $CLOCK_PID 2>/dev/null
+
+echo "-- clock distribution during benchmark --"
+awk '{printf "%d\n", $1/1000000}' "$OUTDIR/$TAG.clock.txt" | sort -n | uniq -c \
+  | awk '{printf "   %s MHz: %s samples\n", $2, $1}'
+
+echo "-- GPU compute time --"
+grep -aE "GPU Compute Time:|Latency:|Throughput:" "$OUTDIR/$TAG.bench.log"
+
+echo "-- profile (separate run) --"
+"$TRTEXEC" --loadEngine="$ENGINE" \
+  --iterations=30 --avgRuns=10 --useSpinWait --warmUp=500 \
+  --dumpProfile --separateProfileRun \
+  --exportProfile="$OUTDIR/$TAG.profile.json" \
+  --dumpLayerInfo --exportLayerInfo="$OUTDIR/$TAG.layers.json" \
+  > "$OUTDIR/$TAG.profile.log" 2>&1
+
+echo "-- CRITICAL CHECK: fused MHA kernel _gemm_mha_v2 --"
+for f in "$OUTDIR/$TAG.build.log" "$OUTDIR/$TAG.layers.json" \
+         "$OUTDIR/$TAG.profile.json" "$OUTDIR/$TAG.profile.log"; do
+  [ -f "$f" ] && printf '   %-24s %s hits\n' "$(basename "$f")" \
+    "$(grep -ao "_gemm_mha_v2" "$f" 2>/dev/null | wc -l)"
+done
+echo "   -- all *mha*/*fmha* tactic names present --"
+grep -ahoE "[A-Za-z0-9_]*[fm]mha[A-Za-z0-9_]*" \
+  "$OUTDIR/$TAG.build.log" "$OUTDIR/$TAG.layers.json" 2>/dev/null \
+  | sort | uniq -c | sort -rn | head -12
+echo "   (empty above = NO fused MHA at all)"
+
+echo "DONE $TAG"

--- a/src/rmind/scripts/decoder_only_trt_measure.sh
+++ b/src/rmind/scripts/decoder_only_trt_measure.sh
@@ -101,8 +101,8 @@ for f in "$OUTDIR/$TAG.build.log" "$OUTDIR/$TAG.layers.json" \
   [ -f "$f" ] && printf '   %-24s %s hits\n' "$(basename "$f")" \
     "$(grep -ao "_gemm_mha_v2" "$f" 2>/dev/null | wc -l)"
 done
-echo "   -- all *mha*/*fmha* tactic names present --"
-grep -ahoE "[A-Za-z0-9_]*[fm]mha[A-Za-z0-9_]*" \
+echo "   -- all *mha* tactic names present --"
+grep -ahoE "[A-Za-z0-9_]*mha[A-Za-z0-9_]*" \
   "$OUTDIR/$TAG.build.log" "$OUTDIR/$TAG.layers.json" 2>/dev/null \
   | sort | uniq -c | sort -rn | head -12
 echo "   (empty above = NO fused MHA at all)"

--- a/src/rmind/scripts/decoder_only_verify.py
+++ b/src/rmind/scripts/decoder_only_verify.py
@@ -1,0 +1,740 @@
+"""Correctness + precision gates for a TRAINED decoder-only PatchPolicy export.
+
+`decoder_only_export.py` produces the ONNX; this script is everything that must
+pass *before* a TRT engine built from it may be trusted, plus the trial-set
+generation that the on-Orin parity ladder consumes.
+
+Random weights could establish latency and memory (docs/decoder_only_kv_cache.md
+§9, §6) but not any of this: every gate here is a statement about weight
+*statistics*, so it needs a real checkpoint.
+
+Subcommands, in the order they should be run:
+
+    # 1. the architectural gate, now with trained weights.
+    #    Streaming against a ring of `window - 1` frames == one full forward
+    #    under frame_block_causal_mask(window). float64 pins it as exact;
+    #    float32 shows the accumulation-order residual. Both carry a negative
+    #    control, so a pass is falsifiable.
+    python -m rmind.scripts.decoder_only_verify gates \
+        --artifact yaak/rmind/model-do8m9ot8:v0
+
+    # 2. ONNX-vs-eager. Report ABSOLUTE error against the tensor's own scale --
+    #    torch.onnx.export(verify=True) reports per-element RELATIVE error and
+    #    screams about near-zero K/V entries (§5, a documented false alarm).
+    python -m rmind.scripts.decoder_only_verify onnx-vs-eager \
+        --artifact yaak/rmind/model-do8m9ot8:v0 --onnx decoder_n16.onnx
+
+    # 3. the margin screen (trt-export skill §4a): how close is each in-graph
+    #    ArgMax to flipping, in fp16 ULPs? ORT-only, no GPU. min ULP < 1 means
+    #    low precision WILL flip decisions.
+    python -m rmind.scripts.decoder_only_verify margins --onnx decoder_n16.onnx
+
+    # 4. the n=200 trial set + its ORT fp32 reference, and raw .dat files for
+    #    trtexec --loadInputs on the Orin (there is no python tensorrt there).
+    python -m rmind.scripts.decoder_only_verify trials \
+        --onnx decoder_n16.onnx --trials 200 --out trialset/
+
+    # 5. score engine outputs collected on the Orin against that reference
+    python -m rmind.scripts.decoder_only_verify score \
+        --trialset trialset/ --outputs fp16/ --label fp16
+
+Why the trial set holds `--histories` distinct caches rather than 200
+--------------------------------------------------------------------
+A trial's `past_k`/`past_v` are 126 MiB at window 16, so 200 independent caches
+would be 25 GiB to generate, store and copy to the Orin. Instead the set holds
+`--histories` genuinely *streamed* caches -- each one built by running the eager
+model tick by tick over a real frame sequence, exactly as drivr would -- and
+varies the current frame, speed and waypoints within each. The cache is the
+slowest-moving part of the real input (it is driving history), so this is the
+cheap axis to share; it is still a limitation and is reported as one.
+"""
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import torch
+from structlog import get_logger
+from torch import Tensor
+
+from rmind.components.transformer.causal_frame import (
+    CausalFrameTransformer,
+    frame_rope_cos_sin,
+)
+from rmind.models.patch_policy_decoder import PatchPolicyDecoderStep
+from rmind.scripts.decoder_only_export import load_trained_policy
+
+logger = get_logger(__name__)
+
+# `policy.joint_actions` channels. The tokenizer's continuous normalizer is
+# Identity, so gas/brake/steering are already in their `*_normalized` units.
+# `turn_signal` has a far larger dynamic range and dominates any single scalar
+# summary -- report per channel (trt-export skill §4).
+CHANNELS = ("gas_pedal", "brake_pedal", "steering_angle", "turn_signal")
+DEFAULT_FRAMES = "/tmp/native_raw.png,/tmp/frame_video1.jpg,/tmp/frame_video0_.jpg"  # noqa: S108
+# |diff| above this counts as a changed DECISION rather than float noise: float
+# agreement is ~1e-4 and a flipped code moves an action by ~0.1.
+CODE_TOL = 0.02
+
+
+# --------------------------------------------------------------------------- #
+# shared
+# --------------------------------------------------------------------------- #
+
+
+def _trained_step(artifact: str | None, ckpt: str | None) -> PatchPolicyDecoderStep:
+    policy = load_trained_policy(artifact=artifact, ckpt=ckpt)
+    if not isinstance(policy.encoder, CausalFrameTransformer):
+        msg = f"encoder is {type(policy.encoder).__name__}, not CausalFrameTransformer"
+        raise TypeError(msg)
+    return PatchPolicyDecoderStep(policy=policy).eval()
+
+
+def _scale_rel(got: Tensor, ref: Tensor) -> tuple[float, float]:
+    """`(max abs diff, max abs diff / max abs ref)`.
+
+    Scale-relative, never per-element relative: `new_k` has entries at ~1e-7
+    beside entries at ~5, and dividing elementwise turns fp32 round-off on the
+    former into a "relative error of 2.7" (§5).
+    """
+    diff = (got - ref).abs().max().item()
+    scale = ref.abs().max().item()
+    return diff, (diff / scale if scale else float("nan"))
+
+
+def _real_frames(spec: str, size: int) -> list[np.ndarray]:
+    """Center-cropped, resized `[0,1]` RGB CHW frames from real camera images.
+
+    Real frames are not a nicety: synthetic noise both understated one measured
+    failure (4/10 vs 8/10) and manufactured a false one elsewhere, so the
+    harness refuses to run without at least one readable image. PIL rather than
+    cv2 because the rmind venv has no cv2 and must not be re-synced (ptars has
+    no wheel, so `uv sync` destroys it).
+
+    Raises:
+        SystemExit: if not one frame in `spec` could be read.
+    """
+    from PIL import Image  # noqa: PLC0415
+
+    out: list[np.ndarray] = []
+    for name in (s.strip() for s in spec.split(",")):
+        if not name:
+            continue
+        try:
+            img = Image.open(name).convert("RGB")
+        except OSError:
+            logger.warning("unreadable frame, skipping", path=name)
+            continue
+        w, h = img.size
+        side = min(h, w)
+        img = img.crop((
+            (w - side) // 2,
+            (h - side) // 2,
+            (w - side) // 2 + side,
+            (h - side) // 2 + side,
+        )).resize((size, size), Image.Resampling.BILINEAR)
+        arr = np.asarray(img, dtype=np.float32).transpose(2, 0, 1) / 255.0
+        out.append(arr.astype(np.float32))
+    if not out:
+        msg = f"no readable frames in {spec!r}: the harness REQUIRES real camera frames"
+        raise SystemExit(msg)
+    logger.info("real frames", count=len(out))
+    return out
+
+
+def _small_inputs(
+    rng: np.random.Generator, frame: np.ndarray, num_waypoints: int
+) -> dict[str, np.ndarray]:
+    """The per-tick inputs: one real frame plus synthetic speed and waypoints.
+
+    Synthetic speed/waypoints is what makes this harness ~7x harsher than the
+    road (trt-export skill); the image must nonetheless be real, because noise
+    both understated and manufactured failures when it was not.
+    """
+    jitter = np.float32(rng.uniform(0.92, 1.08))
+    return {
+        "inputs_image": np.clip(frame * jitter, 0, 1)[None, None].astype(np.float32),
+        "inputs_speed": np.full((1, 1, 1), rng.uniform(0, 40), np.float32),
+        "inputs_waypoints": np.stack(
+            [
+                rng.normal(0, 0.02, num_waypoints).astype(np.float32),
+                (np.arange(num_waypoints, dtype=np.float32) + 1)
+                * np.float32(rng.uniform(2, 25) / 100.0),
+            ],
+            axis=1,
+        )[None, None].astype(np.float32),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# 1. the streaming / full-window equivalence gate, with trained weights
+# --------------------------------------------------------------------------- #
+
+
+def _readouts(flat: Tensor, num_frames: int) -> Tensor:
+    b, s, d = flat.shape
+    return flat.reshape(b, num_frames, s // num_frames, d)[:, :, -1]
+
+
+def _stream(
+    trunk: CausalFrameTransformer,
+    tokens: Tensor,
+    *,
+    cache_frames: int,
+    frozen_rope: bool = False,
+) -> Tensor:
+    """One frame per tick against a host-side ring, i.e. what drivr does.
+
+    `frozen_rope` is the NEGATIVE CONTROL: it feeds every tick the rotation of
+    frame 0, which is what a runtime that forgot to advance the frame counter
+    would do (§7 failure mode 3). It must miss by orders of magnitude, otherwise
+    the gate is not measuring the positional scheme at all.
+    """
+    b, num_frames, k, _ = tokens.shape
+    past_k, past_v, bias = trunk.empty_cache(
+        batch_size=b, cache_frames=cache_frames, dtype=tokens.dtype
+    )
+    outs: list[Tensor] = []
+    for t in range(num_frames):
+        cos, sin = frame_rope_cos_sin(
+            torch.tensor(0 if frozen_rope else t),
+            head_dim=trunk.head_dim,
+            base=trunk.rope_base,
+        )
+        out, new_k, new_v = trunk.step(
+            tokens[:, t],
+            past_k=past_k,
+            past_v=past_v,
+            cos=cos.to(tokens.dtype),
+            sin=sin.to(tokens.dtype),
+            cache_bias=bias,
+        )
+        outs.append(out[:, -1])
+        if not cache_frames:
+            continue
+        # ring slot write: touch ONE frame block, move nothing (§7). Valid
+        # because attention is permutation-invariant over keys and every key
+        # carries its own rotation and its own cache_bias entry.
+        slot = slice((t % cache_frames) * k, (t % cache_frames + 1) * k)
+        past_k, past_v, bias = past_k.clone(), past_v.clone(), bias.clone()
+        past_k[..., slot, :] = new_k
+        past_v[..., slot, :] = new_v
+        bias[..., slot] = 0.0
+    return torch.stack(outs, dim=1)
+
+
+def cmd_gates(args: argparse.Namespace) -> int:  # noqa: PLR0914
+    step = _trained_step(args.artifact, args.ckpt)
+    trunk = step.trunk
+    window = args.window or trunk.window
+    if window is None:
+        msg = "--window required: the trunk has window=None"
+        raise SystemExit(msg)
+    # The full forward needs the DENSE mask path: FlexAttention has no CPU
+    # backward, is torch.compile-only to be block-sparse, and is numerically
+    # equivalent to sdpa anyway (§11.2). `step` is always sdpa regardless.
+    trunk.attention_impl = "sdpa"
+    for layer in trunk.layers:
+        layer.attn.attention_impl = "sdpa"
+
+    num_frames = window + 1  # one frame past a full window: the sliding case
+    k = trunk.tokens_per_frame
+    g = torch.Generator().manual_seed(1337)
+    tokens32 = torch.randn(1, num_frames, k, trunk.dim_model, generator=g)
+
+    logger.info(
+        "gate geometry",
+        window=window,
+        num_frames=num_frames,
+        tokens_per_frame=k,
+        cached_keys=(window - 1) * k,
+        seq_len=num_frames * k,
+    )
+
+    results: dict[str, Any] = {"window": window, "num_frames": num_frames}
+    for dtype_name, dtype in (("float64", torch.float64), ("float32", torch.float32)):
+        t = trunk.to(dtype)
+        tokens = tokens32.to(dtype)
+        flat = tokens.reshape(1, num_frames * k, trunk.dim_model)
+        with torch.inference_mode():
+            recompute = _readouts(t(flat, num_frames=num_frames), num_frames)
+            streamed = _stream(t, tokens, cache_frames=window - 1)
+            control = _stream(t, tokens, cache_frames=window - 1, frozen_rope=True)
+        abs_d, rel_d = _scale_rel(streamed, recompute)
+        c_abs, c_rel = _scale_rel(control, recompute)
+        results[dtype_name] = {
+            "abs": abs_d,
+            "rel": rel_d,
+            "control_abs": c_abs,
+            "control_rel": c_rel,
+        }
+        logger.info(
+            "streaming == full windowed forward",
+            dtype=dtype_name,
+            abs_diff=f"{abs_d:.3e}",
+            scale_rel=f"{rel_d:.3e}",
+            negative_control_rel=f"{c_rel:.3e}",
+        )
+    trunk.to(torch.float32)
+
+    # float64 must be at machine epsilon (the equivalence is EXACT, so any
+    # larger residual is a real defect), float32 only at accumulation noise.
+    ok = (
+        results["float64"]["rel"] < 1e-12  # noqa: PLR2004
+        and results["float32"]["rel"] < 1e-4  # noqa: PLR2004
+        and results["float64"]["control_rel"] > 1e-3  # noqa: PLR2004
+    )
+    logger.info("GATE", passed=ok)
+    if args.out:
+        Path(args.out).write_text(json.dumps(results, indent=2), encoding="utf-8")
+    return 0 if ok else 1
+
+
+# --------------------------------------------------------------------------- #
+# 2. ONNX vs eager
+# --------------------------------------------------------------------------- #
+
+
+def _eager_feed(
+    step: PatchPolicyDecoderStep, cache_frames: int, seed: int
+) -> dict[str, Tensor]:
+    """A warm-cache input set. `past_k`/`past_v` are randn, which is the right
+    SCALE for real keys but not real keys -- `trials` streams the real thing."""
+    g = torch.Generator().manual_seed(seed)
+    past_k, past_v, bias = step.empty_cache(cache_frames=cache_frames)
+    cos, sin = step.rope(cache_frames)
+    return {
+        "image": torch.rand(1, 1, 3, 224, 224, generator=g),
+        "speed": torch.rand(1, 1, 1, generator=g) * 130,
+        "waypoints": torch.rand(1, 1, 10, 2, generator=g) * 2 - 1,
+        "past_k": torch.randn(past_k.shape, generator=g),
+        "past_v": torch.randn(past_v.shape, generator=g),
+        "cache_bias": torch.zeros_like(bias),
+        "rope_cos": cos,
+        "rope_sin": sin,
+    }
+
+
+def cmd_onnx_vs_eager(args: argparse.Namespace) -> int:
+    import onnxruntime as ort  # noqa: PLC0415
+
+    step = _trained_step(args.artifact, args.ckpt)
+    sess = ort.InferenceSession(str(args.onnx), providers=["CPUExecutionProvider"])
+    shapes = {i.name: i.shape for i in sess.get_inputs()}
+    cache_frames = shapes["inputs_past_k"][3] // step.trunk.tokens_per_frame
+
+    worst = 0.0
+    results: dict[str, Any] = {"cache_frames": cache_frames, "trials": {}}
+    for trial in range(args.trials):
+        feed = _eager_feed(step, cache_frames, seed=1000 + trial)
+        with torch.inference_mode():
+            eager = step(feed)
+        got = sess.run(None, {f"inputs_{k}": v.numpy() for k, v in feed.items()})
+        names = [o.name for o in sess.get_outputs()]
+        ref = {
+            "policy.joint_actions": eager["policy", "joint_actions"],
+            "new_k": eager["new_k"],
+            "new_v": eager["new_v"],
+        }
+        per_trial = {}
+        for name, value in zip(names, got, strict=True):
+            abs_d, rel_d = _scale_rel(torch.from_numpy(value), ref[name])
+            per_trial[name] = {"abs": abs_d, "scale_rel": rel_d}
+            worst = max(worst, rel_d)
+        results["trials"][trial] = per_trial
+        logger.info(
+            "onnx vs eager",
+            trial=trial,
+            **{
+                k: f"abs {v['abs']:.2e} rel {v['scale_rel']:.2e}"
+                for k, v in per_trial.items()
+            },
+        )
+
+    ok = worst < args.tol
+    results["worst_scale_rel"] = worst
+    logger.info("ONNX-vs-EAGER GATE", worst_scale_rel=f"{worst:.3e}", passed=ok)
+    if args.out:
+        Path(args.out).write_text(json.dumps(results, indent=2), encoding="utf-8")
+    return 0 if ok else 1
+
+
+# --------------------------------------------------------------------------- #
+# 3. margin screen (trt-export skill §4a), on the decoder step graph
+# --------------------------------------------------------------------------- #
+
+
+def cmd_margins(args: argparse.Namespace) -> int:  # noqa: PLR0914, PLR0915
+    import onnx  # noqa: PLC0415
+    import onnxruntime as ort  # noqa: PLC0415
+    from onnx import TensorProto, helper  # noqa: PLC0415
+
+    model = onnx.load(str(args.onnx))
+    graph = model.graph
+    exposed = {o.name for o in graph.output}
+    probes: list[tuple[str, str]] = []
+    for node in graph.node:
+        if node.op_type != "ArgMax":
+            continue
+        src = node.input[0]
+        if src not in exposed:
+            graph.output.append(
+                helper.make_tensor_value_info(src, TensorProto.FLOAT, None)
+            )
+            exposed.add(src)
+        probes.append((node.name, src))
+    if not probes:
+        logger.warning("no ArgMax in the graph -- nothing to screen")
+        return 0
+    logger.info("ArgMax probes", count=len(probes))
+
+    probe_path = Path(args.workdir) / "margin_probe.onnx"
+    probe_path.parent.mkdir(parents=True, exist_ok=True)
+    onnx.save(
+        model,
+        str(probe_path),
+        save_as_external_data=True,
+        all_tensors_to_one_file=True,
+        location=probe_path.name + ".w",
+        size_threshold=1024,
+    )
+    sess = ort.InferenceSession(str(probe_path), providers=["CPUExecutionProvider"])
+    meta = {i.name: (i.shape, i.type) for i in sess.get_inputs()}
+    cache_tokens = meta["inputs_past_k"][0][3]
+    num_waypoints = meta["inputs_waypoints"][0][2]
+    frames = _real_frames(args.frames, meta["inputs_image"][0][-1])
+
+    rng = np.random.default_rng(args.seed)
+    per_probe: dict[str, list[float]] = {name: [] for name, _ in probes}
+    names = [o.name for o in sess.get_outputs()]
+    for trial in range(args.trials):
+        feed = _small_inputs(rng, frames[trial % len(frames)], num_waypoints)
+        # a WARM cache: unfilled slots would mask the cache away entirely and
+        # screen a context the served model never sees
+        feed["inputs_past_k"] = rng.standard_normal(
+            meta["inputs_past_k"][0], dtype=np.float32
+        )
+        feed["inputs_past_v"] = rng.standard_normal(
+            meta["inputs_past_v"][0], dtype=np.float32
+        )
+        feed["inputs_cache_bias"] = np.zeros((1, 1, 1, cache_tokens), np.float32)
+        cos, sin = frame_rope_cos_sin(
+            torch.tensor(int(rng.integers(0, 4096))),
+            head_dim=meta["inputs_rope_cos"][0][-1],
+            base=1000.0,
+        )
+        feed["inputs_rope_cos"] = cos.reshape(1, -1).numpy().astype(np.float32)
+        feed["inputs_rope_sin"] = sin.reshape(1, -1).numpy().astype(np.float32)
+
+        got = dict(zip(names, sess.run(None, feed), strict=True))
+        for probe_name, tensor_name in probes:
+            logits = np.asarray(got[tensor_name], dtype=np.float64)
+            flat = logits.reshape(-1, logits.shape[-1])
+            top2 = np.sort(flat, axis=-1)[:, -2:]
+            margin = top2[:, 1] - top2[:, 0]
+            # fp16 spacing at the top1 magnitude: below one of these the two
+            # codes are not distinguishable in fp16 at all
+            ulp = np.spacing(np.abs(top2[:, 1]).astype(np.float16)).astype(np.float64)
+            per_probe[probe_name].extend((margin / np.maximum(ulp, 1e-12)).tolist())
+
+    summary: dict[str, Any] = {}
+    overall_min = float("inf")
+    for probe_name, ulps in per_probe.items():
+        arr = np.asarray(ulps)
+        summary[probe_name] = {
+            "n": int(arr.size),
+            "min_ulp": float(arr.min()),
+            "p1_ulp": float(np.percentile(arr, 1)),
+            "median_ulp": float(np.median(arr)),
+            "frac_under_1_ulp": float((arr < 1).mean()),
+            "frac_under_4_ulp": float((arr < 4).mean()),  # noqa: PLR2004
+        }
+        overall_min = min(overall_min, summary[probe_name]["min_ulp"])
+        logger.info("margin", probe=probe_name, **summary[probe_name])
+
+    verdict = (
+        "fp16 WILL flip decisions -- serve fp32"
+        if overall_min < 1
+        else "marginal: verify parity at n>=200 before serving low precision"
+        if overall_min < 4  # noqa: PLR2004
+        else "fp16 has always been clean at this margin"
+    )
+    logger.info("MARGIN SCREEN", min_ulp=f"{overall_min:.3f}", verdict=verdict)
+    if args.out:
+        Path(args.out).write_text(
+            json.dumps(
+                {"min_ulp": overall_min, "verdict": verdict, "probes": summary},
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# 4. trial set + ORT fp32 reference + raw .dat for trtexec
+# --------------------------------------------------------------------------- #
+
+
+def cmd_trials(args: argparse.Namespace) -> int:  # noqa: PLR0914
+    import onnxruntime as ort  # noqa: PLC0415
+
+    out = Path(args.out)
+    (out / "inputs").mkdir(parents=True, exist_ok=True)
+    (out / "caches").mkdir(parents=True, exist_ok=True)
+
+    step = _trained_step(args.artifact, args.ckpt)
+    sess = ort.InferenceSession(str(args.onnx), providers=["CPUExecutionProvider"])
+    meta = {i.name: i.shape for i in sess.get_inputs()}
+    k = step.trunk.tokens_per_frame
+    cache_frames = meta["inputs_past_k"][3] // k
+    num_waypoints = meta["inputs_waypoints"][2]
+    frames = _real_frames(args.frames, meta["inputs_image"][-1])
+    rng = np.random.default_rng(args.seed)
+
+    per_history = args.trials // args.histories
+    if per_history * args.histories != args.trials:
+        msg = (
+            f"--trials {args.trials} must be divisible by --histories {args.histories}"
+        )
+        raise SystemExit(msg)
+
+    manifest: dict[str, Any] = {
+        "onnx": str(args.onnx),
+        "trials": args.trials,
+        "histories": args.histories,
+        "cache_frames": cache_frames,
+        "code_tol": CODE_TOL,
+        "channels": list(CHANNELS),
+        "frames": args.frames,
+        "seed": args.seed,
+        "items": [],
+    }
+    reference = np.zeros(
+        (args.trials, *tuple(sess.get_outputs()[0].shape[1:])), np.float32
+    )
+
+    trial = 0
+    for history in range(args.histories):
+        # --- build this history by genuinely STREAMING the eager model, tick by
+        # tick, exactly as drivr would: cold cache, ring slot writes, monotone
+        # frame counter. Not randn -- these are real keys of real frames.
+        past_k, past_v, bias = step.empty_cache(cache_frames=cache_frames)
+        for tick in range(cache_frames):
+            small = _small_inputs(
+                rng, frames[(history + tick) % len(frames)], num_waypoints
+            )
+            cos, sin = step.rope(tick)
+            feed = {
+                "image": torch.from_numpy(small["inputs_image"]),
+                "speed": torch.from_numpy(small["inputs_speed"]),
+                "waypoints": torch.from_numpy(small["inputs_waypoints"]),
+                "past_k": past_k,
+                "past_v": past_v,
+                "cache_bias": bias,
+                "rope_cos": cos,
+                "rope_sin": sin,
+            }
+            with torch.inference_mode():
+                res = step(feed)
+            slot = slice((tick % cache_frames) * k, (tick % cache_frames + 1) * k)
+            past_k, past_v, bias = past_k.clone(), past_v.clone(), bias.clone()
+            past_k[..., slot, :] = res["new_k"]
+            past_v[..., slot, :] = res["new_v"]
+            bias[..., slot] = 0.0
+        logger.info("history streamed", history=history, ticks=cache_frames)
+
+        past_k_np = past_k.numpy().astype(np.float32)
+        past_v_np = past_v.numpy().astype(np.float32)
+        bias_np = bias.numpy().astype(np.float32)
+        for name, value in (
+            ("past_k", past_k_np),
+            ("past_v", past_v_np),
+            ("cache_bias", bias_np),
+        ):
+            value.tofile(out / "caches" / f"h{history}_{name}.dat")
+
+        for _ in range(per_history):
+            small = _small_inputs(rng, frames[trial % len(frames)], num_waypoints)
+            frame_index = cache_frames + int(rng.integers(0, 512))
+            cos, sin = step.rope(frame_index)
+            feed = {
+                **small,
+                "inputs_past_k": past_k_np,
+                "inputs_past_v": past_v_np,
+                "inputs_cache_bias": bias_np,
+                "inputs_rope_cos": cos.numpy().astype(np.float32),
+                "inputs_rope_sin": sin.numpy().astype(np.float32),
+            }
+            reference[trial] = sess.run(["policy.joint_actions"], feed)[0][0]
+            for name in (
+                "inputs_image",
+                "inputs_speed",
+                "inputs_waypoints",
+                "inputs_rope_cos",
+                "inputs_rope_sin",
+            ):
+                feed[name].tofile(out / "inputs" / f"t{trial:03d}_{name}.dat")
+            manifest["items"].append({"trial": trial, "history": history})
+            if trial % 20 == 0:
+                logger.info("trial", trial=trial, action0=reference[trial][0].tolist())
+            trial += 1
+
+    np.save(out / "reference_ort_fp32.npy", reference)
+    (out / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    logger.info(
+        "trial set written",
+        path=str(out),
+        trials=args.trials,
+        histories=args.histories,
+        reference_shape=list(reference.shape),
+    )
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# 5. score collected engine outputs against the reference
+# --------------------------------------------------------------------------- #
+
+
+def cmd_score(args: argparse.Namespace) -> int:  # noqa: PLR0914
+    trialset = Path(args.trialset)
+    manifest = json.loads((trialset / "manifest.json").read_text())
+    reference = np.load(trialset / "reference_ort_fp32.npy")
+    tol = args.code_tol
+
+    got = []
+    missing = []
+    for trial in range(manifest["trials"]):
+        path = Path(args.outputs) / f"t{trial:03d}_joint_actions.dat"
+        if not path.exists():
+            missing.append(trial)
+            continue
+        got.append((trial, np.fromfile(path, np.float32).reshape(reference.shape[1:])))
+    if missing:
+        logger.warning("missing engine outputs", count=len(missing), first=missing[:5])
+    if not got:
+        msg = f"no engine outputs found in {args.outputs}"
+        raise SystemExit(msg)
+
+    changed: list[dict[str, Any]] = []
+    per_channel = {c: {"max": 0.0, "sum": 0.0, "n": 0} for c in CHANNELS}
+    worst = 0.0
+    for trial, value in got:
+        diff = np.abs(value - reference[trial])
+        worst = max(worst, float(diff.max()))
+        for i, channel in enumerate(CHANNELS):
+            column = diff[..., i]
+            per_channel[channel]["max"] = max(
+                per_channel[channel]["max"], float(column.max())
+            )
+            per_channel[channel]["sum"] += float(column.sum())
+            per_channel[channel]["n"] += int(column.size)
+        if diff.max() > tol:
+            flipped = [
+                CHANNELS[i] for i in range(len(CHANNELS)) if diff[..., i].max() > tol
+            ]
+            changed.append({
+                "trial": trial,
+                "max_abs": float(diff.max()),
+                "channels": flipped,
+            })
+
+    control_only = [
+        c
+        for c in changed
+        if set(c["channels"]) <= {"gas_pedal", "brake_pedal", "steering_angle"}
+    ]
+    summary = {
+        "label": args.label,
+        "scored": len(got),
+        "decision_changes": len(changed),
+        "decision_changes_control_only": len(control_only),
+        "worst_max_abs": worst,
+        "code_tol": tol,
+        "per_channel": {
+            c: {"max_abs": v["max"], "mean_abs": v["sum"] / max(v["n"], 1)}
+            for c, v in per_channel.items()
+        },
+        "changed": changed,
+    }
+    logger.info(
+        "PARITY",
+        label=args.label,
+        decisions=f"{len(changed)}/{len(got)}",
+        control_only=f"{len(control_only)}/{len(got)}",
+        worst_max_abs=f"{worst:.6f}",
+    )
+    for channel, value in summary["per_channel"].items():
+        logger.info(
+            "per channel",
+            channel=channel,
+            max_abs=f"{value['max_abs']:.4e}",
+            mean_abs=f"{value['mean_abs']:.4e}",
+        )
+    if args.out:
+        Path(args.out).write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    def weights(p: argparse.ArgumentParser) -> None:
+        g = p.add_mutually_exclusive_group(required=True)
+        g.add_argument("--artifact", help="e.g. yaak/rmind/model-do8m9ot8:v0")
+        g.add_argument("--ckpt", help="local checkpoint path")
+
+    p_gates = sub.add_parser("gates", help="streaming == full windowed forward")
+    weights(p_gates)
+    p_gates.add_argument("--window", type=int, default=None)
+    p_gates.add_argument("--out", default=None)
+    p_gates.set_defaults(fn=cmd_gates)
+
+    p_ove = sub.add_parser("onnx-vs-eager", help="ORT CPU fp32 vs PyTorch")
+    weights(p_ove)
+    p_ove.add_argument("--onnx", type=Path, required=True)
+    p_ove.add_argument("--trials", type=int, default=3)
+    p_ove.add_argument("--tol", type=float, default=1e-5, help="scale-relative")
+    p_ove.add_argument("--out", default=None)
+    p_ove.set_defaults(fn=cmd_onnx_vs_eager)
+
+    p_m = sub.add_parser("margins", help="ArgMax top1-top2 in fp16 ULPs")
+    p_m.add_argument("--onnx", type=Path, required=True)
+    p_m.add_argument("--trials", type=int, default=25)
+    p_m.add_argument("--frames", default=DEFAULT_FRAMES)
+    p_m.add_argument("--workdir", default="/tmp/decoder_margin")  # noqa: S108
+    p_m.add_argument("--seed", type=int, default=1337)
+    p_m.add_argument("--out", default=None)
+    p_m.set_defaults(fn=cmd_margins)
+
+    p_t = sub.add_parser("trials", help="trial set + ORT fp32 reference + .dat files")
+    weights(p_t)
+    p_t.add_argument("--onnx", type=Path, required=True)
+    p_t.add_argument("--trials", type=int, default=200)
+    p_t.add_argument("--histories", type=int, default=10)
+    p_t.add_argument("--frames", default=DEFAULT_FRAMES)
+    p_t.add_argument("--seed", type=int, default=1337)
+    p_t.add_argument("--out", required=True)
+    p_t.set_defaults(fn=cmd_trials)
+
+    p_s = sub.add_parser("score", help="score engine outputs vs the reference")
+    p_s.add_argument("--trialset", required=True)
+    p_s.add_argument("--outputs", required=True)
+    p_s.add_argument("--label", default="engine")
+    p_s.add_argument("--code-tol", type=float, default=CODE_TOL)
+    p_s.add_argument("--out", default=None)
+    p_s.set_defaults(fn=cmd_score)
+
+    args = parser.parse_args()
+    return int(args.fn(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/rmind/scripts/decoder_parity_orin.py
+++ b/src/rmind/scripts/decoder_parity_orin.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python
+# This file is deliberately exempt from the repo's lint profile, and `T201` is the
+# reason that matters: `ruff` runs here with `fix = true, unsafe-fixes = true`, and
+# left to itself it DELETES every `print` in this script -- which is the script's
+# entire product. Its output IS the measurement. The same trap cost a benchmark run
+# once already (docs/decoder_only_kv_cache.md §11.6.2, where PLR6104 rewrote a
+# `mask_mod` into an in-place op and killed the FlexAttention path).
+#
+# The rest is the ordinary shape of a standalone operational script rather than
+# library code: one long `main` that reads as a procedure, lazy `tensorrt`/`torch`
+# imports so the ORT-only paths work on a host with no CUDA, and messages passed
+# straight to `SystemExit`.
+# ruff: noqa: T201, TRY003, EM101, EM102, ANN001, ANN201, ANN204, PLC0415, C901,
+# ruff: noqa: PLR0912, PLR0914, PLR0915, RUF015, RUF069, B905, C416, EXE001,
+# ruff: noqa: FURB101, PTH123, PLR6201
+"""Decision-parity ladder for the KV-cached decoder step, run entirely on the Orin.
+
+Self-contained on purpose: the KV cache is 126 MiB per trial at window 16, so
+shipping 200 pre-built caches from the NAS would be 25 GiB over a ZeroTier relay.
+Instead the histories are streamed HERE, using ONNX Runtime on the very graph the
+engines were built from -- which is exactly the streaming the runtime does, and
+ORT-vs-eager is separately gated to ~1e-5 on sisyphos.
+
+    decoder_parity_orin.py --onnx M.onnx --engines a.trt,b.trt --labels a,b \
+        --trials 200 --histories 10 --frames f1.jpg,f2.jpg,f3.jpg
+
+What is scored is DECISION CHANGES -- trials where any action channel moves more
+than --code-tol -- not float error. The graph ends in ArgMax over code logits, so
+a tiny numeric error flips a discrete code and the action moves by a step, not a
+nudge. Float noise is ~1e-4 and a code flip is ~0.1, so the threshold is not
+delicate.
+
+Rules this obeys, each learned by someone getting it wrong (trt-export skill §5):
+  * real camera frames, several of them -- synthetic noise both understated a
+    failure (4/10 vs 8/10) and manufactured a false one;
+  * >=50 trials to detect, >=200 to decide (2/50 and 4/50 are indistinguishable);
+  * ALWAYS an fp32 control, so precision loss can be told apart from ArgMax
+    boundary ties -- an input sitting ON a boundary flips under any perturbation;
+  * per-channel magnitudes, because turn_signal's dynamic range dominates any
+    single headline number.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+CHANNELS = ("gas_pedal", "brake_pedal", "steering_angle", "turn_signal")
+CONTROL = ("gas_pedal", "brake_pedal", "steering_angle")
+
+
+def rope_cos_sin(frame_index: int, head_dim: int, base: float = 1000.0):
+    """Frame-RoPE `(1, head_dim)` cos/sin, float64 internally then cast to fp32.
+
+    Mirrors rmind.components.transformer.causal_frame.frame_rope_cos_sin: the
+    half-split (GPT-NeoX/Llama) pairing, computed in float64 so a long-episode
+    absolute frame counter stays exact. This is the serving contract -- drivr
+    computes these host-side, which is why the graph has zero Sin/Cos nodes.
+    """
+    inv_freq = base ** (-np.arange(0, head_dim, 2, dtype=np.float64) / head_dim)
+    angle = float(frame_index) * inv_freq
+    cos = np.concatenate([np.cos(angle), np.cos(angle)])
+    sin = np.concatenate([np.sin(angle), np.sin(angle)])
+    return (
+        cos.reshape(1, -1).astype(np.float32),
+        sin.reshape(1, -1).astype(np.float32),
+    )
+
+
+def real_frames(spec: str, size: int) -> list[np.ndarray]:
+    import cv2
+
+    out = []
+    for name in (s.strip() for s in spec.split(",") if s.strip()):
+        img = cv2.imread(name)
+        if img is None:
+            print(f"  !! unreadable, skipping: {name}")
+            continue
+        h, w = img.shape[:2]
+        side = min(h, w)
+        img = img[(h - side) // 2 : (h + side) // 2, (w - side) // 2 : (w + side) // 2]
+        img = cv2.resize(img, (size, size), interpolation=cv2.INTER_AREA)
+        out.append((img[:, :, ::-1].transpose(2, 0, 1) / 255.0).astype(np.float32))
+    if not out:
+        raise SystemExit(f"no readable frames in {spec!r} -- real frames are required")
+    print(f"  real frames: {len(out)}")
+    return out
+
+
+def small_inputs(rng, frame, num_waypoints):
+    jitter = np.float32(rng.uniform(0.92, 1.08))
+    return {
+        "inputs_image": np.clip(frame * jitter, 0, 1)[None, None].astype(np.float32),
+        "inputs_speed": np.full((1, 1, 1), rng.uniform(0, 40), np.float32),
+        "inputs_waypoints": np.stack(
+            [
+                rng.normal(0, 0.02, num_waypoints).astype(np.float32),
+                (np.arange(num_waypoints, dtype=np.float32) + 1)
+                * np.float32(rng.uniform(2, 25) / 100.0),
+            ],
+            axis=1,
+        )[None, None].astype(np.float32),
+    }
+
+
+class TRTRunner:
+    """Static-shape engine runner. Validates EVERY binding against the engine.
+
+    `set_tensor_address` takes a raw pointer with no size validation, so a cache
+    allocated for a different cache_frames / layer count / head count / dtype is
+    not an error -- TRT reinterprets the buffer and the model merely looks weak
+    (docs/decoder_only_kv_cache.md §3). Hence the explicit check.
+    """
+
+    def __init__(self, path: Path):
+        import tensorrt as trt
+        import torch
+
+        self.torch = torch
+        logger = trt.Logger(trt.Logger.ERROR)
+        with open(path, "rb") as f:
+            self.engine = trt.Runtime(logger).deserialize_cuda_engine(f.read())
+        if self.engine is None:
+            raise SystemExit(f"failed to deserialize {path} (TRT/arch mismatch?)")
+        self.ctx = self.engine.create_execution_context()
+        self.io = []
+        for i in range(self.engine.num_io_tensors):
+            name = self.engine.get_tensor_name(i)
+            self.io.append((
+                name,
+                self.engine.get_tensor_mode(name) == trt.TensorIOMode.INPUT,
+                tuple(self.engine.get_tensor_shape(name)),
+                trt.nptype(self.engine.get_tensor_dtype(name)),
+            ))
+
+    def describe(self):
+        return [
+            {
+                "name": n,
+                "input": bool(i),
+                "shape": list(s),
+                "dtype": np.dtype(d).name,
+                "bytes": int(np.prod(s)) * np.dtype(d).itemsize,
+            }
+            for n, i, s, d in self.io
+        ]
+
+    def __call__(self, feed):
+        torch = self.torch
+        # `keep` holds a reference to every device buffer until after
+        # synchronize(): set_tensor_address stores a raw pointer, so letting an
+        # input tensor be garbage-collected before execution frees memory the
+        # engine is about to read, with no error and arbitrary results.
+        keep, out = [], {}
+        for name, is_in, shape, npdt in self.io:
+            if is_in:
+                if name not in feed:
+                    raise SystemExit(f"no feed for engine input {name}")
+                src = feed[name]
+                if tuple(src.shape) != shape:
+                    raise SystemExit(
+                        f"{name}: engine wants {shape}, got {tuple(src.shape)} "
+                        "-- set_tensor_address would NOT catch this"
+                    )
+                t = torch.from_numpy(np.ascontiguousarray(src.astype(npdt))).cuda()
+            else:
+                t = torch.empty(shape, dtype=getattr(torch, np.dtype(npdt).name)).cuda()
+                out[name] = t
+            keep.append(t)
+            self.ctx.set_tensor_address(name, int(t.data_ptr()))
+        stream = torch.cuda.Stream()
+        with torch.cuda.stream(stream):
+            self.ctx.execute_async_v3(stream.cuda_stream)
+        stream.synchronize()
+        result = {k: v.cpu().numpy() for k, v in out.items()}
+        del keep
+        return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--onnx", type=Path, required=True)
+    ap.add_argument("--engines", required=True, help="comma-separated .trt paths")
+    ap.add_argument("--labels", required=True, help="comma-separated labels")
+    ap.add_argument("--trials", type=int, default=200)
+    ap.add_argument("--histories", type=int, default=10)
+    ap.add_argument("--frames", required=True)
+    ap.add_argument("--code-tol", type=float, default=0.02)
+    ap.add_argument("--seed", type=int, default=1337)
+    ap.add_argument("--out", type=Path, required=True)
+    a = ap.parse_args()
+
+    import onnxruntime as ort
+
+    engines = [Path(p) for p in a.engines.split(",")]
+    labels = a.labels.split(",")
+    if len(engines) != len(labels):
+        raise SystemExit("--engines and --labels must have the same length")
+
+    print("== ORT fp32 reference session (CPU) ==")
+    sess = ort.InferenceSession(str(a.onnx), providers=["CPUExecutionProvider"])
+    meta = {i.name: i.shape for i in sess.get_inputs()}
+    tokens_per_frame = [o.shape for o in sess.get_outputs() if o.name == "new_k"][0][3]
+    cache_tokens = meta["inputs_past_k"][3]
+    cache_frames = cache_tokens // tokens_per_frame
+    head_dim = meta["inputs_rope_cos"][-1]
+    num_waypoints = meta["inputs_waypoints"][2]
+    image_hw = meta["inputs_image"][-1]
+    print(
+        f"  cache_frames={cache_frames} tokens_per_frame={tokens_per_frame} "
+        f"cache_tokens={cache_tokens} head_dim={head_dim} image={image_hw}"
+    )
+
+    runners = {}
+    for label, path in zip(labels, engines):
+        print(f"== loading engine {label}: {path.name} ==")
+        runners[label] = TRTRunner(path)
+
+    # KV-cache memory, read off the ENGINE rather than re-derived from a formula
+    cache_report = {}
+    for label, runner in runners.items():
+        rows = [b for b in runner.describe() if b["name"] in
+                ("inputs_past_k", "inputs_past_v", "inputs_cache_bias",
+                 "new_k", "new_v")]
+        total = sum(b["bytes"] for b in rows if b["name"].startswith("inputs_past"))
+        cache_report[label] = {
+            "bindings": rows,
+            "kv_cache_bytes": total,
+            "kv_cache_mib": total / 1024 / 1024,
+        }
+        print(f"  {label}: KV cache = {total / 1024 / 1024:.2f} MiB "
+              f"({[b['dtype'] for b in rows if b['name'] == 'inputs_past_k'][0]})")
+
+    frames = real_frames(a.frames, image_hw)
+    rng = np.random.default_rng(a.seed)
+    per_history = a.trials // a.histories
+    if per_history * a.histories != a.trials:
+        raise SystemExit("--trials must be divisible by --histories")
+
+    reference = np.zeros((a.trials, *tuple(sess.get_outputs()[0].shape[1:])), np.float32)
+    got = {label: np.zeros_like(reference) for label in labels}
+
+    trial = 0
+    for history in range(a.histories):
+        # --- stream this history tick by tick through ORT: cold cache, ring slot
+        # writes, monotone frame counter. Real keys of real frames, not randn.
+        past_k = np.zeros(meta["inputs_past_k"], np.float32)
+        past_v = np.zeros(meta["inputs_past_v"], np.float32)
+        bias = np.full((1, 1, 1, cache_tokens), -1e4, np.float32)
+        for tick in range(cache_frames):
+            cos, sin = rope_cos_sin(tick, head_dim)
+            feed = small_inputs(
+                rng, frames[(history + tick) % len(frames)], num_waypoints
+            )
+            feed |= {
+                "inputs_past_k": past_k,
+                "inputs_past_v": past_v,
+                "inputs_cache_bias": bias,
+                "inputs_rope_cos": cos,
+                "inputs_rope_sin": sin,
+            }
+            _, new_k, new_v = sess.run(
+                ["policy.joint_actions", "new_k", "new_v"], feed
+            )
+            lo = (tick % cache_frames) * tokens_per_frame
+            hi = lo + tokens_per_frame
+            past_k[:, :, :, lo:hi, :] = new_k
+            past_v[:, :, :, lo:hi, :] = new_v
+            bias[:, :, :, lo:hi] = 0.0
+        print(f"  history {history}: streamed {cache_frames} ticks")
+
+        for _ in range(per_history):
+            cos, sin = rope_cos_sin(
+                cache_frames + int(rng.integers(0, 512)), head_dim
+            )
+            feed = small_inputs(rng, frames[trial % len(frames)], num_waypoints)
+            feed |= {
+                "inputs_past_k": past_k,
+                "inputs_past_v": past_v,
+                "inputs_cache_bias": bias,
+                "inputs_rope_cos": cos,
+                "inputs_rope_sin": sin,
+            }
+            reference[trial] = sess.run(["policy.joint_actions"], feed)[0][0]
+            for label, runner in runners.items():
+                got[label][trial] = runner({k: v for k, v in feed.items()})[
+                    "policy.joint_actions"
+                ][0]
+            if trial % 10 == 0:
+                print(f"    trial {trial}/{a.trials}", flush=True)
+            trial += 1
+
+    summary = {
+        "onnx": str(a.onnx),
+        "trials": a.trials,
+        "histories": a.histories,
+        "code_tol": a.code_tol,
+        "frames": a.frames,
+        "seed": a.seed,
+        "cache": cache_report,
+        "engines": {},
+    }
+    for label in labels:
+        diff = np.abs(got[label] - reference)
+        flat = diff.reshape(a.trials, -1, len(CHANNELS))
+        changed, control_only = [], 0
+        for t in range(a.trials):
+            if flat[t].max() > a.code_tol:
+                chans = [
+                    CHANNELS[c]
+                    for c in range(len(CHANNELS))
+                    if flat[t, :, c].max() > a.code_tol
+                ]
+                changed.append({
+                    "trial": t,
+                    "max_abs": float(flat[t].max()),
+                    "channels": chans,
+                })
+                if set(chans) <= set(CONTROL):
+                    control_only += 1
+        summary["engines"][label] = {
+            "decision_changes": len(changed),
+            "decision_changes_control_only": control_only,
+            "worst_max_abs": float(diff.max()),
+            "mean_abs": float(diff.mean()),
+            "bit_exact": bool(diff.max() == 0.0),
+            "per_channel": {
+                CHANNELS[c]: {
+                    "max_abs": float(flat[:, :, c].max()),
+                    "mean_abs": float(flat[:, :, c].mean()),
+                }
+                for c in range(len(CHANNELS))
+            },
+            "changed": changed,
+        }
+        e = summary["engines"][label]
+        print(
+            f"\n== {label}: decisions {len(changed)}/{a.trials} "
+            f"(control-only {control_only}) worst |d| {diff.max():.6f} "
+            f"mean {diff.mean():.3e} bit_exact={e['bit_exact']}"
+        )
+        for c, v in e["per_channel"].items():
+            print(f"     {c:16s} max {v['max_abs']:.4e}  mean {v['mean_abs']:.4e}")
+
+    a.out.parent.mkdir(parents=True, exist_ok=True)
+    a.out.write_text(json.dumps(summary, indent=2))
+    print(f"\nwrote {a.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/rmind/scripts/train.py
+++ b/src/rmind/scripts/train.py
@@ -4,12 +4,12 @@ from subprocess import check_output  # noqa: S404
 import hydra
 import pytorch_lightning as pl
 import torch
-import wandb
 from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf
 from pytorch_lightning.utilities import rank_zero_only
 from structlog import get_logger
 
+import wandb
 from rmind.utils.precision import auto_precision
 
 logger = get_logger(__name__)

--- a/tests/bench_causal_frame.py
+++ b/tests/bench_causal_frame.py
@@ -276,6 +276,14 @@ def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("section", choices=["attention", "trunk", "vit"])
     parser.add_argument("--batches", default="4,16")
+    parser.add_argument(
+        "--only",
+        default=None,
+        help='restrict GEOMETRIES, e.g. "32x16" or "32x16,64x16". Use this (with a '
+        "single --batches value) when measuring one cell: a shared process that has "
+        "already peaked at tens of GiB fragments the allocator for whatever runs next, "
+        "which shows up as a spurious OOM.",
+    )
     parser.add_argument("--dtype", default="bf16", choices=["bf16", "fp32"])
     args = parser.parse_args()
     if not torch.cuda.is_available():
@@ -283,6 +291,15 @@ def main() -> None:
         raise SystemExit(msg)
     dtype = {"bf16": torch.bfloat16, "fp32": torch.float32}[args.dtype]
     batches = [int(b) for b in args.batches.split(",")]
+    if args.only:
+        wanted = {
+            tuple(int(x) for x in pair.split("x")) for pair in args.only.split(",")
+        }
+        global GEOMETRIES  # noqa: PLW0603
+        GEOMETRIES = tuple(g for g in GEOMETRIES if g in wanted)
+        if not GEOMETRIES:
+            msg = f"--only {args.only} matches none of the known geometries"
+            raise SystemExit(msg)
     emit(
         f"{torch.__version__} {torch.cuda.get_device_name(0)} dtype={args.dtype} "
         f"free/total GiB {[round(x / 2**30, 1) for x in torch.cuda.mem_get_info()]}"

--- a/tests/bench_causal_frame.py
+++ b/tests/bench_causal_frame.py
@@ -1,0 +1,289 @@
+"""Benchmark: dense-mask SDPA vs block-sparse FlexAttention for the causal trunk.
+
+Not a pytest module (pytest only collects `test_*.py`) -- run it directly on a
+machine with a free GPU:
+
+    nix develop /path/to/rmind-rqv --command bash -c \\
+      'PYTHONPATH=$PWD/src .venv/bin/python tests/bench_causal_frame.py trunk'
+
+Sections:
+
+* `attention` -- one attention layer, fwd+bwd. Isolates the kernel: this is the
+  term that grows quadratically with context length under a dense mask.
+* `trunk` -- the whole `CausalFrameTransformer` in `.train()`, i.e. WITH gradient
+  checkpointing, which is how it actually trains. This is the number the recipe is
+  sized from, because the MLP (linear in tokens) dilutes the attention saving.
+* `vit` -- the frozen image encoder's forward, for context: it is linear in
+  `batch * num_frames` and is unaffected by any of this, so it sets the floor on
+  what a longer context can cost.
+
+Everything runs in bf16 (`trainer.precision: bf16-mixed`); the correctness work in
+`tests/test_causal_frame.py` is fp32 on purpose.
+
+`(num_frames, window)` pairs are deliberately off-diagonal as well as on it:
+`num_frames == window` is plain block-causal and still grows as `F^2`, while
+`num_frames > window` is the regime where block-sparsity makes the cost LINEAR in
+context length. Results as of 2026-08-05 are in §11 of docs/decoder_only_kv_cache.md.
+
+Output goes through `emit` rather than `print` because the repo's ruff config
+auto-removes `print` calls (`select = ["ALL"]`, `fix = true`).
+"""
+
+import argparse
+import gc
+import sys
+import time
+from collections.abc import Callable, Iterable
+
+import torch
+from torch import Tensor
+from torch.nn import functional as F
+
+from rmind.components.transformer.causal_frame import (
+    AttentionImpl,
+    CausalFrameTransformer,
+    apply_rope,
+    flex_frame_attention,
+    frame_block_causal_block_mask,
+    frame_block_causal_mask,
+    frame_rope_cos_sin,
+)
+
+TOKENS_PER_FRAME = 257
+
+# (num_frames, window). The first row is today's 6-frame arm: the denominator for
+# every ratio in the report.
+GEOMETRIES: tuple[tuple[int, int], ...] = (
+    (6, 6),
+    (16, 6),
+    (16, 16),
+    (32, 8),
+    (32, 16),
+    (32, 32),
+    (64, 16),
+    (64, 64),
+)
+WIDTHS: tuple[tuple[int, int, int], ...] = (  # dim_model, num_heads, num_layers
+    (512, 8, 8),
+    (768, 12, 12),
+)
+
+
+def emit(line: str) -> None:
+    sys.stdout.write(line + "\n")
+    sys.stdout.flush()
+
+
+def timed(
+    fn: Callable[[], object], *, iters: int = 10, warmup: int = 3
+) -> tuple[float, float]:
+    """`(ms per call, peak MiB)`."""
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    gc.collect()
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iters):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) / iters, torch.cuda.max_memory_allocated() / 2**20
+
+
+def _guard(fn: Callable[[], tuple[float, float]]) -> str:
+    """Run a case, reporting OOM as a result rather than losing the sweep."""
+    try:
+        ms, peak = fn()
+    except torch.OutOfMemoryError:
+        return f"{'OOM':>9} {'-':>9}"
+    except Exception as e:  # noqa: BLE001
+        return f"ERR {type(e).__name__}: {str(e)[:60]}"
+    finally:
+        gc.collect()
+        torch.cuda.empty_cache()
+    return f"{ms:>9.2f} {peak:>9.0f}"
+
+
+def bench_attention(batches: Iterable[int], dtype: torch.dtype) -> None:
+    emit(
+        f"{'F':>4} {'win':>4} {'d':>5} {'b':>3} {'seq':>6} {'impl':>5} "
+        f"{'ms':>9} {'peakMiB':>9}"
+    )
+    for dim, heads, _ in WIDTHS:
+        head_dim = dim // heads
+        for num_frames, window in GEOMETRIES:
+            seq = num_frames * TOKENS_PER_FRAME
+            for batch in batches:
+                for impl in ("sdpa", "flex"):
+
+                    def run(  # noqa: ANN202, PLR0913
+                        *,
+                        impl: AttentionImpl = impl,  # ty:ignore[invalid-parameter-default]
+                        batch: int = batch,
+                        num_frames: int = num_frames,
+                        window: int = window,
+                        seq: int = seq,
+                        heads: int = heads,
+                        head_dim: int = head_dim,
+                    ):
+                        g = torch.Generator(device="cuda").manual_seed(0)
+                        qkv = [
+                            torch.randn(
+                                batch,
+                                heads,
+                                seq,
+                                head_dim,
+                                generator=g,
+                                device="cuda",
+                                dtype=dtype,
+                            ).requires_grad_()
+                            for _ in range(3)
+                        ]
+                        grad = torch.randn(qkv[0].shape, device="cuda", dtype=dtype)
+                        cos, sin = frame_rope_cos_sin(
+                            torch.arange(seq, device="cuda") // TOKENS_PER_FRAME,
+                            head_dim=head_dim,
+                        )
+                        cos, sin = cos.to(dtype), sin.to(dtype)
+                        mask = (
+                            frame_block_causal_block_mask(
+                                num_frames,
+                                TOKENS_PER_FRAME,
+                                window=window,
+                                device=torch.device("cuda"),
+                            )
+                            if impl == "flex"
+                            else frame_block_causal_mask(
+                                num_frames,
+                                TOKENS_PER_FRAME,
+                                window=window,
+                                device=torch.device("cuda"),
+                            )
+                        )
+
+                        def step() -> None:
+                            q, k, v = qkv
+                            q, k = apply_rope(q, cos, sin), apply_rope(k, cos, sin)
+                            out = (
+                                flex_frame_attention(q, k, v, mask)  # ty:ignore[invalid-argument-type]
+                                if impl == "flex"
+                                else F.scaled_dot_product_attention(
+                                    q,
+                                    k,
+                                    v,
+                                    attn_mask=~mask,  # ty:ignore[unsupported-operator]
+                                )
+                            )
+                            out.backward(grad)
+
+                        return timed(step)
+
+                    emit(
+                        f"{num_frames:>4} {window:>4} {dim:>5} {batch:>3} {seq:>6} "
+                        f"{impl:>5} {_guard(run)}"
+                    )
+
+
+def bench_trunk(batches: Iterable[int], dtype: torch.dtype) -> None:
+    emit(
+        f"{'F':>4} {'win':>4} {'d':>5} {'L':>3} {'b':>3} {'seq':>6} {'impl':>5} "
+        f"{'ms':>9} {'peakMiB':>9}"
+    )
+    for dim, heads, layers in WIDTHS:
+        for num_frames, window in GEOMETRIES:
+            seq = num_frames * TOKENS_PER_FRAME
+            for batch in batches:
+                for impl in ("sdpa", "flex"):
+
+                    def run(  # noqa: ANN202, PLR0913
+                        *,
+                        impl: AttentionImpl = impl,  # ty:ignore[invalid-parameter-default]
+                        batch: int = batch,
+                        num_frames: int = num_frames,
+                        window: int = window,
+                        seq: int = seq,
+                        dim: int = dim,
+                        heads: int = heads,
+                        layers: int = layers,
+                    ):
+                        torch.manual_seed(0)
+                        trunk = CausalFrameTransformer(
+                            dim_model=dim,
+                            num_layers=layers,
+                            num_heads=heads,
+                            tokens_per_frame=TOKENS_PER_FRAME,
+                            window=window,
+                            attn_dropout=0.0,
+                            attention_impl=impl,
+                        ).cuda()
+                        trunk.train()  # gradient checkpointing, as in training
+                        x = torch.randn(batch, seq, dim, device="cuda", dtype=dtype)
+                        grad = torch.randn(x.shape, device="cuda", dtype=dtype)
+
+                        def step() -> None:
+                            trunk.zero_grad(set_to_none=True)
+                            inp = x.detach().clone().requires_grad_()
+                            with torch.autocast("cuda", dtype=dtype):
+                                out = trunk(inp, num_frames=num_frames)
+                            out.backward(grad)
+
+                        return timed(step, iters=5, warmup=2)
+
+                    emit(
+                        f"{num_frames:>4} {window:>4} {dim:>5} {layers:>3} {batch:>3} "
+                        f"{seq:>6} {impl:>5} {_guard(run)}"
+                    )
+
+
+def bench_vit(batches: Iterable[int], dtype: torch.dtype) -> None:
+    """Frozen encoder forward, for the per-step context the trunk numbers live in."""
+    import timm  # noqa: PLC0415
+
+    model = (
+        timm
+        .create_model(
+            "vit_small_patch14_dinov2.lvd142m", pretrained=False, img_size=224
+        )
+        .eval()
+        .cuda()
+        .to(dtype)
+    )
+    emit(f"{'images':>7} {'ms':>9} {'peakMiB':>9}")
+    for n in batches:
+        img = torch.randn(n, 3, 224, 224, device="cuda", dtype=dtype)
+
+        def step(img: Tensor = img) -> None:
+            with torch.no_grad():
+                model.forward_features(img)
+
+        emit(f"{n:>7} {_guard(lambda step=step: timed(step, iters=5, warmup=2))}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("section", choices=["attention", "trunk", "vit"])
+    parser.add_argument("--batches", default="4,16")
+    parser.add_argument("--dtype", default="bf16", choices=["bf16", "fp32"])
+    args = parser.parse_args()
+    if not torch.cuda.is_available():
+        msg = "no CUDA device"
+        raise SystemExit(msg)
+    dtype = {"bf16": torch.bfloat16, "fp32": torch.float32}[args.dtype]
+    batches = [int(b) for b in args.batches.split(",")]
+    emit(
+        f"{torch.__version__} {torch.cuda.get_device_name(0)} dtype={args.dtype} "
+        f"free/total GiB {[round(x / 2**30, 1) for x in torch.cuda.mem_get_info()]}"
+    )
+    started = time.perf_counter()
+    {"attention": bench_attention, "trunk": bench_trunk, "vit": bench_vit}[
+        args.section
+    ](batches, dtype)
+    emit(f"# {args.section} done in {time.perf_counter() - started:.0f}s")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/bench_causal_frame.py
+++ b/tests/bench_causal_frame.py
@@ -36,6 +36,7 @@ import time
 from collections.abc import Callable, Iterable
 
 import torch
+import torch._dynamo
 from torch import Tensor
 from torch.nn import functional as F
 
@@ -48,6 +49,14 @@ from rmind.components.transformer.causal_frame import (
     frame_block_causal_mask,
     frame_rope_cos_sin,
 )
+
+# One `torch.compile`d `flex_attention` serves every shape in the sweep, and
+# `dynamic=False` specializes per shape. The dynamo default of 8 cache entries is
+# silently exceeded around row 8 of this grid, after which flex falls back to EAGER
+# (which materializes the score matrix) and the measurement becomes meaningless --
+# exactly on the long-context rows the recommendation rests on.
+torch._dynamo.config.cache_size_limit = 256  # noqa: SLF001
+torch._dynamo.config.accumulated_cache_size_limit = 512  # noqa: SLF001
 
 TOKENS_PER_FRAME = 257
 
@@ -122,7 +131,7 @@ def bench_attention(batches: Iterable[int], dtype: torch.dtype) -> None:
 
                     def run(  # noqa: ANN202, PLR0913
                         *,
-                        impl: AttentionImpl = impl,  # ty:ignore[invalid-parameter-default]
+                        impl: AttentionImpl = impl,
                         batch: int = batch,
                         num_frames: int = num_frames,
                         window: int = window,
@@ -201,7 +210,7 @@ def bench_trunk(batches: Iterable[int], dtype: torch.dtype) -> None:
 
                     def run(  # noqa: ANN202, PLR0913
                         *,
-                        impl: AttentionImpl = impl,  # ty:ignore[invalid-parameter-default]
+                        impl: AttentionImpl = impl,
                         batch: int = batch,
                         num_frames: int = num_frames,
                         window: int = window,
@@ -258,7 +267,7 @@ def bench_vit(batches: Iterable[int], dtype: torch.dtype) -> None:
 
         def step(img: Tensor = img) -> None:
             with torch.no_grad():
-                model.forward_features(img)
+                model.forward_features(img)  # ty:ignore[call-non-callable]
 
         emit(f"{n:>7} {_guard(lambda step=step: timed(step, iters=5, warmup=2))}")
 

--- a/tests/test_causal_frame.py
+++ b/tests/test_causal_frame.py
@@ -1,0 +1,430 @@
+"""Cache-vs-recompute correctness for the decoder-only PatchPolicy trunk.
+
+This is the gate from `/nasa/max/docs/decoder_only_handoff.md` §5.1: warm-cache
+streaming must agree with a full recompute to ~1e-6, and if it does not, the
+positional encoding is window-absolute (§3.2).
+
+Three things are checked, and the distinction between them matters:
+
+* `test_shift_invariance*` -- the positional scheme does not depend on where a
+  frame sits in the window. This is the actual discriminator for the §3.2 trap.
+* `test_stream_equals_*_recompute` -- streaming against a ring buffer reproduces
+  a single full forward, exactly. With `window=N` the equivalent recompute uses
+  `frame_block_causal_mask(..., window=N)`; frame `t`'s window there is
+  `[t-N+1 .. t]`, i.e. for N=6 at t=6 exactly the frames `[1..6]` §5.1 names.
+* `test_isolated_window_recompute_is_not_identical` -- re-running `[1..6]` as a
+  *fresh 6-frame episode* is NOT the same computation and cannot be, for any
+  bounded window with more than one layer: there frame 5 never saw frame 0,
+  whereas in the stream its layer-2+ K/V were produced with frame 0 in context.
+  Recorded as a quantified, expected residual, not a pass.
+
+Every equivalence test is paired with a negative control on a window-absolute
+variant of the same trunk, run through the same harness, so a pass is
+falsifiable rather than vacuous.
+"""
+
+from typing import override
+
+import pytest
+import torch
+from torch import Tensor, nn
+
+from rmind.components.transformer.causal_frame import (
+    MASK_BIAS,
+    CausalFrameTransformer,
+    frame_block_causal_mask,
+    frame_rope_cos_sin,
+)
+from rmind.models.patch_policy import block_causal_mask
+
+TOKENS_PER_FRAME = 17  # stands in for 257; the property is independent of it
+DIM = 32
+HEADS = 4
+LAYERS = 3
+TOL = 1e-6
+
+
+def _trunk(
+    *, window: int | None = None, cls: type[CausalFrameTransformer] | None = None
+) -> CausalFrameTransformer:
+    torch.manual_seed(0)
+    trunk = (cls or CausalFrameTransformer)(
+        dim_model=DIM,
+        num_layers=LAYERS,
+        num_heads=HEADS,
+        tokens_per_frame=TOKENS_PER_FRAME,
+        window=window,
+    )
+    return trunk.double().eval()
+
+
+def _tokens(num_frames: int, *, batch: int = 2, seed: int = 1) -> Tensor:
+    g = torch.Generator().manual_seed(seed)
+    return torch.randn(
+        batch, num_frames, TOKENS_PER_FRAME, DIM, generator=g, dtype=torch.float64
+    )
+
+
+def _flat(tokens: Tensor) -> Tensor:
+    b, t, k, d = tokens.shape
+    return tokens.reshape(b, t * k, d)
+
+
+def _readouts(flat_out: Tensor, num_frames: int) -> Tensor:
+    """Last token of every frame -- the readout position (speed token is prepended)."""
+    b, s, d = flat_out.shape
+    return flat_out.reshape(b, num_frames, s // num_frames, d)[:, :, -1]
+
+
+class WindowAbsoluteTrunk(CausalFrameTransformer):
+    """Negative control: the CURRENT scheme -- a learned embedding over the
+    flattened window, indexed window-absolutely, and no RoPE.
+
+    Structurally identical to `CausalFrameTransformer` otherwise, and driven
+    through the same streaming harness, so any difference in the results is
+    attributable to the positional encoding alone.
+    """
+
+    MAX_FRAMES = 16
+
+    def __init__(self, **kwargs: object) -> None:
+        super().__init__(**kwargs)  # ty:ignore[missing-argument]
+        self.absolute_position_embedding = nn.Embedding(
+            self.MAX_FRAMES * self.tokens_per_frame, self.dim_model
+        )
+        nn.init.trunc_normal_(self.absolute_position_embedding.weight, std=0.02)
+
+    def _unit_rope(self, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, ...]:
+        return (
+            torch.ones(1, 1, 1, self.head_dim, device=device, dtype=dtype),
+            torch.zeros(1, 1, 1, self.head_dim, device=device, dtype=dtype),
+        )
+
+    @override
+    def forward(
+        self, src: Tensor, *, num_frames: int, frame_offset: int = 0
+    ) -> Tensor:
+        _, seq_len, _ = src.shape
+        # window-absolute: shifting the frames later in the episode shifts the
+        # positional lookup, which is exactly what sliding the window does
+        x = src + self.absolute_position_embedding(
+            torch.arange(seq_len, device=src.device)
+            + frame_offset * self.tokens_per_frame
+        )
+        cos, sin = self._unit_rope(src.device, src.dtype)
+        mask = frame_block_causal_mask(
+            num_frames, self.tokens_per_frame, window=self.window, device=src.device
+        )
+        for layer in self.layers:
+            x = layer(x, cos, sin, mask)
+        return self.norm(x)
+
+    @override
+    def step(  # noqa: PLR0913
+        self,
+        src: Tensor,
+        *,
+        past_k: Tensor,
+        past_v: Tensor,
+        cos: Tensor,
+        sin: Tensor,
+        cache_bias: Tensor,
+        readout_only_final_block: bool = False,
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        del cos, sin
+        # window-absolute: the newest frame always occupies the LAST block of the
+        # window, so its positional input changes every time the window slides
+        num_cached = cache_bias.shape[-1] // self.tokens_per_frame
+        offset = num_cached * self.tokens_per_frame
+        idx = torch.arange(src.shape[1], device=src.device) + offset
+        x = src + self.absolute_position_embedding(idx)
+        cos, sin = self._unit_rope(src.device, src.dtype)
+
+        new_k: list[Tensor] = []
+        new_v: list[Tensor] = []
+        for i, layer in enumerate(self.layers):
+            x, k, v = layer.step(x, cos, sin, past_k[i], past_v[i], cache_bias)
+            new_k.append(k)
+            new_v.append(v)
+        return self.norm(x), torch.stack(new_k), torch.stack(new_v)
+
+
+def stream(
+    trunk: CausalFrameTransformer, tokens: Tensor, *, cache_frames: int
+) -> Tensor:
+    """One-frame-per-tick decode against a host-side ring buffer.
+
+    Emulates exactly what drivr would do: the graph reads `past_k`/`past_v` and
+    returns only the new frame's K/V, and the host shifts them into the ring.
+    Returns the readout token per frame, `(b, t, d)`.
+    """
+    b, num_frames, k, _ = tokens.shape
+    past_k, past_v, bias = trunk.empty_cache(
+        batch_size=b, cache_frames=cache_frames, dtype=tokens.dtype
+    )
+    outs: list[Tensor] = []
+    for t in range(num_frames):
+        cos, sin = frame_rope_cos_sin(
+            torch.tensor(t), head_dim=trunk.head_dim, base=trunk.rope_base
+        )
+        out, new_k, new_v = trunk.step(
+            tokens[:, t],
+            past_k=past_k,
+            past_v=past_v,
+            cos=cos.to(tokens.dtype),
+            sin=sin.to(tokens.dtype),
+            cache_bias=bias,
+        )
+        outs.append(out[:, -1])
+        if cache_frames:
+            past_k = torch.cat((past_k[..., k:, :], new_k), dim=-2)
+            past_v = torch.cat((past_v[..., k:, :], new_v), dim=-2)
+            bias = torch.cat((bias[..., k:], torch.zeros_like(bias[..., :k])), dim=-1)
+    return torch.stack(outs, dim=1)
+
+
+# --------------------------------------------------------------------------- #
+# masks
+# --------------------------------------------------------------------------- #
+
+
+def test_unwindowed_mask_matches_reference() -> None:
+    """`window=None` is the existing block-causal mask, unchanged."""
+    torch.testing.assert_close(
+        frame_block_causal_mask(6, TOKENS_PER_FRAME),
+        block_causal_mask(6, TOKENS_PER_FRAME),
+    )
+
+
+def test_windowed_mask_geometry() -> None:
+    mask = frame_block_causal_mask(8, 1, window=3)
+    # frame 5 sees exactly frames 3, 4, 5
+    assert (~mask[5]).nonzero().flatten().tolist() == [3, 4, 5]
+    # intra-frame is bidirectional: the diagonal block is never blocked
+    block = frame_block_causal_mask(4, TOKENS_PER_FRAME, window=2)
+    k = TOKENS_PER_FRAME
+    assert not block[2 * k : 3 * k, 2 * k : 3 * k].any()
+
+
+# --------------------------------------------------------------------------- #
+# positional scheme
+# --------------------------------------------------------------------------- #
+
+
+def test_intra_frame_attention_is_exactly_unrotated() -> None:
+    """RoPE at frame granularity cancels within a frame: `(Rq)ᵀ(Rk) = qᵀk`.
+
+    This is why intra-frame attention stays bidirectional and position-agnostic
+    (ordered only by the intra-frame embedding). A pairing/axis bug in
+    `apply_rope` breaks this.
+    """
+    from rmind.components.transformer.causal_frame import apply_rope
+
+    g = torch.Generator().manual_seed(3)
+    q = torch.randn(2, HEADS, TOKENS_PER_FRAME, DIM // HEADS, generator=g).double()
+    k = torch.randn(2, HEADS, TOKENS_PER_FRAME, DIM // HEADS, generator=g).double()
+    cos, sin = frame_rope_cos_sin(
+        torch.tensor(37), head_dim=DIM // HEADS, dtype=torch.float64
+    )
+    cos, sin = cos.reshape(1, 1, 1, -1), sin.reshape(1, 1, 1, -1)
+    torch.testing.assert_close(
+        apply_rope(q, cos, sin) @ apply_rope(k, cos, sin).transpose(-1, -2),
+        q @ k.transpose(-1, -2),
+        rtol=0,
+        atol=1e-12,
+    )
+
+
+def test_shift_invariance() -> None:
+    """The §3.2 discriminator: the SAME frames at a different episode offset must
+    produce the SAME output. A window-absolute embedding cannot do this.
+    """
+    trunk = _trunk()
+    x = _flat(_tokens(6))
+    torch.testing.assert_close(
+        trunk(x, num_frames=6, frame_offset=0),
+        trunk(x, num_frames=6, frame_offset=7),
+        rtol=0,
+        atol=TOL,
+    )
+
+
+def test_shift_invariance_negative_control() -> None:
+    """The same test on the window-absolute control -- must FAIL, by a lot.
+
+    Symmetric to `test_shift_invariance`: identical frames, identical blocks,
+    only the positional encoding differs. This is the §3.2 trap, reproduced.
+    """
+    trunk = _trunk(window=6, cls=WindowAbsoluteTrunk)
+    x = _flat(_tokens(6))
+    err = (
+        (trunk(x, num_frames=6, frame_offset=0) - trunk(x, num_frames=6, frame_offset=7))
+        .abs()
+        .max()
+        .item()
+    )
+    assert err > 1e-2, f"control should not be shift-invariant, got {err:.3e}"
+
+
+# --------------------------------------------------------------------------- #
+# THE GATE: cache vs recompute
+# --------------------------------------------------------------------------- #
+
+
+def test_stream_equals_full_recompute_unbounded() -> None:
+    """Full-history cache: streaming T frames == one causal forward over [0..T-1].
+
+    Checked at EVERY frame's readout, not just the last.
+    """
+    num_frames = 7
+    trunk = _trunk()
+    tokens = _tokens(num_frames)
+    recompute = _readouts(trunk(_flat(tokens), num_frames=num_frames), num_frames)
+    streamed = stream(trunk, tokens, cache_frames=num_frames - 1)
+    torch.testing.assert_close(streamed, recompute, rtol=0, atol=TOL)
+
+
+@pytest.mark.parametrize("window", [2, 3, 6])
+def test_stream_equals_sliding_window_recompute(window: int) -> None:
+    """§5.1, in the form that is exact.
+
+    Ring of capacity `window - 1` past frames + the current one == a full forward
+    under `frame_block_causal_mask(window=window)`. At `window=6`, frame 6's
+    context is exactly frames [1..6] -- the case §5.1 names -- and it matches to
+    ~1e-6 while sharing no recomputation with the earlier frames.
+    """
+    num_frames = 7
+    trunk = _trunk(window=window)
+    tokens = _tokens(num_frames)
+    recompute = _readouts(trunk(_flat(tokens), num_frames=num_frames), num_frames)
+    streamed = stream(trunk, tokens, cache_frames=window - 1)
+    torch.testing.assert_close(streamed, recompute, rtol=0, atol=TOL)
+
+
+def test_stream_vs_recompute_negative_control() -> None:
+    """The same gate on the window-absolute trunk -- must FAIL.
+
+    Demonstrates the gate has teeth: identical harness, identical block
+    structure, only the positional encoding differs.
+    """
+    num_frames = 7
+    window = 6
+    trunk = _trunk(window=window, cls=WindowAbsoluteTrunk)
+    tokens = _tokens(num_frames)
+    recompute = _readouts(trunk(_flat(tokens), num_frames=num_frames), num_frames)
+    streamed = stream(trunk, tokens, cache_frames=window - 1)
+    err = (streamed - recompute).abs().max().item()
+    assert err > 1e-2, f"control should diverge, got {err:.3e}"
+
+
+def test_isolated_window_recompute_is_not_identical() -> None:
+    """Documented, expected residual -- NOT a gate.
+
+    Re-running frames [1..6] as a fresh 6-frame episode differs from the stream,
+    because there frame 5 never saw frame 0 while in the stream its layer-2+ K/V
+    were produced with frame 0 in context. Inherent to any bounded window with
+    L > 1; unrelated to the positional encoding.
+    """
+    trunk = _trunk(window=6)
+    tokens = _tokens(7)
+    streamed = stream(trunk, tokens, cache_frames=5)[:, -1]
+    isolated = _readouts(trunk(_flat(tokens[:, 1:]), num_frames=6, frame_offset=1), 6)[
+        :, -1
+    ]
+    residual = (streamed - isolated).abs().max().item()
+    assert residual > TOL, "single-layer coincidence?"
+    # sanity: the deviation is a truncation effect, not divergence
+    assert residual < 10 * streamed.abs().max().item()
+
+
+def test_single_layer_isolated_recompute_is_identical() -> None:
+    """Corroborates the explanation above: with L=1 there is no layer-2 leakage,
+    so the isolated [1..6] recompute IS bit-identical to the stream.
+    """
+    torch.manual_seed(0)
+    trunk = (
+        CausalFrameTransformer(
+            dim_model=DIM,
+            num_layers=1,
+            num_heads=HEADS,
+            tokens_per_frame=TOKENS_PER_FRAME,
+            window=6,
+        )
+        .double()
+        .eval()
+    )
+    tokens = _tokens(7)
+    streamed = stream(trunk, tokens, cache_frames=5)[:, -1]
+    isolated = _readouts(trunk(_flat(tokens[:, 1:]), num_frames=6, frame_offset=1), 6)[
+        :, -1
+    ]
+    torch.testing.assert_close(streamed, isolated, rtol=0, atol=TOL)
+
+
+# --------------------------------------------------------------------------- #
+# cache mechanics
+# --------------------------------------------------------------------------- #
+
+
+def test_cold_cache_ignores_unfilled_slots() -> None:
+    """A cold cache with garbage in the unfilled slots gives the same answer as
+    an empty one -- `cache_bias` is what makes cold-start correct, and it is why
+    cold and warm ticks cost the same.
+    """
+    trunk = _trunk(window=6)
+    tokens = _tokens(1)
+    past_k, past_v, bias = trunk.empty_cache(
+        batch_size=2, cache_frames=5, dtype=tokens.dtype
+    )
+    cos, sin = frame_rope_cos_sin(torch.tensor(0), head_dim=trunk.head_dim)
+    kwargs = {"cos": cos.double(), "sin": sin.double(), "cache_bias": bias}
+    clean, *_ = trunk.step(tokens[:, 0], past_k=past_k, past_v=past_v, **kwargs)
+    g = torch.Generator().manual_seed(7)
+    garbage_k = torch.randn(past_k.shape, generator=g, dtype=torch.float64) * 100
+    garbage_v = torch.randn(past_v.shape, generator=g, dtype=torch.float64) * 100
+    dirty, *_ = trunk.step(tokens[:, 0], past_k=garbage_k, past_v=garbage_v, **kwargs)
+    torch.testing.assert_close(dirty, clean, rtol=0, atol=TOL)
+    assert bias.min().item() == MASK_BIAS
+
+
+def test_readout_only_final_block_matches_full_final_block() -> None:
+    """§3.3's free win: skipping the final block's work on the non-readout
+    positions changes nothing at the readout, and still emits full K/V.
+    """
+    trunk = _trunk(window=6)
+    tokens = _tokens(1)
+    past_k, past_v, bias = trunk.empty_cache(
+        batch_size=2, cache_frames=5, dtype=tokens.dtype
+    )
+    g = torch.Generator().manual_seed(11)
+    past_k = torch.randn(past_k.shape, generator=g, dtype=torch.float64)
+    past_v = torch.randn(past_v.shape, generator=g, dtype=torch.float64)
+    bias = torch.zeros_like(bias)
+    cos, sin = frame_rope_cos_sin(torch.tensor(5), head_dim=trunk.head_dim)
+    kwargs = {
+        "past_k": past_k,
+        "past_v": past_v,
+        "cos": cos.double(),
+        "sin": sin.double(),
+        "cache_bias": bias,
+    }
+    full, full_k, full_v = trunk.step(tokens[:, 0], **kwargs)
+    gathered, gath_k, gath_v = trunk.step(
+        tokens[:, 0], readout_only_final_block=True, **kwargs
+    )
+    assert gathered.shape[1] == 1
+    torch.testing.assert_close(gathered[:, 0], full[:, -1], rtol=0, atol=TOL)
+    torch.testing.assert_close(gath_k, full_k, rtol=0, atol=TOL)
+    torch.testing.assert_close(gath_v, full_v, rtol=0, atol=TOL)
+
+
+def test_multihead_attention_state_dict_is_loadable() -> None:
+    """A trunk trained with `BlockCausalTransformer` transfers 1:1, so this is a
+    positional-encoding change and not a re-parameterization.
+    """
+    ref = nn.MultiheadAttention(embed_dim=DIM, num_heads=HEADS, batch_first=True)
+    trunk = _trunk(window=6)
+    missing, unexpected = trunk.layers[0].attn.load_state_dict(
+        ref.state_dict(), strict=False
+    )
+    assert not missing and not unexpected

--- a/tests/test_causal_frame.py
+++ b/tests/test_causal_frame.py
@@ -30,10 +30,14 @@ import torch
 from torch import Tensor, nn
 
 from rmind.components.transformer.causal_frame import (
+    FLEX_BLOCK_SIZE,
     MASK_BIAS,
+    AttentionImpl,
     CausalFrameTransformer,
     apply_rope,
+    frame_block_causal_block_mask,
     frame_block_causal_mask,
+    frame_block_causal_mask_mod,
     frame_rope_cos_sin,
 )
 from rmind.models.patch_policy import block_causal_mask
@@ -45,6 +49,25 @@ LAYERS = 3
 TOL = 1e-6
 # a negative control must miss the 1e-6 gate by orders of magnitude, not narrowly
 CONTROL_MIN_ERROR = 1e-2
+
+# production geometry, for the flex-vs-sdpa parity gate
+PROD_TOKENS_PER_FRAME = 257
+# fp32 parity gate, applied SCALE-RELATIVE (max|diff| / max|reference|).
+#
+# An absolute 1e-5 is the right gate for activations and input gradients (both are
+# O(1) here and land at ~1e-6), but it is the wrong gate for a PARAMETER gradient:
+# `in_proj_weight.grad` is a sum over all 1542-4112 sequence positions, so its
+# entries are O(10) and its fp32 accumulation noise alone is ~1e-5 in absolute
+# terms no matter which kernel produced it. Measured on a 5090 with tf32 off, every
+# tensor is <= 1.5e-6 scale-relative, and
+# `test_flex_is_no_further_from_exact_than_sdpa` shows that residual IS the fp32
+# noise: flex sits 1.4x sdpa's own distance from a float64 reference, not 10x.
+FLEX_TOL = 1e-5
+# 128-block tiling of a 257-token frame: the boundary waste must stay far below the
+# 2.23x that padding frames to 384 (3 exact blocks) would cost
+MAX_TILE_WASTE = 1.3
+# and the block-sparse kernel must compute clearly less than the dense mask does
+MAX_DENSE_FRACTION = 0.8
 
 
 def _trunk(
@@ -458,6 +481,272 @@ def test_multihead_attention_state_dict_is_loadable() -> None:
     )
     assert not missing
     assert not unexpected
+
+
+# --------------------------------------------------------------------------- #
+# FlexAttention path: exact parity with the dense-mask SDPA path
+#
+# The saving is real only if the kernel is *identical*, not merely similar: the
+# block-sparse path is the training path for the SAME weights that serve through
+# `step`, so any drift here is a train/infer mismatch on top of a speedup.
+# --------------------------------------------------------------------------- #
+
+
+def _prod_trunk(  # noqa: PLR0913
+    *,
+    window: int,
+    dim: int,
+    heads: int,
+    impl: AttentionImpl,
+    layers: int = 2,
+    tokens_per_frame: int = PROD_TOKENS_PER_FRAME,
+) -> CausalFrameTransformer:
+    """Production-width trunk in fp32 (FlexAttention has no float64 CUDA kernel).
+
+    `attn_dropout=0` is required by the flex path and is set on both arms so the
+    two are comparable; `layers=2` is enough to exercise the stack while keeping
+    the 4112-token cases cheap.
+    """
+    torch.manual_seed(0)
+    return CausalFrameTransformer(
+        dim_model=dim,
+        num_layers=layers,
+        num_heads=heads,
+        tokens_per_frame=tokens_per_frame,
+        window=window,
+        attn_dropout=0.0,
+        resid_dropout=0.0,
+        mlp_dropout=0.0,
+        attention_impl=impl,
+    )
+
+
+def _pair(
+    *, window: int, dim: int, heads: int, device: str, layers: int = 2
+) -> tuple[CausalFrameTransformer, CausalFrameTransformer]:
+    """Same weights, two attention implementations."""
+    sdpa = _prod_trunk(window=window, dim=dim, heads=heads, impl="sdpa", layers=layers)
+    flex = _prod_trunk(window=window, dim=dim, heads=heads, impl="flex", layers=layers)
+    flex.load_state_dict(sdpa.state_dict())
+    return sdpa.to(device), flex.to(device)
+
+
+def _scale_rel(got: Tensor, ref: Tensor) -> float:
+    """`max|got - ref| / max|ref|` -- see the FLEX_TOL comment for why not atol."""
+    return ((got.double() - ref.double()).abs().max() / ref.double().abs().max()).item()
+
+
+def _fwd_bwd(
+    trunk: CausalFrameTransformer, x: Tensor, grad_out: Tensor, *, num_frames: int
+) -> dict[str, Tensor]:
+    """Forward + backward, returning the output and the gradients under comparison.
+
+    An input-gradient-only comparison would miss a parameter whose gradient path
+    runs through the mask, so both an attention projection and the intra-frame
+    position embedding are included.
+    """
+    trunk.zero_grad()
+    inp = x.detach().clone().requires_grad_()
+    out = trunk(inp, num_frames=num_frames)
+    out.backward(grad_out)
+    assert inp.grad is not None
+    return {
+        "out": out.detach(),
+        "d_input": inp.grad,
+        "d_in_proj_weight": trunk.layers[0].attn.in_proj_weight.grad.clone(),  # ty:ignore[possibly-unbound-attribute]
+        "d_out_proj_weight": trunk.layers[-1].attn.out_proj.weight.grad.clone(),  # ty:ignore[possibly-unbound-attribute]
+        "d_intra_position": trunk.intra_position_embedding.weight.grad.clone(),  # ty:ignore[possibly-unbound-attribute]
+    }
+
+
+def test_flex_mask_mod_matches_dense_mask() -> None:
+    """The `mask_mod` predicate is the dense mask, inverted. Device-free, exact.
+
+    Checked at the production 257 so the `// tokens_per_frame` arithmetic is
+    exercised on a frame width that is not a power of two.
+    """
+    for window in (None, 2, 6):
+        idx = torch.arange(5 * PROD_TOKENS_PER_FRAME)
+        mod = frame_block_causal_mask_mod(PROD_TOKENS_PER_FRAME, window)
+        keep = mod(torch.tensor(0), torch.tensor(0), idx[:, None], idx[None, :])
+        blocked = frame_block_causal_mask(5, PROD_TOKENS_PER_FRAME, window=window)
+        torch.testing.assert_close(keep, ~blocked)
+
+
+@pytest.mark.parametrize(("num_frames", "window"), [(6, 6), (16, 6), (32, 16)])
+def test_flex_block_mask_is_block_sparse(num_frames: int, window: int) -> None:
+    """The BlockMask really skips blocks, and the 257-vs-128 waste stays small.
+
+    This is the tile-alignment finding as an assertion: a 257-token frame block
+    can never tile a 128-element kernel block, so every frame boundary produces a
+    partial block that costs a full one. The overhead is a boundary effect and
+    amortizes with the number of frames -- but it must never approach the 2.23x
+    that padding frames to 384 would cost, which is the alternative this rejects.
+    """
+    k = PROD_TOKENS_PER_FRAME
+    bm = frame_block_causal_block_mask(num_frames, k, window=window)
+    computed = (
+        int(bm.kv_num_blocks.sum().item()) + int(bm.full_kv_num_blocks.sum().item())
+    ) * FLEX_BLOCK_SIZE**2
+    exact = k * k * sum(min(f + 1, window) for f in range(num_frames))
+    dense = (num_frames * k) ** 2
+    assert computed < dense, "no blocks skipped -- the mask is not sparse"
+    assert 1.0 <= computed / exact < MAX_TILE_WASTE, (
+        f"tile waste {computed / exact:.3f}"
+    )
+    # and the whole point: less work than the dense mask, by the expected margin
+    assert computed / dense < MAX_DENSE_FRACTION
+
+
+def test_flex_forward_matches_sdpa_on_cpu() -> None:
+    """Parity without a GPU, so CI covers the mask/plumbing even on a CPU runner.
+
+    Eager FlexAttention (the CPU fallback) has no backward, so this is
+    forward-only; the fwd+bwd gate is the CUDA test below.
+    """
+    sdpa, flex = _pair(window=2, dim=32, heads=4, device="cpu", layers=2)
+    g = torch.Generator().manual_seed(5)
+    x = torch.randn(1, 4 * PROD_TOKENS_PER_FRAME, 32, generator=g)
+    with torch.no_grad():
+        torch.testing.assert_close(
+            flex(x, num_frames=4), sdpa(x, num_frames=4), rtol=0, atol=FLEX_TOL
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="FlexAttention needs CUDA")
+@pytest.mark.parametrize(("dim", "heads"), [(512, 8), (768, 12)])
+@pytest.mark.parametrize("window", [6, 16])
+def test_flex_matches_sdpa_forward_and_backward(
+    dim: int, heads: int, window: int
+) -> None:
+    """THE GATE: production shapes, fp32, forward and backward.
+
+    `num_frames == window` so the mask is the full block-causal one -- the widest
+    case, where nothing is skipped by the window and only causality is sparse. tf32
+    is disabled so this measures the kernels, not the tensor cores' mantissa.
+    """
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+    sdpa, flex = _pair(window=window, dim=dim, heads=heads, device="cuda")
+    g = torch.Generator(device="cuda").manual_seed(9)
+    x = torch.randn(1, window * PROD_TOKENS_PER_FRAME, dim, generator=g, device="cuda")
+    grad_out = torch.randn(x.shape, generator=g, device="cuda")
+
+    ref = _fwd_bwd(sdpa, x, grad_out, num_frames=window)
+    got = _fwd_bwd(flex, x, grad_out, num_frames=window)
+    errors = {key: _scale_rel(got[key], ref[key]) for key in ref}
+    assert all(e < FLEX_TOL for e in errors.values()), errors
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="FlexAttention needs CUDA")
+@pytest.mark.parametrize("window", [6, 16])
+def test_flex_matches_sdpa_under_gradient_checkpointing(window: int) -> None:
+    """The same parity in `.train()`, which is a different code path.
+
+    `run_layer_stack` only wraps layers in `checkpoint(use_reentrant=False)` while
+    training, so an eval-only test never runs the compiled flex kernel inside a
+    checkpoint or its recompute. With every dropout at 0 the two arms are still
+    exactly comparable. This is what catches a `BlockMask`-through-`checkpoint`
+    regression -- a `BlockMask` is not a tensor, and `checkpoint` has to carry it
+    through to the recompute unchanged.
+    """
+    torch.backends.cuda.matmul.allow_tf32 = False
+    sdpa, flex = _pair(window=window, dim=512, heads=8, device="cuda")
+    sdpa.train()
+    flex.train()
+    g = torch.Generator(device="cuda").manual_seed(13)
+    x = torch.randn(1, window * PROD_TOKENS_PER_FRAME, 512, generator=g, device="cuda")
+    grad_out = torch.randn(x.shape, generator=g, device="cuda")
+
+    ref = _fwd_bwd(sdpa, x, grad_out, num_frames=window)
+    got = _fwd_bwd(flex, x, grad_out, num_frames=window)
+    errors = {key: _scale_rel(got[key], ref[key]) for key in ref}
+    assert all(e < FLEX_TOL for e in errors.values()), errors
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="FlexAttention needs CUDA")
+def test_flex_is_no_further_from_exact_than_sdpa() -> None:  # noqa: PLR0914
+    """Why FLEX_TOL is not an arbitrary number.
+
+    Both fp32 arms are compared against the SAME trunk run in float64 on the CPU,
+    which is the exact answer for this mask. If the flex kernel had a semantic
+    difference -- a mis-tiled block, a dropped partial block, a wrong scale -- it
+    would sit orders of magnitude further from the fp64 reference than sdpa does.
+    Measured on a 5090: sdpa 6.8e-7, flex 9.4e-7 scale-relative on the worst
+    tensor, i.e. flex is 1.4x sdpa's own fp32 accumulation noise. The 2x budget
+    below is therefore tight, not permissive.
+
+    One layer, `window=6`: enough to be exact, cheap enough to run in float64 on a
+    CPU.
+    """
+    torch.backends.cuda.matmul.allow_tf32 = False
+    dim, heads, window = 512, 8, 6
+    sdpa, flex = _pair(window=window, dim=dim, heads=heads, device="cuda", layers=1)
+    exact = _prod_trunk(
+        window=window, dim=dim, heads=heads, impl="sdpa", layers=1
+    ).double()
+    exact.load_state_dict({k: v.double().cpu() for k, v in sdpa.state_dict().items()})
+
+    g = torch.Generator().manual_seed(9)
+    x = torch.randn(1, window * PROD_TOKENS_PER_FRAME, dim, generator=g)
+    grad_out = torch.randn(x.shape, generator=g)
+    truth = _fwd_bwd(exact, x.double(), grad_out.double(), num_frames=window)
+    xc, gc = x.cuda(), grad_out.cuda()
+    ref = _fwd_bwd(sdpa, xc, gc, num_frames=window)
+    got = _fwd_bwd(flex, xc, gc, num_frames=window)
+
+    for key, exact_value in truth.items():
+        sdpa_err = _scale_rel(ref[key].cpu(), exact_value)
+        flex_err = _scale_rel(got[key].cpu(), exact_value)
+        assert flex_err < FLEX_TOL, (key, flex_err)
+        assert flex_err <= 2 * sdpa_err + 1e-9, (key, flex_err, sdpa_err)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="FlexAttention needs CUDA")
+def test_flex_is_invariant_to_frame_offset() -> None:
+    """RoPE is applied to q/k *before* attention, so it is orthogonal to the
+    kernel: the flex path keeps the shift-invariance that makes the cache valid.
+    """
+    torch.backends.cuda.matmul.allow_tf32 = False
+    _, flex = _pair(window=4, dim=512, heads=8, device="cuda")
+    flex.eval()
+    g = torch.Generator(device="cuda").manual_seed(17)
+    x = torch.randn(1, 4 * PROD_TOKENS_PER_FRAME, 512, generator=g, device="cuda")
+    with torch.no_grad():
+        torch.testing.assert_close(
+            flex(x, num_frames=4, frame_offset=11),
+            flex(x, num_frames=4, frame_offset=0),
+            rtol=0,
+            atol=FLEX_TOL,
+        )
+
+
+def test_flex_rejects_attention_dropout() -> None:
+    """FlexAttention has no `dropout_p`; silently losing attention dropout when
+    switching impl would be an unlogged regularization change.
+    """
+    with pytest.raises(ValueError, match="dropout"):
+        CausalFrameTransformer(
+            dim_model=DIM,
+            num_layers=1,
+            num_heads=HEADS,
+            tokens_per_frame=TOKENS_PER_FRAME,
+            window=2,
+            attention_impl="flex",
+        )
+
+
+def test_unknown_attention_impl_is_rejected() -> None:
+    with pytest.raises(ValueError, match="attention_impl"):
+        CausalFrameTransformer(
+            dim_model=DIM,
+            num_layers=1,
+            num_heads=HEADS,
+            tokens_per_frame=TOKENS_PER_FRAME,
+            window=2,
+            attn_dropout=0.0,
+            attention_impl="flash",  # ty:ignore[invalid-argument-type]
+        )
 
 
 @pytest.mark.parametrize("window", [2, 3, 6])

--- a/tests/test_causal_frame.py
+++ b/tests/test_causal_frame.py
@@ -23,11 +23,13 @@ variant of the same trunk, run through the same harness, so a pass is
 falsifiable rather than vacuous.
 """
 
+from collections.abc import Callable
 from typing import override
 
 import pytest
 import torch
 from torch import Tensor, nn
+from torch.fx.experimental.proxy_tensor import make_fx
 
 from rmind.components.transformer.causal_frame import (
     FLEX_BLOCK_SIZE,
@@ -542,21 +544,70 @@ def _fwd_bwd(
     """Forward + backward, returning the output and the gradients under comparison.
 
     An input-gradient-only comparison would miss a parameter whose gradient path
-    runs through the mask, so both an attention projection and the intra-frame
-    position embedding are included.
+    runs through the mask, so an attention projection at each end of the stack and
+    the intra-frame position embedding are included too.
     """
     trunk.zero_grad()
     inp = x.detach().clone().requires_grad_()
     out = trunk(inp, num_frames=num_frames)
     out.backward(grad_out)
     assert inp.grad is not None
-    return {
-        "out": out.detach(),
-        "d_input": inp.grad,
-        "d_in_proj_weight": trunk.layers[0].attn.in_proj_weight.grad.clone(),  # ty:ignore[possibly-unbound-attribute]
-        "d_out_proj_weight": trunk.layers[-1].attn.out_proj.weight.grad.clone(),  # ty:ignore[possibly-unbound-attribute]
-        "d_intra_position": trunk.intra_position_embedding.weight.grad.clone(),  # ty:ignore[possibly-unbound-attribute]
+    params = dict(trunk.named_parameters())
+    last = trunk.num_layers - 1
+    wanted = {
+        "d_in_proj_weight": "layers.0.attn.in_proj_weight",
+        "d_out_proj_weight": f"layers.{last}.attn.out_proj.weight",
+        "d_intra_position": "intra_position_embedding.weight",
     }
+    grads: dict[str, Tensor] = {"out": out.detach(), "d_input": inp.grad}
+    for key, name in wanted.items():
+        grad = params[name].grad
+        assert grad is not None, name
+        grads[key] = grad.clone()
+    return grads
+
+
+def _mutating_ops(mask_mod: Callable[..., Tensor]) -> list[str]:
+    """Names of the in-place aten ops a `mask_mod` traces down to."""
+    idx = torch.arange(4)
+    graph = make_fx(mask_mod)(torch.tensor(0), torch.tensor(0), idx, idx)
+    return [
+        str(node.target)
+        for node in graph.graph.nodes
+        if getattr(getattr(node.target, "_schema", None), "is_mutable", False)
+    ]
+
+
+def test_mask_mod_is_free_of_in_place_ops() -> None:
+    """Regression guard, and the reason it exists is not hypothetical.
+
+    Inductor lowers a `mask_mod` as a pointwise subgraph, in which no buffer may be
+    created -- so a single in-place op makes the flex path fail to compile at EVERY
+    shape ("SubgraphLoweringException: Buffers cannot be created while lowering a
+    pointwise subgraph"). `ruff check` in this repo runs with `fix = true` and
+    `unsafe-fixes = true`, and PLR6104 happily rewrites `keep = keep & x` into
+    `keep &= x`, which is exactly that failure. It bit once already.
+
+    This check runs on CPU, so it guards the flex path on machines that cannot run
+    the CUDA parity tests at all.
+    """
+    for window in (None, 6, 16):
+        assert not _mutating_ops(
+            frame_block_causal_mask_mod(PROD_TOKENS_PER_FRAME, window)
+        )
+
+
+def test_in_place_mask_mod_is_detected() -> None:
+    """Negative control for the guard above: the form ruff produces must be caught."""
+
+    def in_place(b: Tensor, h: Tensor, q_idx: Tensor, kv_idx: Tensor) -> Tensor:
+        del b, h
+        delta = q_idx // PROD_TOKENS_PER_FRAME - kv_idx // PROD_TOKENS_PER_FRAME
+        keep = delta >= 0
+        keep &= delta <= LAYERS  # any bound; the in-place `&=` is the point
+        return keep
+
+    assert _mutating_ops(in_place) == ["aten.bitwise_and_.Tensor"]
 
 
 def test_flex_mask_mod_matches_dense_mask() -> None:
@@ -585,8 +636,12 @@ def test_flex_block_mask_is_block_sparse(num_frames: int, window: int) -> None:
     """
     k = PROD_TOKENS_PER_FRAME
     bm = frame_block_causal_block_mask(num_frames, k, window=window)
+    # partial blocks (masked elementwise inside the kernel) cost the same as full
+    # ones, so both count toward the work actually done
+    full_blocks = bm.full_kv_num_blocks
+    assert full_blocks is not None, "no fully-unmasked blocks at all?"
     computed = (
-        int(bm.kv_num_blocks.sum().item()) + int(bm.full_kv_num_blocks.sum().item())
+        int(bm.kv_num_blocks.sum().item()) + int(full_blocks.sum().item())
     ) * FLEX_BLOCK_SIZE**2
     exact = k * k * sum(min(f + 1, window) for f in range(num_frames))
     dense = (num_frames * k) ** 2

--- a/tests/test_causal_frame.py
+++ b/tests/test_causal_frame.py
@@ -32,6 +32,7 @@ from torch import Tensor, nn
 from rmind.components.transformer.causal_frame import (
     MASK_BIAS,
     CausalFrameTransformer,
+    apply_rope,
     frame_block_causal_mask,
     frame_rope_cos_sin,
 )
@@ -42,6 +43,8 @@ DIM = 32
 HEADS = 4
 LAYERS = 3
 TOL = 1e-6
+# a negative control must miss the 1e-6 gate by orders of magnitude, not narrowly
+CONTROL_MIN_ERROR = 1e-2
 
 
 def _trunk(
@@ -94,16 +97,16 @@ class WindowAbsoluteTrunk(CausalFrameTransformer):
         )
         nn.init.trunc_normal_(self.absolute_position_embedding.weight, std=0.02)
 
-    def _unit_rope(self, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, ...]:
+    def _unit_rope(
+        self, device: torch.device, dtype: torch.dtype
+    ) -> tuple[Tensor, ...]:
         return (
             torch.ones(1, 1, 1, self.head_dim, device=device, dtype=dtype),
             torch.zeros(1, 1, 1, self.head_dim, device=device, dtype=dtype),
         )
 
     @override
-    def forward(
-        self, src: Tensor, *, num_frames: int, frame_offset: int = 0
-    ) -> Tensor:
+    def forward(self, src: Tensor, *, num_frames: int, frame_offset: int = 0) -> Tensor:
         _, seq_len, _ = src.shape
         # window-absolute: shifting the frames later in the episode shifts the
         # positional lookup, which is exactly what sliding the window does
@@ -120,7 +123,7 @@ class WindowAbsoluteTrunk(CausalFrameTransformer):
         return self.norm(x)
 
     @override
-    def step(  # noqa: PLR0913
+    def step(
         self,
         src: Tensor,
         *,
@@ -218,8 +221,6 @@ def test_intra_frame_attention_is_exactly_unrotated() -> None:
     (ordered only by the intra-frame embedding). A pairing/axis bug in
     `apply_rope` breaks this.
     """
-    from rmind.components.transformer.causal_frame import apply_rope
-
     g = torch.Generator().manual_seed(3)
     q = torch.randn(2, HEADS, TOKENS_PER_FRAME, DIM // HEADS, generator=g).double()
     k = torch.randn(2, HEADS, TOKENS_PER_FRAME, DIM // HEADS, generator=g).double()
@@ -258,12 +259,17 @@ def test_shift_invariance_negative_control() -> None:
     trunk = _trunk(window=6, cls=WindowAbsoluteTrunk)
     x = _flat(_tokens(6))
     err = (
-        (trunk(x, num_frames=6, frame_offset=0) - trunk(x, num_frames=6, frame_offset=7))
+        (
+            trunk(x, num_frames=6, frame_offset=0)
+            - trunk(x, num_frames=6, frame_offset=7)
+        )
         .abs()
         .max()
         .item()
     )
-    assert err > 1e-2, f"control should not be shift-invariant, got {err:.3e}"
+    assert err > CONTROL_MIN_ERROR, (
+        f"control should not be shift-invariant, got {err:.3e}"
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -314,7 +320,7 @@ def test_stream_vs_recompute_negative_control() -> None:
     recompute = _readouts(trunk(_flat(tokens), num_frames=num_frames), num_frames)
     streamed = stream(trunk, tokens, cache_frames=window - 1)
     err = (streamed - recompute).abs().max().item()
-    assert err > 1e-2, f"control should diverge, got {err:.3e}"
+    assert err > CONTROL_MIN_ERROR, f"control should diverge, got {err:.3e}"
 
 
 def test_isolated_window_recompute_is_not_identical() -> None:
@@ -427,4 +433,5 @@ def test_multihead_attention_state_dict_is_loadable() -> None:
     missing, unexpected = trunk.layers[0].attn.load_state_dict(
         ref.state_dict(), strict=False
     )
-    assert not missing and not unexpected
+    assert not missing
+    assert not unexpected

--- a/tests/test_causal_frame.py
+++ b/tests/test_causal_frame.py
@@ -153,13 +153,28 @@ class WindowAbsoluteTrunk(CausalFrameTransformer):
 
 
 def stream(
-    trunk: CausalFrameTransformer, tokens: Tensor, *, cache_frames: int
+    trunk: CausalFrameTransformer,
+    tokens: Tensor,
+    *,
+    cache_frames: int,
+    ring: bool = False,
 ) -> Tensor:
     """One-frame-per-tick decode against a host-side ring buffer.
 
     Emulates exactly what drivr would do: the graph reads `past_k`/`past_v` and
-    returns only the new frame's K/V, and the host shifts them into the ring.
+    returns only the new frame's K/V, and the host places them in the ring.
     Returns the readout token per frame, `(b, t, d)`.
+
+    Two placement policies, and they must agree (see
+    `test_ring_slot_write_matches_shift_left`):
+
+    * `ring=False` -- shift the whole cache left by one frame block. Simple, but it
+      moves the entire cache every tick.
+    * `ring=True` -- write into slot `t % cache_frames`, moving nothing. Valid
+      because attention is permutation-invariant over keys and each key carries its
+      own rotation (RoPE with its absolute frame index) and its own `cache_bias`
+      slot. This is what the runtime should do: 257 tokens per layer instead of the
+      whole cache, and no overlapping in-place copy.
     """
     b, num_frames, k, _ = tokens.shape
     past_k, past_v, bias = trunk.empty_cache(
@@ -179,7 +194,15 @@ def stream(
             cache_bias=bias,
         )
         outs.append(out[:, -1])
-        if cache_frames:
+        if not cache_frames:
+            continue
+        if ring:
+            slot = slice((t % cache_frames) * k, (t % cache_frames + 1) * k)
+            past_k, past_v, bias = past_k.clone(), past_v.clone(), bias.clone()
+            past_k[..., slot, :] = new_k
+            past_v[..., slot, :] = new_v
+            bias[..., slot] = 0.0
+        else:
             past_k = torch.cat((past_k[..., k:, :], new_k), dim=-2)
             past_v = torch.cat((past_v[..., k:, :], new_v), dim=-2)
             bias = torch.cat((bias[..., k:], torch.zeros_like(bias[..., :k])), dim=-1)
@@ -435,3 +458,23 @@ def test_multihead_attention_state_dict_is_loadable() -> None:
     )
     assert not missing
     assert not unexpected
+
+
+@pytest.mark.parametrize("window", [2, 3, 6])
+def test_ring_slot_write_matches_shift_left(window: int) -> None:
+    """The host may write the new frame into slot `t % cache_frames` and move
+    nothing, instead of shifting the whole cache left.
+
+    Valid because attention is permutation-invariant over keys and every key
+    carries its own RoPE rotation (absolute frame index) and its own `cache_bias`
+    slot -- so cache ORDER is not information. Worth testing rather than asserting:
+    it is the difference between moving 257 tokens per layer per tick and moving the
+    entire cache, ~18 MiB versus ~2.3 GiB of device traffic at `_big`/64 frames, and
+    the shift-left form is an overlapping in-place copy that is undefined on GPU.
+    """
+    num_frames = 9
+    trunk = _trunk(window=window)
+    tokens = _tokens(num_frames)
+    shifted = stream(trunk, tokens, cache_frames=window - 1, ring=False)
+    slotted = stream(trunk, tokens, cache_frames=window - 1, ring=True)
+    torch.testing.assert_close(slotted, shifted, rtol=0, atol=TOL)

--- a/tests/test_overfit_regularizers.py
+++ b/tests/test_overfit_regularizers.py
@@ -249,3 +249,25 @@ def test_full_model_train_step_causal_sdpa_cpu() -> None:
 def test_full_model_train_step_causal_flex_gpu() -> None:
     torch.manual_seed(0)
     _train_step(_causal_regularized_model("flex"), "cuda")
+
+
+def test_context_depth_bucket_metrics_present() -> None:
+    # window=2, episode_length=3: position 0 is partial-window, 1..2 full
+    model = _causal_regularized_model("sdpa").eval()
+    metrics = model._compute_metrics(_make_batch())  # noqa: SLF001
+    for bucket in ("partial_window", "full_window"):
+        assert ("policy", "metric", f"code_{bucket}") in metrics.keys(
+            include_nested=True
+        )
+        assert ("policy", "metric", f"offset_{bucket}") in metrics.keys(
+            include_nested=True
+        )
+
+
+def test_context_depth_buckets_absent_for_block_causal_trunk() -> None:
+    from tests.test_patch_policy import _make_model as _make_sdpa_model
+
+    metrics = _make_sdpa_model()._compute_metrics(_make_batch())  # noqa: SLF001
+    assert ("policy", "metric", "code_full_window") not in metrics.keys(
+        include_nested=True
+    )

--- a/tests/test_overfit_regularizers.py
+++ b/tests/test_overfit_regularizers.py
@@ -1,0 +1,171 @@
+"""The anti-overfitting package for the causal arms: stochastic depth,
+label-smoothed focal code loss, and per-module weight-decay overrides."""
+
+import pytest
+import torch
+from torch import nn
+
+from rmind.components.loss import FocalLoss
+from rmind.components.optimizers.selective_adamw import SelectiveAdamW
+from rmind.components.transformer.causal_frame import CausalFrameTransformer, DropPath
+
+RESCALED = 2.0  # 1 / keep for drop_prob 0.5
+DROP_RATE_BAND = (0.35, 0.65)
+MEAN_TOL = 0.15
+NEAR_ZERO = 1e-6
+
+
+def test_drop_path_eval_is_exact_identity() -> None:
+    dp = DropPath(0.5).eval()
+    x = torch.randn(4, 3, 8)
+    assert torch.equal(dp(x), x)
+
+
+def test_drop_path_zero_rate_is_identity_in_train() -> None:
+    dp = DropPath(0.0).train()
+    x = torch.randn(4, 3, 8)
+    assert torch.equal(dp(x), x)
+
+
+def test_drop_path_drops_whole_samples_and_rescales() -> None:
+    torch.manual_seed(0)
+    dp = DropPath(0.5).train()
+    x = torch.ones(512, 2, 4)
+    y = dp(x)
+    per_sample = y.flatten(1)
+    zeroed = (per_sample == 0).all(dim=1)
+    kept = (per_sample == RESCALED).all(dim=1)
+    # every sample is either fully dropped or fully kept-and-rescaled
+    assert (zeroed | kept).all()
+    # unbiased in expectation: drop rate near 0.5, mean near 1
+    lo, hi = DROP_RATE_BAND
+    assert lo < zeroed.float().mean().item() < hi
+    assert abs(y.mean().item() - 1.0) < MEAN_TOL
+
+
+def test_drop_path_invalid_rate_raises() -> None:
+    with pytest.raises(ValueError, match="drop_prob"):
+        DropPath(1.0)
+
+
+def test_trunk_ramp_is_linear_and_eval_output_unchanged() -> None:
+    kwargs = {
+        "dim_model": 64,
+        "num_layers": 4,
+        "num_heads": 4,
+        "tokens_per_frame": 5,
+        "window": 2,
+    }
+    torch.manual_seed(7)
+    plain = CausalFrameTransformer(**kwargs)
+    torch.manual_seed(7)
+    reg = CausalFrameTransformer(**kwargs, drop_path_rate=0.1)
+
+    rates = [blk.drop_path.drop_prob for blk in reg.layers]
+    assert rates == pytest.approx([0.0, 0.1 / 3, 0.2 / 3, 0.1])
+
+    # same seed -> same weights; in eval, drop-path must be invisible
+    x = torch.randn(2, 3 * 5, 64)
+    out_plain = plain.eval()(x, num_frames=3)
+    out_reg = reg.eval()(x, num_frames=3)
+    torch.testing.assert_close(out_plain, out_reg, rtol=0, atol=0)
+
+
+def test_trunk_train_mode_actually_drops() -> None:
+    torch.manual_seed(3)
+    trunk = CausalFrameTransformer(
+        dim_model=64,
+        num_layers=4,
+        num_heads=4,
+        tokens_per_frame=5,
+        window=2,
+        attn_dropout=0.0,
+        resid_dropout=0.0,
+        mlp_dropout=0.0,
+        drop_path_rate=0.9,
+    ).train()
+    x = torch.randn(8, 3 * 5, 64)
+    a, b = trunk(x, num_frames=3), trunk(x, num_frames=3)
+    assert not torch.allclose(a, b)
+
+
+def test_zero_smoothing_matches_legacy_exactly() -> None:
+    torch.manual_seed(0)
+    logits = torch.randn(64, 16)
+    target = torch.randint(0, 16, (64,))
+    new = FocalLoss(gamma=2.0, label_smoothing=0.0)(logits, target)
+    # legacy formula, inlined
+    ce = torch.nn.functional.cross_entropy(logits, target, reduction="none")
+    pt = torch.exp(-ce)
+    legacy = ((1 - pt).pow(2.0) * ce).mean()
+    torch.testing.assert_close(new, legacy, rtol=0, atol=0)
+
+
+def test_smoothing_penalizes_overconfidence() -> None:
+    # near-one-hot confident-correct predictions: unsmoothed focal ~ 0, and the
+    # smoothed loss must NOT be cancelled by the (1-pt)^gamma factor -- growing
+    # the margin must grow the penalty
+    target = torch.arange(16)
+    confident = torch.full((16, 16), -20.0)
+    confident[torch.arange(16), target] = 20.0
+    overconfident = confident * 2
+    plain = FocalLoss(label_smoothing=0.0)(confident, target)
+    smoothed = FocalLoss(label_smoothing=0.1)
+    assert plain.item() < NEAR_ZERO
+    assert smoothed(confident, target).item() > NEAR_ZERO
+    assert smoothed(overconfident, target).item() > smoothed(confident, target).item()
+
+
+def test_smoothed_focal_gradient_flows() -> None:
+    logits = torch.randn(8, 16, requires_grad=True)
+    loss = FocalLoss(label_smoothing=0.1)(logits, torch.randint(0, 16, (8,)))
+    loss.backward()
+    assert logits.grad is not None
+    assert torch.isfinite(logits.grad).all()
+
+
+class _Toy(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.trunk = nn.Linear(4, 4)
+        self.code_head = nn.Sequential(nn.Linear(4, 8), nn.Linear(8, 4))
+        self.norm = nn.LayerNorm(4)
+
+
+def _opt(**kw: object) -> SelectiveAdamW:
+    return SelectiveAdamW(
+        _Toy(),
+        lr=1e-4,
+        weight_decay=0.1,
+        weight_decay_module_blacklist=(nn.LayerNorm, nn.Embedding),
+        **kw,
+    )
+
+
+def test_override_group_gets_its_decay() -> None:
+    opt = _opt(weight_decay_overrides={"code_head": 0.2})
+    decays = [g["weight_decay"] for g in opt.param_groups]
+    sizes = [len(g["params"]) for g in opt.param_groups]
+    # [blacklist 0.0, whitelist 0.1, code_head 0.2]
+    assert decays == [0.0, 0.1, 0.2]
+    # code_head has its 2 Linear weights here; biases stay in the 0.0 group
+    assert sizes[2] == len([
+        n for n, _ in _Toy().named_parameters() if "code_head" in n and "weight" in n
+    ])
+
+
+BASE_GROUPS = 2  # [no-decay blacklist, decayed whitelist]
+
+
+def test_no_override_is_two_groups() -> None:
+    assert len(_opt().param_groups) == BASE_GROUPS
+
+
+def test_unmatched_override_prefix_raises() -> None:
+    with pytest.raises(ValueError, match="matched no decayed params"):
+        _opt(weight_decay_overrides={"nonexistent_head": 0.2})
+
+
+def test_overlapping_override_prefixes_raise() -> None:
+    with pytest.raises(ValueError, match="overlap"):
+        _opt(weight_decay_overrides={"code_head": 0.2, "code_head.0": 0.3})

--- a/tests/test_overfit_regularizers.py
+++ b/tests/test_overfit_regularizers.py
@@ -192,7 +192,9 @@ def _causal_regularized_model(attention_impl: str) -> PatchPolicy:
     model.encoder = CausalFrameTransformer(
         dim_model=POLICY_DIM,
         num_layers=2,
-        num_heads=2,
+        # FlexAttention requires head_dim >= 16 (production: 512/8 = 64);
+        # 1 head keeps the toy POLICY_DIM=16 legal on the flex path
+        num_heads=1,
         tokens_per_frame=NUM_PATCHES + 1,
         window=2,
         max_sequence_length=EPISODE_LENGTH * (NUM_PATCHES + 1),

--- a/tests/test_overfit_regularizers.py
+++ b/tests/test_overfit_regularizers.py
@@ -265,9 +265,7 @@ def test_context_depth_bucket_metrics_present() -> None:
 
 
 def test_context_depth_buckets_absent_for_block_causal_trunk() -> None:
-    from tests.test_patch_policy import _make_model as _make_sdpa_model
-
-    metrics = _make_sdpa_model()._compute_metrics(_make_batch())  # noqa: SLF001
+    metrics = _make_model()._compute_metrics(_make_batch())  # noqa: SLF001
     assert ("policy", "metric", "code_full_window") not in metrics.keys(
         include_nested=True
     )

--- a/tests/test_overfit_regularizers.py
+++ b/tests/test_overfit_regularizers.py
@@ -169,3 +169,81 @@ def test_unmatched_override_prefix_raises() -> None:
 def test_overlapping_override_prefixes_raise() -> None:
     with pytest.raises(ValueError, match="overlap"):
         _opt(weight_decay_overrides={"code_head": 0.2, "code_head.0": 0.3})
+
+
+# ---------------------------------------------------------------------------
+# The pre-launch gate: a full PatchPolicy training step through the causal
+# trunk with ALL THREE regularizers active, backward, and a SelectiveAdamW
+# step with the code_head decay override. Runs on CPU with sdpa; the flex
+# variant needs a GPU (same gate, attention_impl="flex").
+# ---------------------------------------------------------------------------
+
+
+def _causal_regularized_model(attention_impl: str) -> "PatchPolicy":
+    from tests.test_patch_policy import (
+        EPISODE_LENGTH,
+        NUM_PATCHES,
+        POLICY_DIM,
+        _make_model,
+    )
+
+    model = _make_model()
+    model.encoder = CausalFrameTransformer(
+        dim_model=POLICY_DIM,
+        num_layers=2,
+        num_heads=2,
+        tokens_per_frame=NUM_PATCHES + 1,
+        window=2,
+        max_sequence_length=EPISODE_LENGTH * (NUM_PATCHES + 1),
+        attn_dropout=0.0,
+        attention_impl=attention_impl,  # type: ignore[arg-type]
+        drop_path_rate=0.1,
+    )
+    model.losses["code"] = FocalLoss(label_smoothing=0.1)
+    return model
+
+
+def _train_step(model: "PatchPolicy", device: str) -> None:
+    from tests.test_patch_policy import _make_batch
+
+    model = model.to(device).train()
+    opt = SelectiveAdamW(
+        model,
+        lr=1e-4,
+        weight_decay=0.1,
+        weight_decay_overrides={"code_head": 0.2},
+        weight_decay_module_blacklist=(nn.LayerNorm, nn.Embedding),
+    )
+    batch = {}
+    src = _make_batch()
+
+    def _to(x: object) -> object:
+        return (
+            {k: _to(v) for k, v in x.items()} if isinstance(x, dict) else x.to(device)
+        )  # type: ignore[union-attr]
+
+    batch = _to(src)
+    loss = model._compute_metrics(batch)["policy", "loss"].sum(reduce=True)  # noqa: SLF001
+    assert torch.isfinite(loss)
+    loss.backward()
+    grads = {
+        n: p.grad is not None and bool(torch.isfinite(p.grad).all())
+        for n, p in model.named_parameters()
+        if p.requires_grad
+    }
+    assert grads and all(grads.values()), [n for n, ok in grads.items() if not ok]
+    assert any("encoder.intra_position_embedding" in n for n in grads)
+    assert any(n.startswith("code_head") for n in grads)
+    opt.step()
+    opt.zero_grad()
+
+
+def test_full_model_train_step_causal_sdpa_cpu() -> None:
+    torch.manual_seed(0)
+    _train_step(_causal_regularized_model("sdpa"), "cpu")
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="flex needs a GPU")
+def test_full_model_train_step_causal_flex_gpu() -> None:
+    torch.manual_seed(0)
+    _train_step(_causal_regularized_model("flex"), "cuda")

--- a/tests/test_overfit_regularizers.py
+++ b/tests/test_overfit_regularizers.py
@@ -8,6 +8,14 @@ from torch import nn
 from rmind.components.loss import FocalLoss
 from rmind.components.optimizers.selective_adamw import SelectiveAdamW
 from rmind.components.transformer.causal_frame import CausalFrameTransformer, DropPath
+from rmind.models.patch_policy import PatchPolicy
+from tests.test_patch_policy import (
+    EPISODE_LENGTH,
+    NUM_PATCHES,
+    POLICY_DIM,
+    _make_batch,
+    _make_model,
+)
 
 RESCALED = 2.0  # 1 / keep for drop_prob 0.5
 DROP_RATE_BAND = (0.35, 0.65)
@@ -179,14 +187,7 @@ def test_overlapping_override_prefixes_raise() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _causal_regularized_model(attention_impl: str) -> "PatchPolicy":
-    from tests.test_patch_policy import (
-        EPISODE_LENGTH,
-        NUM_PATCHES,
-        POLICY_DIM,
-        _make_model,
-    )
-
+def _causal_regularized_model(attention_impl: str) -> PatchPolicy:
     model = _make_model()
     model.encoder = CausalFrameTransformer(
         dim_model=POLICY_DIM,
@@ -203,9 +204,7 @@ def _causal_regularized_model(attention_impl: str) -> "PatchPolicy":
     return model
 
 
-def _train_step(model: "PatchPolicy", device: str) -> None:
-    from tests.test_patch_policy import _make_batch
-
+def _train_step(model: PatchPolicy, device: str) -> None:
     model = model.to(device).train()
     opt = SelectiveAdamW(
         model,
@@ -231,7 +230,8 @@ def _train_step(model: "PatchPolicy", device: str) -> None:
         for n, p in model.named_parameters()
         if p.requires_grad
     }
-    assert grads and all(grads.values()), [n for n, ok in grads.items() if not ok]
+    assert grads
+    assert all(grads.values()), [n for n, ok in grads.items() if not ok]
     assert any("encoder.intra_position_embedding" in n for n in grads)
     assert any(n.startswith("code_head") for n in grads)
     opt.step()


### PR DESCRIPTION
Stacked on #265. Two things: **serving-cost work** (a decoder-only trunk with a KV cache, ~5–19× cheaper per tick) and **training-quality work** that also applies to the std patch policy (anti-overfitting regularizers, a training-health logger, and a fusion-calibration fix).

![Causal Patch Policy architecture](https://raw.githubusercontent.com/yaak-ai/rmind/e1fbb2f/docs/causal_patch_policy_architecture.svg)

<sub>blue = frozen · orange = trained · green = KV-cache state · also committed as `docs/causal_patch_policy_architecture.svg`</sub>

## 1. Decoder-only trunk + KV cache (`CausalFrameTransformer`)

Today's trunk is block-causal over a **fixed 6-frame window**, recomputed from scratch every tick: at tick *t+1* five of six frames are unchanged, but their representations were computed inside a window whose membership changed, so nothing is reusable. ~83% of the work is recomputation.

`CausalFrameTransformer` is a drop-in for `BlockCausalTransformer` (same `forward(src, *, num_frames)` contract, same `nn.MultiheadAttention` parameter layout) that makes caching **sound**, plus a `step()` that consumes and extends a per-layer K/V cache.

**The correctness trap and the fix.** The learned 1D positional embedding over the flattened 1542-token sequence is *window-absolute* — index 0 means "oldest frame currently in the window", so a frame's position changes as the window slides and every cached key is silently invalidated. Replaced by a factorized scheme where both factors are stable:

- **intra-frame**: a learned 257-slot embedding *tiled onto every frame* (token *k* of frame *f* always gets `intra_pos[k]`) — frame-relative, never stale, same intra-frame capacity as the 1542-slot table;
- **inter-frame**: **RoPE at frame granularity** — all 257 tokens of a frame share one rotation, so `(R_f q)ᵀ(R_f k) = qᵀk` leaves intra-frame attention *exactly* unrotated (still bidirectional) while cross-frame logits depend only on `f_q − f_k`. That is precisely why a key rotated with its own absolute frame index stays valid forever. `rope_base=1000` (over ≤64 positions base 10000 leaves most frequency pairs inert). ALiBi was rejected with numbers, not by preference: its per-head bias needs an `(H,S,S)` tensor at train time (~3.2 TB at 32 frames), while RoPE's `cos`/`sin` are host-computed **graph inputs** so the exported engine contains zero trig nodes.

**Correctness gate (`tests/test_causal_frame.py`).** The exact invariant is sliding-window equivalence: *streaming against a ring of `N−1` frames ≡ one full forward under `frame_block_causal_mask(window=N)`*. At production sizes (257 tokens/frame): **1.8e-15 fp64** / 1.4e-06 fp32, both trunk sizes, windows 6/16/32. A **negative control** — same trunk, same harness, only the positional scheme swapped back to window-absolute — fails at **9.4e-02**, five orders of magnitude worse, so the gate has teeth.

**Measured on delta-dev1** (AGX Orin, TRT, pinned 918 MHz; baselines reproduced within 0.1% first). Per tick, 8L/512 trunk:

| context | block-causal baseline | causal fp32 | causal fp16 |
|---|---|---|---|
| 6 frames | 200.9 ms | **41.8 ms** (4.8×) | **10.5 ms** |
| 16 (this arm) | — | 59.6 ms | — |
| 32 | — | 92.3 ms | **27.2 ms** |
| 64 | — | 160.5 ms | 45.7 ms |

The 12L/768 trunk: 420.2 → **87.2** (fp32) / **19.7 ms** (fp16) at 6 frames; 205.1 / 54.2 ms at 32.

### Verified on a trained checkpoint, with the parity ladder (§12 of the doc)

Re-measured on delta-dev1 from the epoch-0 checkpoint of [do8m9ot8](https://wandb.ai/yaak/rmind/runs/do8m9ot8) (`--artifact`/`--ckpt` added to the exporter — it previously only built random graphs, and the random path *replaces* `policy.encoder`, which on a checkpoint would silently discard every trained trunk weight):

- **Every random-weight prediction held to ≤0.4%** (fp32 59.82 ms at the served window 16 vs 59.58 predicted; fp16 16.97). A same-host/same-day random-vs-trained control agreed to 0.3%/0.2%, so "random weights suffice to measure this architecture" is itself now measured.
- **Correctness on trained weights**: streaming ≡ full windowed forward at **6.4e-16 fp64** (exact), 2.9e-07 fp32; ONNX-vs-eager 3.1e-06; a negative control (RoPE counter not advanced) fails at 5.5e-02. Graph: 997 nodes, 5 ArgMax, `Sin=0/Cos=0`, `Resize=0`.
- **`_gemm_mha_v2` is PRESENT** in every fp16 engine — 19 instances, 5.34 ms, **29.4% of the step**, the largest single bucket. Standalone concat kernels cost **0.00 ms** because TRT *absorbs* the concat into that fused kernel: further confirmation it is load-bearing. (Trap for the next person: the build log reports 0 hits unless `profilingVerbosity=detailed` — grep the engine, never only the log.)

**Parity ladder, n=200 real camera frames, judged on decision changes — the recommendation for this arm is to serve fp32:**

| engine | latency | KV cache | decisions changed | worst \|Δ\| |
|---|---|---|---|---|
| **fp32** (TF32 cleared) | **59.82 ms** | 120 MiB | **0/200** | 4.2e-07 |
| fp32 encoder + fp16 trunk | 21.79 ms | 120 MiB | 2/200 | 0.043 |
| fp16 | 16.97 ms | 120 MiB | 5/200 | 0.183 |
| fp16 + fp16 cache I/O | **13.63 ms** | **60 MiB** | 2/200 | 0.043 |

fp32 is 0/200 **and** already **3.36× cheaper than the 200.85 ms the 6-frame baseline costs today**, while attending 16 frames — so there is nothing to trade precision for. And fp16's failures here are worse *in kind* than in the baseline arm, where the headline magnitude was entirely `turn_signal`: here `turn_signal` never crosses tolerance and **all five flips are control channels** (up to 18.3% of steering, 10.6% of throttle). Training also *tightened* the code head's ArgMax margins (21.4 → 1.9 fp16 ULP between init and step 80.8k), so margins must be re-screened per checkpoint and never inherited.

Two findings worth carrying into the export skill: a plain `--fp16` build leaves the **KV cache bindings in fp32** (TRT preserves ONNX-declared I/O dtypes), and the resulting reformat copies of `past_k`/`past_v` cost **2.51 ms — 14% of the step**; declaring `--inputIOFormats`/`--outputIOFormats` halves the cache to 60 MiB *and* drops latency to 13.63 ms. That also inverts the skill's standing "mixed fp32-encoder/fp16-trunk" recommendation for this graph specifically, because the decoder step encodes only one frame, so the image encoder is 69% of the graph's layers and pinning it is no longer cheap.

Two corrections to the original design note, both from measurement: per-tick cost is **linear** in context (≈2.05 / 4.78 ms per frame), *not* constant — what grows superlinearly is the advantage over recomputing an N-frame window; and the `_big` trunk is **12 layers**, not 8. The honest headline: **the big trunk attends to 32 frames for 205 ms, less than half of what 6 frames cost today**, and fp16 would put every arm at every context ≤64 frames inside both the 333 ms tick and the 270 ms plan-distortion threshold — though see the parity result below: for this arm fp32 is the servable configuration, and it already clears the tick comfortably.

## 2. Affordable long-context training (FlexAttention)

The window mask buys nothing under dense SDPA — measured **flat** at 24.3 ms for w=8/16/32. `attention_impl: flex` (default stays `sdpa`) lowers the frame-window mask to a block-sparse kernel: 64-frame/w16 attention **377.4 → 54.7 ms (6.9×)**.

The enabling recipe idea is decoupling **`episode_length`** (supervision density — every frame is a readout) from **`window`** (context depth = serving ring capacity). Setting them equal is just block-causal again, `O(F²)`, and it trains the first `window−1` readouts under less context than serving provides. With `episode_length > window`, cost is linear in `F`; holding `batch × episode_length` at today's 768 frame-slots/step keeps ViT cost, readout count and activation memory invariant, so only attention changes — and flex makes that nearly free:

| arm | geometry | batch | impl | step | trunk peak |
|---|---|---|---|---|---|
| 512-d/8L | 6 fr, w6 (today) | 128 | sdpa | 670.7 ms | 9.60 GiB |
| 512-d/8L | **32 fr, w16** | 24 | **flex** | **701.7 ms** | **9.60 GiB** |
| 768-d/12L | 6 fr, w6 (today) | 128 | sdpa | 1713.5 ms | 16.80 GiB |
| 768-d/12L | **32 fr, w16** | 24 | **flex** | **1779.6 ms** | **16.79 GiB** |

5.3× the context for **1.05×** the step time at identical memory. To be precise about what this does and does not buy: supervision *count* per step is unchanged (768 either way) — what changes is its distribution over context depths, from ~17% of readouts at the served window to ~84%. The cost is ~5× fewer independent scenes per gradient step, which is part of why the regularizers below are not optional here.

Correctness gate: flex-vs-sdpa forward **and backward** at production shapes, tolerance justified against an exact float64 reference (flex sits at 1.4× sdpa's own fp32 noise, and the test asserts that 2× bound rather than a hand-tuned epsilon). Two landmines are fenced by tests: ruff's unsafe `PLR6104` autofix rewrites the mask function into an in-place op that makes inductor **silently** fall back (killing the block-sparse path at every shape), and dynamo's 8-entry compile cache falls back to *eager* flex, which materializes the score matrix.

## 3. Applies to the std patch policy too

- **Anti-overfitting package** (the mid/big arms overfit hard — train `p_gt ≈ 0.6` vs val `≈ 0.13`): stochastic depth (`DropPath`, timm-style linear ramp, exact identity in eval so the streaming gate and the export path are untouched); **label smoothing on the focal code loss**, using the smoothed-CE decomposition with the focal factor on the true-class term only — modulating both would let `(1-pt)^γ → 0` cancel the penalty exactly on the confident predictions smoothing exists to punish; and **per-module weight-decay overrides** in `SelectiveAdamW` (`code_head: 0.2` vs global 0.1).
- **`TrainingQualityLogger`** (port of #263, wired into the patch-policy callback stack): per-group grad/weight norms, grad-to-weight, dead-gradient fraction, train↔val gap, representation effective rank. The extra grouping level under `encoder` separates the block stack from the positional machinery. It earned its place immediately — it surfaced an offset-head dead-gradient fraction climbing 0.29 → 0.83 over 27k steps (structural gather-sparsity floor ≈29% is benign; above that it is dying ReLUs plus a weight-decay ratchet on zero-grad rows).
- **`fusion_goal_rms`** — a real bug fix. The seeded uniform-random-code Monte Carlo overestimates `RMS(z_q)` by **1.86×** (0.143 vs 0.077 measured), so `fusion_norm`'s goal gain lands the goal stream at ~0.54 effective RMS instead of the intended 1.0. Any arm using `fusion_norm` should pass the measured value.
- **Context-depth metrics** (`code_/offset_{partial,full}_window`) — dormant unless the trunk has a `window`, so std behaviour is unchanged.
- **`val_check_interval: 0.25`** for the causal arm. Not cosmetic: 82.1k-step epochs (~28 h) give 3 val points per run, and the quality logger's gap/repr signals only fire at validation end. Related finding worth flagging for **any** arm: when `len(train_dataloader)` over-reports the real epoch length (82,083 vs an actual 80,797 here), Lightning's epoch-end validation trigger `(batch_idx+1) % val_check_batch == 0` is never satisfied and the `is_last_batch` fallback only applies to *infinite* datasets — so **validation is silently skipped every epoch**. A step-based interval sidesteps it; the loader's `__len__` deserves a follow-up fix.

## Status

- `dinov2_dinowm_causal` (32 frames / window 16 / flex / fusion_norm / all three regularizers) is training as [do8m9ot8](https://wandb.ai/yaak/rmind/runs/do8m9ot8). All latency/parity numbers above come from random-init or **epoch-0** weights — **latency, cache correctness and precision parity only; no quality claims**.
- **Open question from the epoch-0 offline validation** (full 14,365-clip val set, branch `diag/patch-policy-causal-offline-val`): the long-context advantage visible in *training* metrics (full-window readouts better by 5.9% and widening) **does not transfer to held-out data** — partial-window vs full-window differ by +0.4%, and per-position p(GT) peaks at t≈11–13 rather than at the deepest readout. If that survives to later epochs, a `window: 6` arm would serve ~3× cheaper for the same held-out quality while keeping the full ~4.8× cache win. Overfitting is real (val-vs-train code gap +75%) but this arm is in a better absolute place than its predecessors (val code 1.083 unsmoothed at epoch 0 vs their 1.34–1.46 at epoch 3), and H6 is healthy (entropy 1.59 nats, no collapse). Decide at the first instrumented val point rather than committing the remaining ~50 h.
- Not included here: the paged/in-place attention investigation (`feat/patch-policy-decoder-paged`), which concluded the KV `Concat` is **load-bearing** for TRT's fused fp16 MHA kernel (removing it is 2.6× *slower*) and that the earlier "34% Concat bottleneck" was a profile name-matching artifact — the biggest "Concat" kernel is the softmax. It also ships a corrected profile bucketing script. Worth landing separately.
- Follow-ups staged, not applied: GELU in the offset head (dying-ReLU fix that keeps decay as the overfit control — the offset head *does* overfit, val +14–21% while train falls, so wd→0 would trade one problem for another); SmoothL1 (β≈0.05, not the default 1.0, which would be a silent 20–50× LR cut at these residual scales) as a *separate* ablation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3dzGC19LKTaHogQ6KFP9Z
