### PR TITLE
feat: nero-arms depth arm — disparity as a fourth camera (contract §22)

### DIFF
--- a/config/experiment/yaak/nero_arms/causal_depth.yaml
+++ b/config/experiment/yaak/nero_arms/causal_depth.yaml
@@ -1,0 +1,141 @@
+# @package _global_
+#
+# DEPTH ARM (contract §22) of the nero-arms causal patch policy -- Max: "I'd
+# include the depth".
+#
+# ⚠️ This is an ADDITIVE, OPT-IN arm (§22.6). `causal.yaml` and
+# `config/model/yaak/nero_patch_policy/raw.yaml` are NOT touched by it, so the
+# depth-OFF model is byte-identical at the config level and bit-identical at the
+# weight level. Depth is measured as an A/B, never assumed to help.
+#
+# WHY A FOURTH CAMERA AND NOT A FOURTH CHANNEL (§22.1)
+# ----------------------------------------------------
+# The disparity stream declares `reference_frame: rectified_CAM_B`,
+# `aligned_to: none` -- it lives in the rectified LEFT MONO camera's frame, a
+# different sensor at a different position with a much wider lens (96.0 deg HFOV
+# against `CAM_A`'s 73.7 deg, §21.8). `setDepthAlign` is deliberately NOT applied
+# upstream because warping invalidates the fx_mono*baseline/disparity conversion.
+# Stacking it onto the overhead RGB would silently misregister every pixel.
+#
+# SEQUENCE LENGTH -- compute it before launching anything (PR #265's lesson):
+#
+#   depth-off: 3 * 160 + 1                = 481 tokens/frame -> 6 * 481 = 2886
+#   depth-on:  3 * 160 + 1 + 1 * 40       = 521 tokens/frame -> 6 * 521 = 3126
+#
+#   +8.3% sequence, ~1.17x attention (quadratic).
+#
+# §22.2 suggested "half the patches" for depth (80 -> 561/frame -> 3366, +16.6%).
+# This arm goes one step coarser -- a 5x8 = 40-token grid -- because disparity
+# carries far less high-frequency information than RGB. The grid falls straight
+# out of the patch size: an 80x128 input at patch 16 IS 5x8, with no pooling
+# anywhere. To take §22.2 literally, use 80x256 at patch 16 for [5, 16].
+#
+# ⚠️ THE ENCODER IS A TRAINABLE Linear, NOT THE FROZEN DINOv2 (§22.7). Routing
+# disparity through the RGB ViT was the first cut here and it was wrong: DINOv2
+# is trained on natural RGB and disparity is a smooth geometric signal, the ViT
+# is frozen so the mismatch is uncorrectable, and a fourth ViT pass costs +33%
+# frozen compute per frame to buy +8% sequence -- the larger cost for the worse
+# representation. Linear(16*16*2 + 13 -> 512) is ~269k TRAINABLE parameters
+# against ~22M frozen, and is cheaper in FLOPs than the pass it replaces.
+
+defaults:
+  - /experiment/yaak/nero_arms/causal
+  - _self_
+
+# --- contract §21/§22 depth stream
+use_depth: true
+# §21.3: the OVERHEAD `base` device only. It looks down at the workspace so
+# disparity maps to table position; the SR side cameras sit near-tangent and
+# localise on-plane objects poorly.
+depth_cameras: [base]
+num_depth_cameras: 1
+# §22.7: the depth stream's own ViT-style patch embedding. 400x640 letterboxes
+# to 80x128 (exactly isotropic), which at patch 16 is a 5x8 = 40-token grid.
+depth_image_height: 80
+depth_image_width: 128
+depth_patch_size: 16
+depth_patch_grid: [5, 8]
+depth_patches: 40 # (80/16) x (128/16)
+# §22.5: depth dropout, applied in training REGARDLESS of how much depth the
+# data has, so the policy never becomes depth-DEPENDENT for basic motion and
+# degrades gracefully when the stream is missing at serving time. None of the 104
+# existing episodes have depth and the recorder's --depth is off by default, so
+# the missing case is the common one and must stay in-distribution.
+depth_dropout: 0.25
+
+# ⚠️ PLACEHOLDER STATISTICS. Contract §22.3 + §5.4 require the disparity
+# standardisation to be fitted on the TRAINING SPLIT ONLY, over VALID pixels
+# only. These two numbers are the moments of a uniform prior over 1..95 and are
+# a stand-in so the config is instantiable; `nero_smoke --stage depth` fits and
+# writes the real artifact. For a real run, replace this block with
+#
+#   depth_standardizer:
+#     _target_: rmind.data.nero.DisparityStandardizer.load
+#     path: ${disparity_standardizer_artifact}
+#
+# which is version-gated on load and fails loudly on a semantics change.
+depth_mean: 48.0
+depth_std: 27.4
+
+model:
+  use_depth: ${use_depth}
+  depth_cameras: ${depth_cameras}
+  depth_patch_size: ${depth_patch_size}
+  depth_patch_grid: ${depth_patch_grid}
+  depth_dropout: ${depth_dropout}
+
+  # 400x640 -> 80x128 is EXACTLY isotropic (x0.2), so this is a pure resize with
+  # NO padding for the contract's depth resolution. It is still a letterbox
+  # and not a Resize, for the same reason as the RGB path (§7.2): an anisotropic
+  # resize scales fx and fy independently and invalidates the normalised
+  # intrinsics in the depth stream's own conditioning vector.
+  #
+  # ⚠️ Resizing DISPARITY would be illegal if the model performed the metric
+  # conversion -- §21.9: a resize scales fx but not the stored disparity values,
+  # so fx*baseline/disparity would be wrong by the resize factor. It is legal
+  # here precisely because §22.3 feeds standardised DISPARITY and the model never
+  # converts to metres. The conversion stays in rbyte, at native resolution.
+  #
+  # NOTE: no ToDtype and no ImageNet Normalize. Disparity is not RGB; its
+  # normalisation is the train-split standardisation below, which is the direct
+  # analogue, and it happens BEFORE this transform so that invalid pixels cannot
+  # bleed into their valid neighbours during interpolation.
+  depth_transform:
+    _target_: rmind.components.image.LetterboxResize
+    size: ["${depth_image_height}", "${depth_image_width}"]
+
+  depth_standardizer:
+    _target_: rmind.data.nero.DisparityStandardizer
+    mean: ${depth_mean}
+    std: ${depth_std}
+    max_disparity: 95 # §21.1 default mode; §21.10 DECLARES it per episode
+    source: PLACEHOLDER-uniform-prior
+
+  # §22.7: per depth token, [ patch_size^2 * 2 channels | camera_cond 13 ].
+  # TWO channels: standardised disparity AND the validity mask, so "no
+  # measurement" is a first-class input rather than something the network must
+  # infer from a fill value (§22.4). Projects straight to d_model -- there is no
+  # frozen feature space to pass through.
+  depth_patch_embedding:
+    _target_: rmind.components.nn.Linear
+    in_features: "${eval:'${depth_patch_size} * ${depth_patch_size} * 2 + ${camera_cond_dim}'}"
+    out_features: ${policy_embedding_dim}
+
+  # ⚠️ MUST be updated together with the token layout. The trunk's tiled
+  # intra-frame embedding and frame-RoPE are indexed by this; a stale value does
+  # not necessarily raise, it tiles WRONG. `nero_smoke --stage budget` asserts
+  # this against the actual `_frame_tokens` output.
+  encoder:
+    tokens_per_frame: "${eval:'${num_cameras} * ${num_patches} + 1 + ${num_depth_cameras} * ${depth_patches}'}"
+
+# The synthetic loader emits the depth stream at the real contract shapes
+# (§21.11: (T, 1, 400, 640) -- LARGER than the RGB tensors, because §21.9
+# forbids resizing depth while §8 downscales RGB).
+datamodule:
+  train:
+    depth: true
+  val:
+    depth: true
+
+wandb:
+  tags: [nero_arms, causal_patch_policy, depth]

--- a/docs/nero_arms_causal_patch_policy.md
+++ b/docs/nero_arms_causal_patch_policy.md
@@ -320,6 +320,183 @@ time is dominated by synthetic image generation on the CPU, not by the model.
 images the difference is uint8 rounding, i.e. nothing measurable — but the three
 are not a controlled comparison of that change.</sub>
 
+## Depth (contract §22) — opt-in, off by default
+
+Max asked for depth in the policy, so it is built — but **config-gated and off by
+default** (§22.6), so the existing arm is untouched and depth can be measured as
+an A/B rather than assumed to help. `config/experiment/yaak/nero_arms/causal.yaml`
+and `config/model/yaak/nero_patch_policy/raw.yaml` are **not modified**; the arm
+is an additive experiment, `causal_depth.yaml`, that inherits `causal.yaml`.
+
+| file | what |
+| --- | --- |
+| `config/experiment/yaak/nero_arms/causal_depth.yaml` | the whole depth arm |
+| `rmind.data.nero.DisparityStandardizer` | train-split disparity standardisation, versioned artifact |
+| `NeroPatchPolicy._patchify_depth` / `._depth_tokens` | the §22.7 embedding and the absence handling |
+| `rmind.datamodules.nero_random` | `depth=True` emits the stream at real contract shapes |
+| `rmind.scripts.nero_smoke --depth`, `--stage depth` | budget/fit/policy smoke |
+
+### Depth is a fourth CAMERA, not a fourth channel (§22.1/§22.2)
+
+The disparity stream declares `reference_frame: rectified_CAM_B`,
+`aligned_to: none`: it lives in the rectified **left mono** camera's frame — a
+different sensor at a different position with a much wider lens (96.0° HFOV
+against `CAM_A`'s 73.7°). `setDepthAlign` is deliberately not applied upstream
+because warping invalidates the `fx_mono · baseline / disparity` conversion. So
+stacking it as a 4th channel on the overhead RGB would silently misregister every
+pixel — the failure would look like a mildly unhelpful input, not like an error.
+
+It therefore gets its own patch tokens and its own 13-dim `camera_cond` built
+from the mono intrinsics at the recorded depth resolution, reusing the machinery
+that already handles three heterogeneous cameras.
+
+### The encoder is a TRAINABLE patch embedding, not the frozen ViT (§22.7)
+
+⚠️ **This was the one real design error, and it is worth recording.** The first
+implementation routed disparity through the same frozen DINOv2 that serves the
+RGB cameras — replicated to 3 channels, at 140×224, with the resulting patch
+features average-pooled to a coarser grid. Wrong on three counts:
+
+1. **Domain.** DINOv2 is trained on natural RGB — photometric statistics,
+   texture, colour, semantics. Disparity is a smooth, single-channel, purely
+   *geometric* signal; as a grey image it has none of those statistics.
+2. **Frozen.** Even if the features partly transferred, nothing downstream can
+   adapt them. The mismatch is uncorrectable anywhere in the pipeline.
+3. **The cost ran backwards.** A fourth ViT pass is +33% frozen-encoder compute
+   per frame to buy only ~+8% sequence — the *larger* cost for the *less
+   appropriate* representation.
+
+The replacement is what a ViT does at its own input, and the standard treatment
+for a non-RGB modality: patchify and project with a `Linear`.
+
+| | frozen-ViT pass (rejected) | trainable patch embedding (shipped) |
+| --- | --- | --- |
+| parameters | ~22M **frozen** | **269k trainable** (`Linear(525 → 512)`) |
+| FLOPs | a 4th full ViT forward | one matmul per patch |
+| domain fit | RGB pretraining, no adaptation | learned on disparity directly |
+
+**Two input channels: standardised disparity and the validity mask.** The mask
+being a first-class input is the point — "no measurement" becomes its own state
+instead of something the network must infer from a fill value.
+
+The coarse grid §22.2 asks for now falls straight out of the patch size, with no
+pooling: 400×640 letterboxes isotropically to 80×128, which at patch 16 is a
+**5×8 = 40-token** grid. §22.2's literal "half the patches" is a config change.
+
+### Normalised disparity, and invalid means invalid (§22.3/§22.4)
+
+Disparity, not metric depth: it is bounded (0–95) and uniformly quantised,
+whereas metric depth is unbounded with precision collapsing at range, so a single
+far pixel dominates any normalisation. It is also the raw measurement, so no
+calibration error enters the model input at all.
+
+`DisparityStandardizer` fits on the **training split only** and over **valid
+pixels only**, and the second rule is not cosmetic — measured on the synthetic
+stream at only 3.9% invalid:
+
+| | mean | std |
+| --- | --- | --- |
+| valid pixels only (correct) | **48.15** | **18.93** |
+| all pixels (the easy mistake) | 46.30 | 20.75 |
+
+The gap scales with the invalid fraction, which on real stereo is far above 3.9%
+and is concentrated exactly where the object is.
+
+`disparity == 0` is *no measurement*, not zero distance. Invalid pixels are
+filled with the train mean (landing on 0 after standardisation — a neutral
+non-measurement) **and** flagged by the mask channel. The fill and the
+standardisation happen at native resolution, **before** any resampling: the other
+order lets invalid zeros bleed into valid neighbours during interpolation, which
+fabricates a small, plausible-looking depth gradient at precisely the object
+boundaries where stereo drops out.
+
+### Absence is the normal case (§22.5)
+
+None of the 104 existing episodes have depth and the recorder's `--depth` is off
+by default. **Three** distinct absences, all handled:
+
+* the `disparity.*` key is **missing from the batch entirely** — no embedding
+  call at all (this is today's real data);
+* the key is present but a sample has `depth_valid=False` — a **mixed batch**;
+* `depth_dropout` (0.25) forcing the second case during training, so the policy
+  never becomes depth-*dependent* for basic motion.
+
+In every case the token becomes a **learned `no_depth`, never zeros**, so "this
+episode has no depth stream" is distinguishable from "a depth map that happens to
+encode near zero". `no_depth` is verified to receive gradient through a real
+backward pass on a depth-absent batch.
+
+Depth tokens sit **between the state token and the RGB patches**, so the readout
+(the last token of a frame block) is still a `side_right` patch exactly as in the
+depth-off model — rather than becoming a constant `no_depth` token on the
+majority of samples.
+
+### Measured — depth-on vs depth-off
+
+Same box (one RTX 5090), same batch size 8, 60 steps, gradient checkpointing on.
+
+| | depth-off | depth-on | delta |
+| --- | --- | --- | --- |
+| tokens / frame | 481 | **521** | +8.3% |
+| flattened sequence (T=6) | 2886 | **3126** | +8.3% |
+| **peak memory** | **1.743 GiB** | **1.859 GiB** | **+6.7%** |
+| median step | 0.218 s | 0.229 s | +5.1% |
+| trainable params | 40.705M | 40.995M | +0.7% |
+| total params | 62.929M | 63.220M | +0.5% |
+
+The +290,304 parameters are exactly `Linear(525 → 512)` = 269,312, the 512-dim
+`no_depth` token, and the trunk's tiled intra-frame embedding growing by
+40 × 512 = 20,480.
+
+⚠️ **This supersedes the §22.2 estimate of +33% sequence and ~1.8× attention**,
+which assumed a fourth stream at the *same* patch grid (641 tokens/frame). At the
+coarse 40-token grid the real cost is +8.3% sequence and a **measured** +6.7%
+peak memory.
+
+⚠️ **The loss curves from these runs are NOT a learning claim.** They were run
+without a trained tokenizer checkpoint, so the inline RVQ is uninitialised and
+collapses every chunk onto code 0 — all four code losses are exactly 0.000 and
+the offset head is fitting a near-constant target. What these runs measure is
+memory, throughput and stability; both arms train without divergence and their
+curves are indistinguishable, which is the expected result when the synthetic
+depth is noise. A real comparison needs the tokenizer stage and real depth data,
+neither of which exists yet.
+
+### Proof that depth-off is unchanged
+
+A within-branch test can only show the depth code is not *reached*. The actual
+guarantee is a **cross-commit fingerprint**: seed, compose
+`experiment=yaak/nero_arms/causal`, and dump the resolved model config, a sha256
+of every `state_dict` tensor, a sha256 of the synthetic batch, and the forward
+output. Run on `feat/nero-arms-causal-patch-policy`, then on this branch:
+
+```
+params      62929320
+tokens      [2, 6, 481, 512]  4744876913c19e82
+features    3cb1fa34ccb1b4d7
+prediction  4cc9853c1a7d5f81
+```
+
+**Byte-identical**, including the resolved config — because `raw.yaml` and
+`causal.yaml` are untouched and every depth module is constructed only under
+`use_depth`, *last*, so the init RNG stream for every pre-existing module is
+unchanged whether depth is on or off. (That ordering also makes the A/B a
+controlled comparison: both arms share identical weights everywhere else.)
+
+### A bug this found
+
+Depth dropout was written as `present &= ...`. `present` comes from
+`batch["depth_valid"].to(dtype=torch.bool, device=cpu)`, and `.to()` with a
+matching dtype and device returns **the same tensor, not a copy** — so the
+in-place op permanently zeroed the loader's own flag for that batch. With a
+cached or reused TensorDict the corruption outlives the step and is invisible:
+the batch simply claims it never had depth. Regression test:
+`test_depth_dropout_does_not_mutate_the_batch`.
+
+⚠️ It was introduced by a `ruff` autofix (PLR6104, non-augmented-assignment)
+rewriting a deliberate out-of-place `&`. Worth knowing that rule can be unsafe
+where the left-hand side may alias caller-owned data.
+
 ## Contract issues
 
 1. **§8's `(T, 2, 60)` contradicts §5.2's quaternion storage.** rbyte implemented
@@ -355,6 +532,52 @@ are not a controlled comparison of that change.</sub>
    `action.future_state` — ~199 MB of a ~470 MB TensorDict, scaling linearly. The
    policy reads exactly one path (config-selected), so nothing downstream pays
    for it; the duplication is worth removing loader-side before the dataset grows.
+
+7. **§22.2 says depth gets "its own 13-dim `camera_cond`" but never says
+   WHERE it lives** — and §8 pins `camera_cond` at `(3, 13)`. Adding a fourth row
+   would change the shape of an existing key for every consumer and force a
+   padded row whenever depth is absent, which is most of the time. This side
+   therefore emits a **separate key**, and the names below need pinning exactly
+   as §21.10 pinned `disparity.{camera}` — the recorder and the consumer already
+   diverged once on precisely this kind of unnamed record:
+
+   | key | shape | meaning |
+   | --- | --- | --- |
+   | `disparity.{camera}` | `(T, 1, 400, 640)` uint8 | the stream (§21.11 resolution) |
+   | `disparity_valid.{camera}` | `(T, 1, 400, 640)` bool | **per-pixel** validity (§21.4) |
+   | `disparity_cond` | `(n_depth_cameras, 13)` float32 | mono intrinsics + extrinsics |
+   | `depth_valid` | `(,)` bool | **per-sample** "this episode has depth" (§22.5) |
+
+   ⚠️ `disparity_valid.*` and `depth_valid` are one word apart and mean entirely
+   different things. Renaming one of them before real data exists would be cheap;
+   afterwards it will not be. All four are config-settable model-side, so pinning
+   them later is a config change rather than a code change.
+8. **§22.2's sequence-cost estimate is superseded.** It projected +33% sequence
+   and ~1.8× attention, assuming a fourth stream at the *same* patch grid. At the
+   coarse 40-token grid this arm measures **+8.3% sequence and +6.7% peak
+   memory**. §22.2 should carry the measured figure.
+9. **§22.2 and §22.7 are in tension as written.** §22.2 says depth "reuses the
+   machinery that already handles three heterogeneous cameras", which read
+   literally is exactly what produced the frozen-ViT error that §22.7 then
+   corrects. §22.2 should say it reuses the *token-and-conditioning* machinery
+   but **not** the encoder.
+10. **§21.9's "the depth stream is never resized" is stated absolutely but is
+    really a constraint on the metric conversion.** Resizing scales `fx` but not
+    the stored disparity values, so `fx · baseline / disparity` breaks — which
+    binds *rbyte*, where the conversion lives. The policy consumes standardised
+    disparity and never converts, so letterboxing to the model grid is legal.
+    §21.9 should say "never resized **before** the conversion", or a future
+    reader will conclude the policy cannot resize it and will pay 400×640 tokens.
+11. **Pre-existing, not depth-specific: `letterbox_camera_cond` is never called
+    in the live path.** It is implemented and unit-tested in
+    `rmind.data.nero`, and the Files table above implies it is applied, but
+    `_frame_tokens` consumes `camera_cond` raw — so the RGB `base` camera's
+    intrinsics are not rewritten for its letterbox padding. Harmless today only
+    because §7's `placeholder: true` makes `camera_cond` a constant. **It must be
+    wired in before the real calibration drops**, and doing so will change the
+    depth-off model, so it wants its own commit and its own A/B. Depth's own
+    letterbox is a pure isotropic resize with no padding, so the rewrite is a
+    no-op for `disparity_cond`.
 
 ## Open items for the user
 

--- a/src/rmind/data/nero.py
+++ b/src/rmind/data/nero.py
@@ -45,6 +45,8 @@ from torch import Tensor, nn
 
 __all__ = [
     "BIMANUAL_DIM",
+    "DISPARITY_INVALID",
+    "DISPARITY_MAX_DEFAULT",
     "NUM_SIDES",
     "POSE_9D_DIM",
     "POSE_BLOCK_LAYOUT",
@@ -53,6 +55,7 @@ __all__ = [
     "SIDE_DIM",
     "STATE_QUAT_DIM",
     "TRANSLATION_INDICES",
+    "DisparityStandardizer",
     "PoseStandardizer",
     "canonicalize_quat",
     "geodesic_angle_error",
@@ -480,6 +483,174 @@ class PoseStandardizer(nn.Module):
             std=payload["std"],
             dim=payload["dim"],
             eps=payload["eps"],
+            source=payload["source"],
+        )
+
+
+# --------------------------------------------------------------- disparity
+
+#: contract §21.1: default-mode max disparity, exactly representable in 8 bits.
+#: ⚠️ `extended_disparity` raises this to ~191 and the episode metadata DECLARES
+#: it (§21.10) -- never infer it from the pixels.
+DISPARITY_MAX_DEFAULT: Final[int] = 95
+#: contract §21.4 / §22.4: 0 means **no measurement**, NOT zero distance.
+DISPARITY_INVALID: Final[int] = 0
+
+
+@final
+class DisparityStandardizer(nn.Module):
+    """Train-split standardisation of the disparity stream (contract §22.3, §5.4).
+
+    Why disparity and not metric depth
+    ----------------------------------
+    rbyte emits both. §22.3 picks disparity as the network input because it is
+    **bounded** (0..`max_disparity`, 95 by default) and uniformly quantised,
+    whereas `fx_mono * baseline / disparity` is unbounded with precision
+    collapsing at range -- a single far pixel produces a huge value that
+    dominates any normalisation. It is also the raw measurement, so no
+    calibration error enters the model input at all.
+
+    Why the invalid fill is the MEAN and not zero (§22.4)
+    ----------------------------------------------------
+    `disparity == 0` means *no measurement*. Zero-filling it asserts "surface at
+    zero distance" with full confidence, and stereo drops out precisely at the
+    depth discontinuities around a grasped object -- i.e. exactly where the
+    signal matters. So invalid pixels are replaced by the train-split **mean**,
+    which lands at 0 after standardisation and is the neutral "no information"
+    value; the *fact* that they were invalid is carried separately, as an
+    explicit per-patch validity fraction on the depth token
+    (`NeroPatchPolicy._depth_tokens`). Neutral value + explicit flag, never a
+    fabricated measurement.
+
+    ⚠️ Statistics are fitted over the **training split only** and over **valid
+    pixels only** -- fitting over all pixels would drag the mean towards zero by
+    the invalid fraction, which varies per scene.
+
+    The buffers are registered (not parameters), so they travel inside the
+    checkpoint; the JSON artifact is the human-auditable copy and the provenance
+    record. A serving path that silently fell back to identity standardisation
+    is the failure mode this is designed against.
+    """
+
+    VERSION: Final[int] = 1
+
+    mean: Tensor
+    std: Tensor
+
+    def __init__(
+        self,
+        *,
+        mean: Tensor | Sequence[float] | float | None = None,
+        std: Tensor | Sequence[float] | float | None = None,
+        eps: float = 1e-6,
+        max_disparity: int = DISPARITY_MAX_DEFAULT,
+        source: str = "identity",
+    ) -> None:
+        super().__init__()
+        self.eps = eps
+        self.max_disparity = max_disparity
+        self.source = source
+        self.register_buffer(
+            "mean",
+            torch.zeros(1)
+            if mean is None
+            else torch.as_tensor(mean, dtype=torch.float32).reshape(1),
+        )
+        self.register_buffer(
+            "std",
+            torch.ones(1)
+            if std is None
+            else torch.as_tensor(std, dtype=torch.float32).reshape(1),
+        )
+
+    @classmethod
+    def from_samples(
+        cls,
+        disparity: Tensor,
+        valid: Tensor,
+        *,
+        source: str = "train-split",
+        **kwargs: object,
+    ) -> Self:
+        """Fit mean/std over the VALID pixels of a training-split sample.
+
+        Args:
+            disparity: any shape, raw disparity levels.
+            valid: broadcastable to `disparity`, True where a measurement exists.
+            source: provenance string written into the artifact.
+            **kwargs: forwarded to `__init__`.
+
+        Raises:
+            ValueError: if the sample contains no valid pixel at all -- fitting
+                on nothing would silently produce an identity standardiser.
+        """
+        selected = disparity.float()[valid.expand_as(disparity).bool()]
+        if selected.numel() == 0:
+            msg = "no valid disparity pixels to fit the standardiser on"
+            raise ValueError(msg)
+        return cls(
+            mean=selected.mean(),
+            std=selected.std().clamp_min(1e-6),
+            source=source,
+            **kwargs,  # ty:ignore[invalid-argument-type]
+        )
+
+    def standardize(self, x: Tensor) -> Tensor:
+        return (x - self.mean) / (self.std + self.eps)
+
+    def unstandardize(self, x: Tensor) -> Tensor:
+        return x * (self.std + self.eps) + self.mean
+
+    @override
+    def forward(self, disparity: Tensor, valid: Tensor) -> Tensor:
+        """`(..., 1, H, W)` raw disparity + validity mask -> standardised float.
+
+        Invalid pixels become the train-split mean *before* standardisation, so
+        they land exactly on 0 -- see the class docstring.
+        """
+        x = disparity.to(self.mean.dtype)
+        x = torch.where(valid.to(torch.bool).expand_as(x), x, self.mean.to(x.dtype))
+        return self.standardize(x)
+
+    # -------------------------------------------------------------- artifact
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "version": self.VERSION,
+            "eps": self.eps,
+            "max_disparity": self.max_disparity,
+            "source": self.source,
+            "invalid_value": DISPARITY_INVALID,
+            "mean": self.mean.tolist(),
+            "std": self.std.tolist(),
+        }
+
+    def save(self, path: str | Path) -> Path:
+        path = Path(path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _ = path.write_text(json.dumps(self.to_dict(), indent=2))
+        return path
+
+    @classmethod
+    def load(cls, path: str | Path) -> Self:
+        """Load a versioned artifact.
+
+        Raises:
+            ValueError: on a version mismatch -- an old artifact with different
+                semantics must fail loudly, not standardise wrongly.
+        """
+        payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        version = payload["version"]
+        if version != cls.VERSION:
+            msg = (
+                f"disparity standardisation artifact version {version} != {cls.VERSION}"
+            )
+            raise ValueError(msg)
+        return cls(
+            mean=payload["mean"],
+            std=payload["std"],
+            eps=payload["eps"],
+            max_disparity=payload["max_disparity"],
             source=payload["source"],
         )
 

--- a/src/rmind/datamodules/nero_random.py
+++ b/src/rmind/datamodules/nero_random.py
@@ -38,6 +38,8 @@ from rmind.data.nero import (
 __all__ = [
     "CAMERA_NAMES",
     "CAMERA_RESOLUTIONS",
+    "DEPTH_CAMERA_NAMES",
+    "DEPTH_GRIDS",
     "NeroRandomDataset",
     "nero_random_batch",
 ]
@@ -59,6 +61,21 @@ CAMERA_GRIDS: dict[str, tuple[int, int]] = {
     "side_left": (300, 480),
     "side_right": (300, 480),
 }
+
+#: contract §21.3: the depth stream exists on the OVERHEAD `base` device only --
+#: it looks down at the workspace so disparity maps to table position, while the
+#: SR side cameras sit near-tangent and localise on-plane objects poorly.
+DEPTH_CAMERA_NAMES: tuple[str, ...] = ("base",)
+#: ⚠️ contract §21.11: the recorder runs `StereoDepth` at **640x400** and §21.9
+#: forbids resizing the stream (a resize scales `fx` but not the stored disparity
+#: values, so `fx * baseline / disparity` would be wrong by the resize factor).
+#: So the depth tensor is LARGER than the RGB tensors, which are downscaled per
+#: §8 -- surprising on first read, and deliberate. Model-side letterboxing to the
+#: ViT grid is still fine, because the policy consumes standardised DISPARITY and
+#: never performs the metric conversion (§22.3).
+DEPTH_GRIDS: dict[str, tuple[int, int]] = {"base": (400, 640)}
+#: contract §21.1 default mode; §21.10 DECLARES it per episode, never infers it.
+DEPTH_MAX_DISPARITY = 95
 
 #: contract §4: start-pose spread std ~[0.037, 0.021, 0.009] m, within-episode
 #: motion range ~[0.32, 0.19, 0.06] m -- i.e. episodes START in a narrow region
@@ -169,6 +186,49 @@ def _side_trajectory(steps: int, generator: torch.Generator) -> Tensor:
     return torch.cat(columns, dim=-1)
 
 
+#: Fraction of synthetic pixels left without a measurement. Generated as
+#: connected blobs, not i.i.d. pixels -- stereo drops out in regions at depth
+#: discontinuities, which is exactly where a grasped object is (§22.4).
+DEPTH_INVALID_FRACTION = 0.15
+
+
+def _disparity_field(
+    shape: tuple[int, ...], height: int, width: int
+) -> tuple[Tensor, Tensor]:
+    """`(*shape, 1, H, W)` synthetic uint8 disparity plus its validity mask.
+
+    Unlike the RGB streams (pure noise -- there is no synthetic-vision claim
+    anywhere in this module) this one is a **smooth low-frequency field**, for a
+    specific reason: `DisparityStandardizer` is fitted on it, and the mean/std of
+    uniform noise over 0..95 are a fixed constant that would make the fitted
+    statistics vacuous. A smooth field at least varies per sample the way a real
+    depth map does.
+
+    Invalid regions are generated as **blobs**, not i.i.d. pixels, because that
+    is how stereo actually fails -- it drops out in connected regions at depth
+    discontinuities (§22.4). Per contract §21.4 the emitted disparity is exactly
+    `0` wherever the mask is False, so the two are self-consistent; the policy
+    still consumes the explicit mask rather than recomputing it, because a real
+    loader may mark additional pixels invalid (confidence threshold, LR check)
+    that are not zero.
+    """
+    low = (8, 12)
+
+    def _smooth(scale: float, offset: float) -> Tensor:
+        coarse = torch.rand(*shape, 1, *low) * scale + offset
+        return torch.nn.functional.interpolate(
+            coarse.reshape(-1, 1, *low),
+            size=(height, width),
+            mode="bilinear",
+            align_corners=False,
+        ).reshape(*shape, 1, height, width)
+
+    disparity = _smooth(1.0, 0.0).mul(DEPTH_MAX_DISPARITY - 1).add(1).round()
+    valid = _smooth(1.0, 0.0) > DEPTH_INVALID_FRACTION
+    disparity = torch.where(valid, disparity, torch.zeros_like(disparity))
+    return disparity.to(torch.uint8), valid
+
+
 def nero_random_batch(  # noqa: PLR0913
     *,
     batch_size: int = 2,
@@ -176,6 +236,9 @@ def nero_random_batch(  # noqa: PLR0913
     action_horizon: int = 6,
     grids: dict[str, tuple[int, int]] | None = None,
     both_sides: bool = True,
+    depth: bool = False,
+    depth_grids: dict[str, tuple[int, int]] | None = None,
+    depth_present: float = 1.0,
     seed: int = 0,
     device: torch.device | str = "cpu",
 ) -> dict[str, Any]:
@@ -192,6 +255,19 @@ def nero_random_batch(  # noqa: PLR0913
     `both_sides=False` reproduces the dummy recording: `side_valid = [False, True]`
     (left absent) with the invalid side's state and action zeroed, which is what
     the contract §6.1 mandates and what the policy's mask path must handle.
+
+    ⚠️ **`depth=False` is the default and it is the REALISTIC case** (contract
+    §22.5): none of the 104 existing episodes carry depth and the recorder's
+    `--depth` is off by default, so a depth-enabled model trains on a mixture
+    where the stream is frequently missing. `depth=False` emits **no**
+    `disparity.*` key at all -- the "key absent from the batch" case, which is
+    different from, and more common than, `depth_present < 1` (the key exists but
+    some samples in the batch have no measurement). The policy must survive both.
+
+    The depth keys are drawn **strictly last**, after every other tensor, so that
+    enabling depth cannot shift the global RNG stream for the images, poses or
+    `camera_cond`. Without that, a depth-on/depth-off comparison would be
+    confounded by a different synthetic dataset rather than by the model.
     """
     generator = torch.Generator().manual_seed(seed)
     steps = episode_length + action_horizon
@@ -251,6 +327,29 @@ def nero_random_batch(  # noqa: PLR0913
         "goal.xyz": torch.randn(batch_size, NUM_SIDES, 3) * _START_XYZ,
         "align_residual_ms": torch.rand(batch_size, episode_length) * 3.0,
     }
+
+    # ⚠️ EVERYTHING BELOW IS DRAWN LAST, ON PURPOSE. See the docstring: keeping
+    # the depth draws after every other tensor is what makes `depth=False`
+    # byte-identical to the pre-depth datamodule.
+    if depth:
+        for name in DEPTH_CAMERA_NAMES:
+            h, w = (depth_grids or DEPTH_GRIDS)[name]
+            disparity, valid = _disparity_field((batch_size, episode_length), h, w)
+            batch[f"disparity.{name}"] = disparity
+            batch[f"disparity_valid.{name}"] = valid
+        # §22.2: depth's own 13-dim conditioning vector, built from the MONO
+        # intrinsics at the recorded depth resolution (§21.11) and the mono
+        # camera's own extrinsics -- a genuinely different camera from `base`'s
+        # RGB `CAM_A` (96.0 deg HFOV against 73.7 deg), which is exactly why it
+        # cannot be a 4th channel on the RGB image (§22.1).
+        batch["disparity_cond"] = torch.randn(
+            batch_size, len(DEPTH_CAMERA_NAMES), CAMERA_COND_DIM
+        )
+        # §22.5: per-sample availability. Distinct from the per-PIXEL
+        # `disparity_valid.*` mask above -- this one says "this episode has a
+        # depth stream at all", that one says "this pixel got a measurement".
+        batch["depth_valid"] = torch.rand(batch_size) < depth_present
+
     return {k: v.to(device) for k, v in batch.items()}
 
 

--- a/src/rmind/models/nero_patch_policy.py
+++ b/src/rmind/models/nero_patch_policy.py
@@ -76,6 +76,67 @@ to the feature. This halves the head parameter count versus two independent
 heads and -- more importantly -- lets right-only dummy data train a head that is
 immediately meaningful for the left hand, matching the weight-shared tokenizer.
 
+Depth (contract §22) -- OPT-IN, off by default
+----------------------------------------------
+`use_depth=False` is the default and nothing below is constructed in that case,
+so the depth-off model is bit-identical to the pre-depth one (same parameters,
+same init RNG stream, same forward). The four decisions, all from §22:
+
+**Depth is a FOURTH CAMERA, not a 4th channel on the RGB image (§22.1/§22.2).**
+The disparity stream's metadata declares `reference_frame: rectified_CAM_B`,
+`aligned_to: none` -- it lives in the rectified LEFT MONO camera's frame, a
+different sensor at a different position with a much wider lens (96.0 deg HFOV
+against `CAM_A`'s 73.7 deg). `setDepthAlign` is deliberately not applied upstream
+because warping invalidates the `fx_mono * baseline / disparity` conversion. So
+stacking it as an extra channel on the overhead RGB would silently misregister
+every pixel. Instead it gets its own patch tokens and its own 13-dim
+`camera_cond` built from the MONO intrinsics at the recorded depth resolution
+(§21.11), which is the same machinery that already handles three heterogeneous
+cameras.
+
+**A TRAINABLE patch embedding, not the frozen DINOv2 encoder (§22.7).** The
+first implementation here routed disparity through the RGB ViT; that was wrong.
+DINOv2 is trained on natural RGB -- photometric statistics, texture, colour,
+semantics -- while disparity is a smooth, single-channel, purely *geometric*
+signal, so replicated to 3 channels it is a grey image with none of the
+statistics the encoder expects. The encoder is also **frozen**, so nothing
+downstream can adapt the mismatch away. And the cost ran backwards: a fourth ViT
+pass is +33% frozen compute per frame to buy only ~+8% sequence, i.e. paying the
+larger cost for the less appropriate representation. Instead the disparity is
+patchified and projected by a `Linear` -- what a ViT does at its own input, and
+the standard treatment for a non-RGB modality: ~262k **trainable** parameters
+against ~22M frozen ones, and cheaper in FLOPs than the pass it replaces.
+
+The coarse depth grid §22.2 asks for then falls out of the patch size directly,
+with no pooling: an 80x128 letterboxed input at patch 16 is a 5x8 = 40-token
+grid. `(5, 16)` -- §22.2's literal "half the patches" -- is a config change.
+
+**Normalised DISPARITY, not metric depth (§22.3), with the validity mask as a
+SECOND INPUT CHANNEL (§22.4).** `disparity == 0` means *no measurement*, not zero
+distance, and stereo drops out precisely at the depth discontinuities around a
+grasped object -- i.e. exactly where the signal matters. Making the mask a
+first-class input channel is what lets "unmeasured" be its own state instead of
+something the network has to infer from a fill value; the disparity channel is
+additionally filled with the train-split mean where invalid, so the two channels
+agree on a neutral value plus an explicit flag rather than asserting a surface at
+zero distance. See `rmind.data.nero.DisparityStandardizer`.
+
+**Depth is ABSENT from most data and that is the normal case (§22.5).** None of
+the 104 existing episodes have depth and the recorder's `--depth` is off by
+default, so a depth-enabled model trains on a mixture. THREE cases, all handled:
+the key is missing from the batch entirely (no encoder call at all), the key is
+present but a given sample has `depth_valid=False`, and `depth_dropout` forcing
+the second case during training so the policy never becomes depth-DEPENDENT and
+degrades gracefully when the stream is missing at serving time. In every case the
+depth tokens carry a **learned `no_depth` embedding, never zeros**, plus an
+explicit availability flag -- the same pattern as the `no_goal` goal-dropout
+embedding and `side_valid`.
+
+Depth tokens are placed BETWEEN the state token and the RGB patches, so the
+readout (the last token of a frame block) is still a `side_right` patch exactly
+as in the depth-off model, rather than becoming a constant `no_depth` token on
+the majority of samples.
+
 Configuration seam (contract §11)
 ---------------------------------
 `action_features` (per-side action dimensionality) and `action_horizon` come from
@@ -107,6 +168,7 @@ from rmind.components import optimizers
 from rmind.components.containers import ModuleDict
 from rmind.config import HydraConfig, init_hydra_param
 from rmind.data.nero import (
+    CAMERA_COND_DIM,
     NUM_SIDES,
     STATE_QUAT_DIM,
     pose_error_metrics,
@@ -126,7 +188,7 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
     """Causal patch policy over 3 cameras + bimanual SE(3) state. See module docstring."""
 
     @validate_call
-    def __init__(  # noqa: PLR0913
+    def __init__(  # ruff: ignore[too-many-arguments, too-many-statements]
         self,
         *,
         image_transform: HydraConfig[Module] | InstanceOf[Module],
@@ -150,6 +212,27 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
         goal_valid: Path = ("goal_valid",),
         chunk: Path = ("action.future_state",),
         use_goal_image: bool = True,
+        # --- contract §22 depth, OFF BY DEFAULT (§22.6). Nothing below is
+        # constructed unless `use_depth`, so the depth-off model is bit-identical
+        # to the pre-depth one.
+        use_depth: bool = False,
+        depth_transform: HydraConfig[Module] | InstanceOf[Module] | None = None,
+        depth_standardizer: HydraConfig[Module] | InstanceOf[Module] | None = None,
+        depth_patch_embedding: HydraConfig[Module] | InstanceOf[Module] | None = None,
+        #: §21.3: the overhead `base` device only -- the SR side cameras sit
+        #: near-tangent and localise on-plane objects poorly.
+        depth_cameras: Sequence[str] = ("base",),
+        depth_key: str = "disparity.{camera}",
+        #: PER-PIXEL validity (§21.4/§22.4), not to be confused with...
+        depth_mask_key: str = "disparity_valid.{camera}",
+        #: ...this, the PER-SAMPLE "does this episode have depth at all" flag (§22.5)
+        depth_valid: Path = ("depth_valid",),
+        depth_camera_cond: Path = ("disparity_cond",),
+        #: side of the square depth patch, e.g. 16 (§22.7)
+        depth_patch_size: int | None = None,
+        #: the depth token grid, e.g. (5, 8) for an 80x128 input at patch 16
+        depth_patch_grid: tuple[int, int] | None = None,
+        depth_dropout: float = 0.25,
         # rbyte emits the contract §5.2 STORAGE form (46 per side: 6 poses x 7 +
         # a 4-dim hub quaternion). The 9D expansion happens here, at the model
         # boundary -- set False if a loader ever hands over 60 directly.
@@ -181,12 +264,12 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
         # frozen feature extractor: never trains, never leaves eval mode (see train())
         self.image_encoder = (
             init_hydra_param(hparams, "image_encoder", image_encoder)
-            .requires_grad_(False)  # noqa: FBT003
+            .requires_grad_(False)  # ruff: ignore[boolean-positional-value-in-call]
             .eval()
         )
         self.tokenizer = (
             init_hydra_param(hparams, "tokenizer", tokenizer)
-            .requires_grad_(False)  # noqa: FBT003
+            .requires_grad_(False)  # ruff: ignore[boolean-positional-value-in-call]
             .eval()
         )
 
@@ -208,6 +291,59 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
         # per-side identity for the weight-shared head
         self.side_embedding = nn.Embedding(NUM_SIDES, policy_embedding_dim)
         nn.init.trunc_normal_(self.side_embedding.weight, std=0.02)
+
+        # --- contract §22 depth. ⚠️ CONSTRUCTED LAST, AND ONLY IF `use_depth`.
+        # Last, so that every module above draws the SAME init RNG whether depth
+        # is on or off -- which is what makes the §22.6 A/B a controlled
+        # comparison instead of two differently-initialised models. Only if
+        # `use_depth`, so the depth-off model has no extra parameters at all.
+        self.use_depth = use_depth
+        self.depth_transform: Module | None = None
+        self.depth_standardizer: Module | None = None
+        self.depth_patch_embedding: Module | None = None
+        self.depth_patch_size: int | None = None
+        self.depth_patch_grid: tuple[int, int] | None = None
+        if use_depth:
+            missing = [
+                name
+                for name, value in (
+                    ("depth_transform", depth_transform),
+                    ("depth_standardizer", depth_standardizer),
+                    ("depth_patch_embedding", depth_patch_embedding),
+                    ("depth_patch_size", depth_patch_size),
+                    ("depth_patch_grid", depth_patch_grid),
+                )
+                if value is None
+            ]
+            if missing:
+                msg = f"use_depth=True requires {missing}"
+                raise ValueError(msg)
+            self.depth_transform = init_hydra_param(
+                hparams, "depth_transform", depth_transform
+            )
+            # not a Parameter: train-split statistics, registered buffers, so it
+            # travels inside the checkpoint (see DisparityStandardizer)
+            self.depth_standardizer = init_hydra_param(
+                hparams, "depth_standardizer", depth_standardizer
+            ).requires_grad_(False)  # ruff: ignore[boolean-positional-value-in-call]
+            self.depth_patch_embedding = init_hydra_param(
+                hparams, "depth_patch_embedding", depth_patch_embedding
+            )
+            self.depth_patch_size = int(depth_patch_size)  # ty:ignore[invalid-argument-type]
+            self.depth_patch_grid = tuple(depth_patch_grid)  # ty:ignore[invalid-argument-type]
+            # §22.5: learned "no depth supplied", NEVER zeros -- so "this episode
+            # has no depth stream" is distinguishable from "a depth map that
+            # happens to encode near zero". It is a learned TOKEN (d_model), the
+            # same role a mask token plays in MAE/BERT.
+            self.no_depth = nn.Parameter(torch.zeros(policy_embedding_dim))
+            nn.init.trunc_normal_(self.no_depth, std=0.02)
+
+        self.depth_cameras = tuple(depth_cameras)
+        self.depth_key = depth_key
+        self.depth_mask_key = depth_mask_key
+        self.depth_valid: Path = depth_valid
+        self.depth_camera_cond: Path = depth_camera_cond
+        self.depth_dropout = depth_dropout
 
         self.cameras = tuple(cameras)
         self.image_key = image_key
@@ -235,6 +371,15 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
             "goal_valid": goal_valid,
             "chunk": chunk,
             "use_goal_image": use_goal_image,
+            "use_depth": use_depth,
+            "depth_cameras": self.depth_cameras,
+            "depth_key": depth_key,
+            "depth_mask_key": depth_mask_key,
+            "depth_valid": depth_valid,
+            "depth_camera_cond": depth_camera_cond,
+            "depth_patch_size": self.depth_patch_size,
+            "depth_patch_grid": self.depth_patch_grid,
+            "depth_dropout": depth_dropout,
             "convert_state_to_9d": convert_state_to_9d,
             "goal_dropout": goal_dropout,
             "sample_codes": sample_codes,
@@ -359,6 +504,173 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
             present[:, :, None, None], features, self.no_goal.to(features.dtype)
         )
 
+    # ------------------------------------------------------------------ depth
+
+    def _patchify_depth(self, disparity: Tensor, mask: Tensor) -> Tensor:
+        """`(b, T, 1, H, W)` disparity + mask -> `(b, T, P, patch * patch * 2)`.
+
+        Contract §22.7: depth gets a **trainable patch embedding, NOT the frozen
+        DINOv2 encoder**. Routing disparity through the RGB ViT was the first
+        implementation here and it was wrong on all three counts: DINOv2 is
+        trained on natural RGB (photometric statistics, texture, colour,
+        semantics) while disparity is a smooth single-channel *geometric* signal,
+        so replicated to 3 channels it is a grey image with none of the
+        statistics the encoder expects; the encoder is **frozen**, so nothing
+        downstream can adapt away the mismatch; and the cost runs the wrong way,
+        a fourth ViT pass being +33% frozen compute per frame to buy only ~+8%
+        sequence. A `Linear` over flattened patches is what a ViT does at its own
+        input anyway, is ~262k TRAINABLE parameters against ~22M frozen ones, and
+        is cheaper in FLOPs than the pass it replaces.
+
+        **Two input channels: standardised disparity and the validity mask**
+        (§22.4). The mask being a first-class input is the point -- it is what
+        lets the model treat "no measurement" as its own state rather than having
+        to infer it from a fill value. The disparity channel is still filled with
+        the train-split mean where invalid (`DisparityStandardizer`), so the two
+        channels agree: a neutral value plus an explicit "this is not a
+        measurement" bit, never a fabricated surface at zero distance.
+
+        Order is load-bearing: the fill and the standardisation happen at native
+        resolution, **before** any resampling. The other way round would let the
+        invalid zeros bleed into their valid neighbours during interpolation -- a
+        small, plausible-looking, entirely fabricated depth gradient exactly at
+        the object boundaries where stereo drops out.
+
+        `depth_transform` (a `LetterboxResize`) is applied to BOTH channels and
+        its zero padding is correct for both by construction: 0 is the train mean
+        in standardised space, and 0 in the mask is "invalid".
+
+        Raises:
+            ValueError: if the transformed size is not an exact multiple of
+                `depth_patch_size`, or disagrees with `depth_patch_grid`. A
+                mismatched reshape would scramble the spatial layout silently.
+        """
+        assert self.depth_standardizer is not None  # noqa: S101
+        assert self.depth_transform is not None  # noqa: S101
+        assert self.depth_patch_size is not None  # noqa: S101
+        standardized = self.depth_standardizer(disparity, mask)
+        small = self.depth_transform(standardized)  # (b, T, 1, h, w)
+        valid = self.depth_transform(mask.to(small.dtype))  # (b, T, 1, h, w)
+        stacked = torch.cat([small, valid], dim=-3)  # (b, T, 2, h, w)
+
+        size = self.depth_patch_size
+        *_, height, width = stacked.shape
+        grid = (height // size, width // size)
+        if (
+            grid[0] * size != height
+            or grid[1] * size != width
+            or grid != self.depth_patch_grid
+        ):
+            msg = (
+                f"depth input {height}x{width} at patch {size} gives grid {grid}, "
+                f"which is not an exact tiling or disagrees with "
+                f"depth_patch_grid {self.depth_patch_grid}"
+            )
+            raise ValueError(msg)
+        return rearrange(
+            stacked, "... c (gh p1) (gw p2) -> ... (gh gw) (c p1 p2)", p1=size, p2=size
+        )
+
+    def _depth_tokens(
+        self, batch: Any, *, batch_size: int, num_frames: int, device: torch.device
+    ) -> Tensor | None:
+        """`(b, T, n_depth_cameras * Pd, d)` depth patch tokens, or None when off.
+
+        Per-token layout into the trainable embedding (§22.7)::
+
+            [ flattened patch: patch * patch * 2 channels | camera_cond (13) ]
+
+        The per-PATCH validity is already inside that first block, as the second
+        channel of every pixel (§22.4) -- so a patch that is entirely unmeasured
+        is representable, and so is one that is half unmeasured, which is the
+        common case at an object boundary.
+
+        The per-SAMPLE `depth_valid` (§22.5) is a different statement -- "this
+        episode has no depth stream at all" -- and it is consumed by SUBSTITUTION
+        rather than as an input dimension: the whole token is replaced by the
+        learned `no_depth`. Feeding it as an extra input dimension as well would
+        be dead weight, since it is 1 for every token that survives the
+        substitution.
+
+        Raises:
+            KeyError: if a disparity stream is present without its validity mask.
+                Falling back to `disparity != 0` would look right and would
+                silently discard the loader's additional invalidations
+                (confidence threshold, left-right check), which are not zero.
+        """
+        if not self.use_depth:
+            return None
+        assert self.depth_patch_grid is not None  # ruff: ignore[assert]
+        assert self.depth_patch_embedding is not None  # ruff: ignore[assert]
+        b, t = batch_size, num_frames
+        num_patches = self.depth_patch_grid[0] * self.depth_patch_grid[1]
+
+        # ⚠️ §22.5: `depth_valid` ABSENT means "no depth", not "assume depth".
+        # None of the 104 existing episodes carry the key at all.
+        present = self._lookup(batch, self.depth_valid)
+        present = (
+            torch.zeros(b, dtype=torch.bool, device=device)
+            if present is None
+            else present.to(device=device, dtype=torch.bool).reshape(b)
+        )
+        # §22.5 depth DROPOUT: applied in training regardless of how much depth
+        # the data actually has, so the policy never becomes depth-dependent for
+        # basic motion and degrades gracefully when the stream is missing at
+        # serving time.
+        if self.training and self.depth_dropout > 0:
+            # ⚠️ NOT `present &= ...`. `present` may ALIAS `batch["depth_valid"]`
+            # -- `.to()` with a matching dtype and device returns the same tensor,
+            # not a copy -- so an in-place op here permanently zeroes the loader's
+            # own flag for that batch. With a cached or reused TensorDict that
+            # corruption outlives the step, and it is invisible: the batch simply
+            # claims it never had depth.
+            present = present & (  # noqa: PLR6104
+                torch.rand(b, device=device) >= self.depth_dropout
+            )
+
+        cond = self._lookup(batch, self.depth_camera_cond)
+        if cond is None:
+            cond = torch.zeros(
+                b, len(self.depth_cameras), CAMERA_COND_DIM, device=device
+            )
+
+        blocks: list[Tensor] = []
+        for index, camera in enumerate(self.depth_cameras):
+            disparity = self._lookup(batch, (self.depth_key.format(camera=camera),))
+            if disparity is None:
+                # the key is missing from the batch entirely -- the NORMAL case
+                # on today's data (§22.5). No embedding call at all.
+                tokens = self.no_depth.expand(b, t, num_patches, -1)
+            else:
+                mask = self._lookup(batch, (self.depth_mask_key.format(camera=camera),))
+                if mask is None:
+                    msg = (
+                        f"{self.depth_key.format(camera=camera)!r} present without "
+                        f"{self.depth_mask_key.format(camera=camera)!r}: contract "
+                        "§21.4/§22.4 requires the explicit validity mask"
+                    )
+                    raise KeyError(msg)
+                patches = self._patchify_depth(disparity, mask)
+                tokens = self.depth_patch_embedding(
+                    torch.cat(
+                        [
+                            patches,
+                            cond[:, index][:, None, None, :].expand(
+                                b, t, num_patches, -1
+                            ),
+                        ],
+                        dim=-1,
+                    )
+                )
+
+            # per-sample substitution, for a MIXED batch (some episodes have
+            # depth, some do not) and for the dropout above
+            available = present[:, None, None, None]
+            tokens = torch.where(available, tokens, self.no_depth.to(tokens.dtype))
+            blocks.append(tokens)
+
+        return torch.cat(blocks, dim=-2)
+
     def _state(self, batch: Any) -> Tensor:
         """`state.pose` in the model-facing 9D form, converting from storage if needed."""
         state = self._get(batch, self.state)
@@ -380,7 +692,7 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
             return state_quat_to_9d(chunk)
         return chunk
 
-    def _frame_tokens(self, batch: Any) -> Tensor:  # noqa: PLR0914
+    def _frame_tokens(self, batch: Any) -> Tensor:  # ruff: ignore[too-many-locals]
         """Per-frame token blocks `(b, T, 3P + 1, d)` -- everything below the trunk.
 
         Factored out so a KV-cached one-frame decode step (the
@@ -422,6 +734,17 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
             dim=-1,
         )  # (b, T, 2 * A_state + 2)
         state_token = self.state_embedding(state_input).unsqueeze(-2)  # (b, T, 1, d)
+
+        # ⚠️ depth goes BETWEEN the state token and the RGB patches, not after
+        # them: the readout is the LAST token of a frame block, and appending
+        # depth would make it a constant `no_depth` token on every sample without
+        # a depth stream -- which is most of them (§22.5). This way the readout
+        # stays the last `side_right` patch, exactly as in the depth-off model.
+        depth_tokens = self._depth_tokens(
+            batch, batch_size=b, num_frames=t, device=device
+        )
+        if depth_tokens is not None:
+            return torch.cat([state_token, depth_tokens, patch_tokens], dim=-2)
 
         # state first, so each frame block ends on a patch token (the readout)
         return torch.cat([state_token, patch_tokens], dim=-2)
@@ -486,12 +809,12 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
         offset = self._offset(offsets, codes)
         return (self.tokenizer.invert(codes) + offset).unflatten(
             -1,
-            (-1, self.tokenizer._action_features),  # noqa: SLF001
+            (-1, self.tokenizer._action_features),  # ruff: ignore[private-member-access]
         )
 
     # ------------------------------------------------------------------ loss
 
-    def _compute_metrics(self, batch: Any) -> TensorDict:  # noqa: PLR0914
+    def _compute_metrics(self, batch: Any) -> TensorDict:  # ruff: ignore[too-many-locals]
         tokenizer = self.tokenizer
         features = self._features(batch)  # (b, T, d)
         chunk = self._chunk(batch)  # (b, T, H, 2, 60)
@@ -505,7 +828,7 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
 
         with torch.no_grad():
             target_codes = tokenizer(flat_chunk)  # (n, g)
-            target = tokenizer._normalize(flat_chunk.flatten(-2, -1))  # noqa: SLF001
+            target = tokenizer._normalize(flat_chunk.flatten(-2, -1))  # ruff: ignore[private-member-access]
 
         side_features = self._per_side_features(features).reshape(
             -1, features.shape[-1]
@@ -541,7 +864,7 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
             if getattr(tokenizer, "has_pose_layout", False):
                 shape = (-1, tokenizer.action_horizon, tokenizer.action_features)
                 metrics |= pose_error_metrics(
-                    tokenizer._denormalize(sampled_chunk.detach()).reshape(shape),  # noqa: SLF001
+                    tokenizer._denormalize(sampled_chunk.detach()).reshape(shape),  # ruff: ignore[private-member-access]
                     flat_chunk.reshape(shape),
                 )
 
@@ -551,7 +874,7 @@ class NeroPatchPolicy(pl.LightningModule, LoadableFromArtifact):
 
     def _step(self, batch: Any, prefix: str) -> STEP_OUTPUT:
         metrics = self._compute_metrics(batch)
-        losses = metrics.select(*((k, "loss") for k in metrics.keys()))  # noqa: SIM118
+        losses = metrics.select(*((k, "loss") for k in metrics.keys()))  # ruff: ignore[in-dict-keys]
         metrics["loss", "total"] = losses.sum(reduce=True)
         self.log_dict(
             {

--- a/src/rmind/scripts/nero_smoke.py
+++ b/src/rmind/scripts/nero_smoke.py
@@ -8,6 +8,16 @@ shapes (3 cameras, 120-dim bimanual action, camera-conditioning, goal images):
     which SDPA backend the trunk actually gets. This is the pre-flight from
     PR #265: at head_dim 20 the fused kernels are inadmissible and the math
     fallback materialises the full `(B, H, L, L)` score matrix and OOMs.
+    It also **verifies the trunk's configured `tokens_per_frame` against the
+    token block the model actually builds** -- a stale value there does not
+    necessarily raise, it tiles the intra-frame embedding and the frame-RoPE
+    wrong, which is a silent correctness bug rather than a crash. That check
+    matters most for the depth arm, where the token count changes.
+``depth``
+    Fit the `DisparityStandardizer` on the **training split only** and over
+    **valid pixels only** (contract §22.3 + §5.4) and write the versioned
+    artifact. Reports the invalid-pixel fraction, because fitting over all
+    pixels instead would drag the mean towards zero by exactly that fraction.
 ``tokenizer``
     Fit the VQ-BeT `NeroPoseTokenizer`, reporting translation error in **mm** and
     rotation error in **degrees**, separately (contract §5.5). Writes the
@@ -34,7 +44,7 @@ from hydra.utils import instantiate
 from omegaconf import OmegaConf
 from torch.nn.attention import SDPBackend, sdpa_kernel
 
-from rmind.data.nero import PoseStandardizer, state_quat_to_9d
+from rmind.data.nero import DisparityStandardizer, PoseStandardizer, state_quat_to_9d
 from rmind.datamodules.nero_random import CAMERA_NAMES, nero_random_batch
 
 CONFIG_DIR = Path(__file__).resolve().parents[3] / "config"
@@ -57,8 +67,10 @@ def _to(batch: dict[str, Any], device: torch.device) -> dict[str, Any]:
 # --------------------------------------------------------------------- budget
 
 
-def stage_budget(cfg: Any) -> dict[str, Any]:
-    tokens_per_frame = cfg.num_cameras * cfg.num_patches + 1
+def stage_budget(cfg: Any, *, verify_tokens: bool = True) -> dict[str, Any]:  # ruff: ignore[too-many-locals]
+    use_depth = bool(cfg.get("use_depth", False))
+    depth_tokens = cfg.num_depth_cameras * cfg.depth_patches if use_depth else 0
+    tokens_per_frame = cfg.num_cameras * cfg.num_patches + 1 + depth_tokens
     sequence_length = cfg.episode_length * tokens_per_frame
     head_dim = cfg.policy_embedding_dim // cfg.num_heads
     patch = 14
@@ -72,8 +84,13 @@ def stage_budget(cfg: Any) -> dict[str, Any]:
 
     report = {
         "patch_grid": list(grid),
+        "use_depth": use_depth,
+        "depth_tokens_per_frame": depth_tokens,
         "tokens_per_frame": tokens_per_frame,
         "sequence_length": sequence_length,
+        # what the depth arm costs against the SAME trunk with depth off
+        "sequence_length_without_depth": cfg.episode_length
+        * (cfg.num_cameras * cfg.num_patches + 1),
         "head_dim": head_dim,
         "head_dim_div8": head_dim % 8 == 0,
         "head_dim_even_for_rope": head_dim % 2 == 0,
@@ -105,7 +122,92 @@ def stage_budget(cfg: Any) -> dict[str, Any]:
         except RuntimeError as error:  # pragma: no cover - backend-dependent
             report["efficient_attention_admissible"] = False
             report["efficient_attention_error"] = str(error)[:200]
+
+    if verify_tokens:
+        # ⚠️ THE CHECK THAT ARITHMETIC CANNOT REPLACE. `tokens_per_frame` is a
+        # config value feeding the trunk's tiled intra-frame embedding and
+        # frame-RoPE. If the token layout and that value disagree the trunk does
+        # not necessarily raise -- it tiles wrong, and the model trains on a
+        # scrambled positional structure. So compare against the block the model
+        # ACTUALLY builds.
+        torch.manual_seed(0)
+        model = instantiate(cfg.model).eval()
+        batch = nero_random_batch(
+            batch_size=1,
+            episode_length=cfg.episode_length,
+            action_horizon=cfg.action_horizon,
+            depth=use_depth,
+            seed=0,
+        )
+        with torch.no_grad():
+            built = int(model._frame_tokens(batch).shape[-2])  # ruff: ignore[private-member-access]
+        configured = int(cfg.model.encoder.tokens_per_frame)
+        report |= {
+            "tokens_per_frame_built": built,
+            "tokens_per_frame_configured": configured,
+        }
+        if not built == configured == tokens_per_frame:
+            msg = (
+                f"tokens_per_frame disagreement: model builds {built}, trunk is "
+                f"configured for {configured}, arithmetic says {tokens_per_frame}"
+            )
+            raise ValueError(msg)
+        report["params_m"] = sum(p.numel() for p in model.parameters()) / 1e6
+        del model
     return report
+
+
+# ----------------------------------------------------------------------- depth
+
+
+def stage_depth(cfg: Any, out: Path, *, batches: int = 32) -> dict[str, Any]:
+    """Fit and write the `DisparityStandardizer` (contract §22.3 + §5.4).
+
+    ⚠️ Train split only, valid pixels only. Fitting over ALL pixels would drag
+    the mean towards zero by the invalid fraction -- and `disparity == 0` is *no
+    measurement*, not zero distance (§21.4), so those pixels are not data.
+
+    Raises:
+        ValueError: if the experiment is not depth-enabled.
+    """
+    if not cfg.get("use_depth", False):
+        msg = "the depth stage needs a depth-enabled experiment (use_depth: true)"
+        raise ValueError(msg)
+
+    disparities: list[torch.Tensor] = []
+    masks: list[torch.Tensor] = []
+    for i in range(batches):
+        batch = nero_random_batch(
+            batch_size=2,
+            episode_length=cfg.episode_length,
+            action_horizon=cfg.action_horizon,
+            grids=dict.fromkeys(CAMERA_NAMES, (8, 8)),  # RGB unused here
+            depth=True,
+            seed=i,
+        )
+        for camera in cfg.depth_cameras:
+            disparities.append(batch[f"disparity.{camera}"])
+            masks.append(batch[f"disparity_valid.{camera}"])
+
+    disparity = torch.cat(disparities)
+    valid = torch.cat(masks)
+    standardizer = DisparityStandardizer.from_samples(
+        disparity, valid, source="smoke-train-split"
+    )
+    artifact = standardizer.save(out / "disparity_standardizer.json")
+
+    # the contrast that makes the "valid pixels only" rule falsifiable rather
+    # than merely stated
+    naive = disparity.float()
+    return {
+        "artifact": str(artifact),
+        "num_pixels": int(disparity.numel()),
+        "invalid_fraction": float((~valid).float().mean()),
+        "mean_valid_only": float(standardizer.mean.item()),
+        "std_valid_only": float(standardizer.std.item()),
+        "mean_if_fitted_on_all_pixels": float(naive.mean()),
+        "std_if_fitted_on_all_pixels": float(naive.std()),
+    }
 
 
 # ------------------------------------------------------------------ tokenizer
@@ -134,7 +236,7 @@ def _chunk_pool(cfg: Any, *, batches: int, device: torch.device) -> torch.Tensor
     return torch.cat(pool).to(device)
 
 
-def stage_tokenizer(  # noqa: PLR0914
+def stage_tokenizer(  # ruff: ignore[too-many-locals]
     cfg: Any, out: Path, *, steps: int, device: torch.device
 ) -> dict[str, Any]:
     torch.manual_seed(0)
@@ -159,7 +261,7 @@ def stage_tokenizer(  # noqa: PLR0914
         index = torch.randint(0, train_pool.shape[0], (batch_size,), device=device)
         chunks = train_pool[index]
         raw = chunks.flatten(-2, -1)
-        a = model._normalize(raw)  # noqa: SLF001
+        a = model._normalize(raw)  # ruff: ignore[private-member-access]
         z = model.encoder(a)
         _codes, z_q, vq = model.quantizer(z)
         a_hat = model.decoder(z + (z_q - z).detach())
@@ -182,7 +284,7 @@ def stage_tokenizer(  # noqa: PLR0914
                 "recon": recon.item(),
                 **{k: v.item() for k, v in metrics.items()},
             })
-            print(  # noqa: T201
+            print(  # ruff: ignore[print]
                 f"[tokenizer] step {step:5d} loss {loss.item():.4f} "
                 f"recon {recon.item():.4f} "
                 f"trans {metrics['translation_mm'].item():.2f} mm "
@@ -202,7 +304,7 @@ def stage_tokenizer(  # noqa: PLR0914
         # the UNQUANTIZED autoencoder, i.e. the ceiling the code path is measured
         # against: the gap between the two is the cost of the codebook, and the
         # gap between this and the mean baseline is what the encoder learned
-        a = model._normalize(raw)  # noqa: SLF001
+        a = model._normalize(raw)  # ruff: ignore[private-member-access]
         z = model.encoder(a)
         ae = {
             k: v.item()
@@ -210,7 +312,7 @@ def stage_tokenizer(  # noqa: PLR0914
         }
         # baseline: predicting the train-split MEAN chunk, so the numbers above
         # are falsifiable rather than merely small
-        mean_chunk = model._normalize(train_pool.flatten(-2, -1)).mean(0, keepdim=True)  # noqa: SLF001
+        mean_chunk = model._normalize(train_pool.flatten(-2, -1)).mean(0, keepdim=True)  # ruff: ignore[private-member-access]
         baseline = {
             k: v.item()
             for k, v in model.reconstruction_metrics(
@@ -235,7 +337,7 @@ def stage_tokenizer(  # noqa: PLR0914
 # --------------------------------------------------------------------- policy
 
 
-def stage_policy(  # noqa: C901, PLR0913, PLR0914, PLR0915
+def stage_policy(  # ruff: ignore[complex-structure, too-many-arguments, too-many-locals, too-many-statements]
     cfg: Any,
     out: Path,
     *,
@@ -245,15 +347,28 @@ def stage_policy(  # noqa: C901, PLR0913, PLR0914, PLR0915
     batch_size: int,
     both_sides: bool = True,
     overfit_one_batch: bool = False,
+    depth_standardizer: Path | None = None,
 ) -> dict[str, Any]:
     torch.manual_seed(0)
     model = instantiate(cfg.model)
+    use_depth = bool(getattr(model, "use_depth", False))
 
     if tokenizer_ckpt is not None and tokenizer_ckpt.exists():
         payload = torch.load(tokenizer_ckpt, map_location="cpu", weights_only=False)
         missing = model.tokenizer.load_state_dict(payload["state_dict"], strict=False)
-        print(f"[policy] tokenizer loaded ({missing})")  # noqa: T201
-    model.tokenizer.requires_grad_(False).eval()  # noqa: FBT003
+        print(f"[policy] tokenizer loaded ({missing})")  # ruff: ignore[print]
+    model.tokenizer.requires_grad_(False).eval()  # ruff: ignore[boolean-positional-value-in-call]
+
+    # ⚠️ the config's disparity statistics are a documented PLACEHOLDER (a
+    # uniform prior). Swap in the artifact fitted on the train split, exactly as
+    # a real run would via `DisparityStandardizer.load`.
+    if use_depth and depth_standardizer is not None and depth_standardizer.exists():
+        model.depth_standardizer = DisparityStandardizer.load(depth_standardizer)
+        print(  # ruff: ignore[print]
+            f"[policy] disparity standardizer {model.depth_standardizer.source}: "
+            f"mean {model.depth_standardizer.mean.item():.2f} "
+            f"std {model.depth_standardizer.std.item():.2f}"
+        )
     model = model.to(device)
     model.train()
 
@@ -276,6 +391,7 @@ def stage_policy(  # noqa: C901, PLR0913, PLR0914, PLR0915
                 episode_length=cfg.episode_length,
                 action_horizon=cfg.action_horizon,
                 both_sides=both_sides,
+                depth=use_depth,
                 seed=0,
             ),
             device,
@@ -291,6 +407,7 @@ def stage_policy(  # noqa: C901, PLR0913, PLR0914, PLR0915
                 episode_length=cfg.episode_length,
                 action_horizon=cfg.action_horizon,
                 both_sides=both_sides,
+                depth=use_depth,
                 seed=step,
             ),
             device,
@@ -302,7 +419,7 @@ def stage_policy(  # noqa: C901, PLR0913, PLR0914, PLR0915
         with torch.autocast(
             device_type=device.type, dtype=torch.bfloat16, enabled=device.type == "cuda"
         ):
-            metrics = model._compute_metrics(batch)  # noqa: SLF001
+            metrics = model._compute_metrics(batch)  # ruff: ignore[private-member-access]
             loss = metrics["policy", "loss"].sum(reduce=True)
 
         optimizer.zero_grad(set_to_none=True)
@@ -331,13 +448,15 @@ def stage_policy(  # noqa: C901, PLR0913, PLR0914, PLR0915
                     f" trans {flat['policy/metric/translation_mm']:.1f} mm "
                     f"rot {flat['policy/metric/rotation_deg']:.1f} deg"
                 )
-            print(  # noqa: T201
+            print(  # ruff: ignore[print]
                 f"[policy] step {step:4d} loss {loss.item():.4f} "
                 f"offset {flat['policy/loss/offset']:.4f}{extra}"
             )
 
     peak = torch.cuda.max_memory_allocated() / 1024**3 if device.type == "cuda" else 0.0
-    tokens_per_frame = cfg.num_cameras * cfg.num_patches + 1
+    # read the trunk's ACTUAL value rather than recomputing it here -- the depth
+    # arm changes it and two copies of the arithmetic is how they drift apart
+    tokens_per_frame = int(cfg.model.encoder.tokens_per_frame)
 
     def _mean(key: str, lo: int, hi: int) -> float:
         return statistics.fmean(c[key] for c in curve[lo:hi])
@@ -346,11 +465,13 @@ def stage_policy(  # noqa: C901, PLR0913, PLR0914, PLR0915
     summary = {
         "batch_size": batch_size,
         "both_sides": both_sides,
+        "use_depth": use_depth,
         "overfit_one_batch": overfit_one_batch,
         # ⚠️ the trunk gradient-CHECKPOINTS while training
         # (rmind.components.transformer.utils.run_layer_stack), so peak memory
         # is a checkpointed figure -- memory traded for recompute.
         "gradient_checkpointing": True,
+        "tokens_per_frame": tokens_per_frame,
         "sequence_length": cfg.episode_length * tokens_per_frame,
         "trainable_params_m": trainable / 1e6,
         "total_params_m": total / 1e6,
@@ -367,6 +488,8 @@ def stage_policy(  # noqa: C901, PLR0913, PLR0914, PLR0915
         "curve": curve,
     }
     name = "policy_curve"
+    if use_depth:
+        name += "_depth"
     if overfit_one_batch:
         name += "_overfit"
     if not both_sides:
@@ -381,9 +504,15 @@ def stage_policy(  # noqa: C901, PLR0913, PLR0914, PLR0915
 def main() -> None:
     parser = argparse.ArgumentParser()
     _ = parser.add_argument(
-        "--stage", default="all", choices=["all", "budget", "tokenizer", "policy"]
+        "--stage",
+        default="all",
+        choices=["all", "budget", "depth", "tokenizer", "policy"],
     )
-    _ = parser.add_argument("--out", default="/tmp/nero-smoke")  # noqa: S108
+    # contract §22 depth arm. OFF by default (§22.6), which also makes the
+    # depth-off numbers in this harness directly comparable to the pre-depth
+    # ones -- the experiment it composes is byte-identical.
+    _ = parser.add_argument("--depth", action="store_true")
+    _ = parser.add_argument("--out", default="/tmp/nero-smoke")  # ruff: ignore[hardcoded-temp-file]
     _ = parser.add_argument("--tokenizer-steps", type=int, default=3000)
     _ = parser.add_argument("--policy-steps", type=int, default=300)
     _ = parser.add_argument("--batch-size", type=int, default=8)
@@ -407,11 +536,19 @@ def main() -> None:
 
     overrides = [] if args.lr is None else [f"lr={args.lr}"]
     report: dict[str, Any] = {}
-    policy_cfg = _cfg("yaak/nero_arms/causal", overrides)
+    experiment = (
+        "yaak/nero_arms/causal_depth" if args.depth else "yaak/nero_arms/causal"
+    )
+    policy_cfg = _cfg(experiment, overrides)
+    report["experiment"] = experiment
 
     if args.stage in {"all", "budget"}:
         report["budget"] = stage_budget(policy_cfg)
-        print(json.dumps(report["budget"], indent=2))  # noqa: T201
+        print(json.dumps(report["budget"], indent=2))  # ruff: ignore[print]
+
+    if args.depth and args.stage in {"all", "depth"}:
+        report["depth"] = stage_depth(policy_cfg, out)
+        print(json.dumps(report["depth"], indent=2))  # ruff: ignore[print]
 
     if args.stage in {"all", "tokenizer"}:
         report["tokenizer"] = stage_tokenizer(
@@ -431,6 +568,7 @@ def main() -> None:
             batch_size=args.batch_size,
             both_sides=not args.right_only,
             overfit_one_batch=args.overfit_one_batch,
+            depth_standardizer=out / "disparity_standardizer.json",
         )
 
     _ = (out / "report.json").write_text(
@@ -438,7 +576,7 @@ def main() -> None:
             report, indent=2, default=lambda o: OmegaConf.to_container(o, resolve=True)
         )
     )
-    print(f"\nwrote {out / 'report.json'}")  # noqa: T201
+    print(f"\nwrote {out / 'report.json'}")  # ruff: ignore[print]
 
 
 if __name__ == "__main__":

--- a/tests/test_nero_patch_policy.py
+++ b/tests/test_nero_patch_policy.py
@@ -27,7 +27,13 @@ from rmind.components.image import LetterboxResize
 from rmind.components.loss import FocalLoss
 from rmind.components.transformer.causal_frame import CausalFrameTransformer
 from rmind.components.vq import ResidualVQ
-from rmind.data.nero import CAMERA_COND_DIM, NUM_SIDES, SIDE_DIM, STATE_QUAT_DIM
+from rmind.data.nero import (
+    CAMERA_COND_DIM,
+    NUM_SIDES,
+    SIDE_DIM,
+    STATE_QUAT_DIM,
+    DisparityStandardizer,
+)
 from rmind.datamodules.nero_random import CAMERA_NAMES, nero_random_batch
 from rmind.models.nero_patch_policy import NeroPatchPolicy
 from rmind.models.nero_pose_tokenizer import NeroPoseTokenizer
@@ -126,6 +132,12 @@ def _policy(**kwargs: Any) -> NeroPatchPolicy:
 
 
 def _batch(*, both_sides: bool = True, seed: int = 0) -> dict[str, Any]:
+    # ⚠️ `seed` only seeds the POSE generator. The images, `camera_cond` and the
+    # depth stream are drawn from the GLOBAL torch RNG, so two calls with the
+    # same `seed` do NOT agree unless the global stream is pinned too. That is
+    # pre-existing behaviour of `nero_random_batch`, not something depth
+    # introduced -- but any test that compares two batches depends on it.
+    torch.manual_seed(seed)
     return nero_random_batch(
         batch_size=2,
         episode_length=EPISODE_LENGTH,
@@ -583,3 +595,304 @@ def test_goal_dropout_does_not_mutate_the_loader_flag() -> None:
             batch, batch_size=2, device=torch.device("cpu")
         )
     assert bool(flag.all()), "goal dropout mutated the caller's goal_valid tensor"
+
+
+# --------------------------------------------------------------- depth (§22)
+#
+# The depth arm is opt-in (§22.6), so the FIRST thing these assert is that it
+# does not exist unless asked for. The rest make the four §22 claims falsifiable:
+# depth is a fourth CAMERA (not a fourth channel), invalid pixels are masked (not
+# zero-filled), absence is handled by a LEARNED embedding (not zeros), and the
+# per-sample flag is genuinely per-sample.
+
+#: §22.7: the depth stream's own patch embedding. A 4x12 input at patch 4 is a
+#: 1x3 = 3-token grid -- coarser than a camera's 6, as §22.2 asks.
+DEPTH_PATCH_SIZE = 4
+DEPTH_INPUT = (4, 12)
+DEPTH_PATCH_GRID = (
+    DEPTH_INPUT[0] // DEPTH_PATCH_SIZE,
+    DEPTH_INPUT[1] // DEPTH_PATCH_SIZE,
+)
+DEPTH_PATCHES = DEPTH_PATCH_GRID[0] * DEPTH_PATCH_GRID[1]
+#: 8x24 -> 4x12 is exactly isotropic, as the contract's 400x640 -> 80x128 is
+DEPTH_TEST_GRIDS = {"base": (8, 24)}
+DEPTH_TOKENS_PER_FRAME = len(CAMERA_NAMES) * NUM_PATCHES + 1 + DEPTH_PATCHES
+
+
+def _depth_policy(**kwargs: Any) -> NeroPatchPolicy:
+    torch.manual_seed(0)
+    action_dim = HORIZON * SIDE_DIM
+    policy = NeroPatchPolicy(
+        image_transform=_Unify(),
+        image_encoder=_TinyImageEncoder(),
+        patch_projection=nn.Linear(2 * IMAGE_DIM + CAMERA_COND_DIM, POLICY_DIM),
+        state_embedding=nn.Linear(NUM_SIDES * SIDE_DIM + NUM_SIDES, POLICY_DIM),
+        encoder=CausalFrameTransformer(
+            dim_model=POLICY_DIM,
+            num_layers=NUM_LAYERS,
+            num_heads=NUM_HEADS,
+            tokens_per_frame=DEPTH_TOKENS_PER_FRAME,
+            window=EPISODE_LENGTH,
+        ),
+        tokenizer=_tokenizer(),
+        code_head=nn.Linear(POLICY_DIM, NUM_QUANTIZERS * CODEBOOK_SIZE),
+        offset_head=nn.Linear(POLICY_DIM, NUM_QUANTIZERS * CODEBOOK_SIZE * action_dim),
+        losses=ModuleDict(modules={"code": FocalLoss(), "offset": nn.L1Loss()}),
+        image_embedding_dim=IMAGE_DIM,
+        policy_embedding_dim=POLICY_DIM,
+        sample_codes=False,
+        use_depth=True,
+        depth_transform=LetterboxResize(size=DEPTH_INPUT),
+        depth_standardizer=DisparityStandardizer(mean=48.0, std=27.4),
+        # §22.7: trainable, and 2 input channels (disparity + validity mask)
+        depth_patch_embedding=nn.Linear(
+            DEPTH_PATCH_SIZE * DEPTH_PATCH_SIZE * 2 + CAMERA_COND_DIM, POLICY_DIM
+        ),
+        depth_patch_size=DEPTH_PATCH_SIZE,
+        depth_patch_grid=DEPTH_PATCH_GRID,
+        **({"goal_dropout": 0.0, "depth_dropout": 0.0} | kwargs),
+    )
+    return policy.eval()
+
+
+def _depth_batch(*, seed: int = 0, depth_present: float = 1.0) -> dict[str, Any]:
+    torch.manual_seed(seed)  # see `_batch`: the global stream must be pinned too
+    return nero_random_batch(
+        batch_size=2,
+        episode_length=EPISODE_LENGTH,
+        action_horizon=HORIZON,
+        grids=TEST_GRIDS,
+        depth=True,
+        depth_grids=DEPTH_TEST_GRIDS,
+        depth_present=depth_present,
+        seed=seed,
+    )
+
+
+def test_depth_off_constructs_nothing_at_all() -> None:
+    """§22.6: the opt-in arm must not touch the existing model.
+
+    Not "the depth branch is skipped" -- there must be no depth PARAMETER, no
+    depth module, and no extra token. A depth-off model that merely never calls
+    the depth path would still have shifted every subsequent init draw.
+    """
+    policy = _policy()
+    assert not policy.use_depth
+    assert not hasattr(policy, "no_depth")
+    assert policy.depth_transform is None
+    assert policy.depth_patch_embedding is None
+    assert policy.depth_standardizer is None
+    assert not [k for k in policy.state_dict() if "depth" in k]
+
+    tokens = policy._frame_tokens(_batch())  # noqa: SLF001
+    assert tokens.shape[-2] == len(CAMERA_NAMES) * NUM_PATCHES + 1
+
+
+def test_a_depth_off_model_ignores_depth_keys_in_the_batch() -> None:
+    """Depth-off must be indifferent to a loader that happens to emit depth."""
+    policy = _policy()
+    with torch.no_grad():
+        plain = policy(_batch(seed=3))["policy", "action"]
+        withdepth = policy(_depth_batch(seed=3))["policy", "action"]
+    assert torch.equal(plain, withdepth)
+
+
+def test_depth_is_a_fourth_camera_with_its_own_coarser_token_block() -> None:
+    """§22.1/§22.2: separate tokens on a COARSER grid, not a channel on the RGB.
+
+    Also pins the placement: depth sits BETWEEN the state token and the RGB
+    patches, so the readout (last token) is still an RGB patch.
+    """
+    policy = _depth_policy()
+    batch = _depth_batch()
+    tokens = policy._frame_tokens(batch)  # noqa: SLF001
+    assert tokens.shape == (2, EPISODE_LENGTH, DEPTH_TOKENS_PER_FRAME, POLICY_DIM)
+    # the depth block is strictly coarser than a camera's block
+    assert DEPTH_PATCHES < NUM_PATCHES
+
+    perturbed = dict(batch)
+    disparity = batch["disparity.base"].clone()
+    disparity[:] = 7
+    perturbed["disparity.base"] = disparity
+    other = policy._frame_tokens(perturbed)  # noqa: SLF001
+
+    depth_slice = slice(1, 1 + DEPTH_PATCHES)
+    rgb_slice = slice(1 + DEPTH_PATCHES, None)
+    assert not torch.equal(tokens[:, :, depth_slice], other[:, :, depth_slice])
+    # depth must not leak into the RGB tokens or the state token
+    assert torch.equal(tokens[:, :, rgb_slice], other[:, :, rgb_slice])
+    assert torch.equal(tokens[:, :, 0], other[:, :, 0])
+
+
+def test_no_depth_embedding_receives_gradient_when_depth_is_absent() -> None:
+    """§22.5: the learned `no_depth` must TRAIN, through a real backward pass.
+
+    The depth-absent case is the normal one -- none of the 104 existing episodes
+    carry depth -- so this embedding is what the model actually sees most of the
+    time. A `no_depth` that never received gradient would be a fancy constant.
+    """
+    policy = _depth_policy()
+    policy.train()
+    batch = _batch()  # NO disparity keys at all: the common real case
+    assert "disparity.base" not in batch
+
+    loss = policy._compute_metrics(batch)["policy", "loss"].sum(reduce=True)  # noqa: SLF001
+    loss.backward()
+
+    assert policy.no_depth.grad is not None
+    assert torch.any(policy.no_depth.grad != 0)
+    # ...but the trainable patch embedding gets NO gradient from a batch with no
+    # depth in it, which is correct: nothing routed through it. §22.7's embedding
+    # trains on the depth-PRESENT samples; `no_depth` covers the rest.
+    assert policy.depth_patch_embedding.weight.grad is None
+
+
+def test_absent_depth_key_and_depth_valid_false_are_the_same_state() -> None:
+    """The two ways depth can be missing must not be two different models."""
+    policy = _depth_policy()
+    absent = _batch(seed=5)
+    flagged = _depth_batch(seed=5)
+    flagged["depth_valid"] = torch.zeros_like(flagged["depth_valid"])
+
+    with torch.no_grad():
+        a = policy(absent)["policy", "action"]
+        b = policy(flagged)["policy", "action"]
+    # the depth CONDITIONING vector is still present in `flagged`, so allow it to
+    # differ there; compare the depth FEATURE path by zeroing the cond too
+    flagged["disparity_cond"] = torch.zeros_like(flagged["disparity_cond"])
+    with torch.no_grad():
+        c = policy(flagged)["policy", "action"]
+    assert torch.equal(a, c)
+    assert b.shape == a.shape
+
+
+def test_invalid_disparity_pixels_cannot_influence_the_output() -> None:
+    """§22.4: `disparity == 0` is NO MEASUREMENT, so its value must not be read.
+
+    The strong form: change the disparity values ONLY where the mask says
+    invalid, and the output must be BIT-identical. A zero-filling implementation
+    passes a "the mask reaches the model" test but fails this one.
+    """
+    policy = _depth_policy()
+    batch = _depth_batch(seed=1)
+    mask = batch["disparity_valid.base"]
+    assert not bool(mask.all()), "test needs some invalid pixels"
+
+    tampered = dict(batch)
+    disparity = batch["disparity.base"].clone()
+    # garbage, but only under the invalid mask
+    noise = torch.randint(0, 96, disparity.shape, dtype=disparity.dtype)
+    tampered["disparity.base"] = torch.where(mask, disparity, noise)
+
+    with torch.no_grad():
+        a = policy(batch)["policy", "action"]
+        b = policy(tampered)["policy", "action"]
+    assert torch.equal(a, b)
+
+
+def test_the_validity_mask_itself_reaches_the_model() -> None:
+    """Control for the test above: the MASK must matter, not just be respected."""
+    policy = _depth_policy()
+    batch = _depth_batch(seed=1)
+    flipped = dict(batch)
+    flipped["disparity_valid.base"] = torch.ones_like(batch["disparity_valid.base"])
+
+    with torch.no_grad():
+        a = policy(batch)["policy", "action"]
+        b = policy(flipped)["policy", "action"]
+    assert not torch.equal(a, b)
+
+
+def test_depth_valid_is_genuinely_per_sample() -> None:
+    """§22.5: a MIXED batch is the realistic case, not all-on or all-off."""
+    policy = _depth_policy()
+    batch = _depth_batch(seed=2)
+    mixed = dict(batch)
+    flag = torch.tensor([True, False])
+    mixed["depth_valid"] = flag
+
+    none = dict(batch)
+    none["depth_valid"] = torch.zeros(2, dtype=torch.bool)
+
+    with torch.no_grad():
+        mixed_out = policy(mixed)["policy", "action"]
+        none_out = policy(none)["policy", "action"]
+        all_out = policy(batch)["policy", "action"]
+
+    # sample 1 has no depth in either -> identical; sample 0 differs
+    assert torch.equal(mixed_out[1], none_out[1])
+    assert not torch.equal(mixed_out[0], none_out[0])
+    assert torch.equal(mixed_out[0], all_out[0])
+
+
+def test_depth_dropout_replaces_depth_with_the_learned_embedding() -> None:
+    """§22.5: dropout applies in TRAINING only, and lands on `no_depth`."""
+    policy = _depth_policy(depth_dropout=1.0)
+    batch = _depth_batch(seed=4)
+
+    absent = dict(batch)
+    absent["depth_valid"] = torch.zeros(2, dtype=torch.bool)
+
+    policy.train()
+    with torch.no_grad():
+        dropped = policy._frame_tokens(batch)  # noqa: SLF001
+        never = policy._frame_tokens(absent)  # noqa: SLF001
+    assert torch.equal(dropped, never)
+
+    # ...and NOT in eval: serving must use the depth it was given
+    policy.eval()
+    with torch.no_grad():
+        kept = policy._frame_tokens(batch)  # noqa: SLF001
+    assert not torch.equal(kept, never)
+
+
+def test_depth_camera_cond_is_bound_to_the_depth_tokens() -> None:
+    """§22.2: depth carries its own 13-dim cond, from the MONO intrinsics."""
+    policy = _depth_policy()
+    batch = _depth_batch(seed=6)
+    changed = dict(batch)
+    changed["disparity_cond"] = torch.randn_like(batch["disparity_cond"])
+
+    with torch.no_grad():
+        a = policy._frame_tokens(batch)  # noqa: SLF001
+        b = policy._frame_tokens(changed)  # noqa: SLF001
+
+    depth_slice = slice(1, 1 + DEPTH_PATCHES)
+    rgb_slice = slice(1 + DEPTH_PATCHES, None)
+    assert not torch.equal(a[:, :, depth_slice], b[:, :, depth_slice])
+    # the RGB cameras' geometry must be untouched by the depth camera's
+    assert torch.equal(a[:, :, rgb_slice], b[:, :, rgb_slice])
+
+
+def test_a_disparity_stream_without_its_mask_is_rejected() -> None:
+    """§21.4/§22.4: never infer the mask from `disparity != 0`.
+
+    A real loader marks additional pixels invalid (confidence, left-right check)
+    that are NOT zero, so a silent fallback would read fabricated measurements.
+    """
+    policy = _depth_policy()
+    batch = _depth_batch(seed=7)
+    del batch["disparity_valid.base"]
+    with pytest.raises(KeyError, match="validity mask"):
+        _ = policy._frame_tokens(batch)  # noqa: SLF001
+
+
+def test_depth_dropout_does_not_mutate_the_batch() -> None:
+    """Regression: dropout must not write through to the loader's own tensor.
+
+    `present.to(dtype=bool, device=cpu)` returns the SAME tensor, not a copy, so
+    an in-place `&=` for the dropout mask zeroes `batch["depth_valid"]`
+    permanently. With a cached or reused TensorDict that corruption outlives the
+    step and is invisible -- the batch simply claims it never had depth. Caught
+    by a test that failed for a completely unrelated-looking reason.
+    """
+    policy = _depth_policy(depth_dropout=1.0)
+    batch = _depth_batch(seed=4)
+    before = batch["depth_valid"].clone()
+    assert bool(before.all()), "test needs depth present to begin with"
+
+    policy.train()
+    with torch.no_grad():
+        _ = policy._frame_tokens(batch)  # noqa: SLF001
+
+    assert torch.equal(batch["depth_valid"], before)

--- a/tests/test_nero_patch_policy.py
+++ b/tests/test_nero_patch_policy.py
@@ -896,3 +896,31 @@ def test_depth_dropout_does_not_mutate_the_batch() -> None:
         _ = policy._frame_tokens(batch)  # noqa: SLF001
 
     assert torch.equal(batch["depth_valid"], before)
+
+
+def test_depth_patch_embedding_trains_when_depth_is_present() -> None:
+    """§22.7: the trainable embedding must actually receive gradient.
+
+    This is the substance of the §22.7 correction -- the ~269k trainable
+    parameters that replaced a ~22M-parameter frozen ViT pass. Its counterpart
+    (`test_no_depth_embedding_receives_gradient_when_depth_is_absent`) covers the
+    depth-ABSENT half and asserts this weight gets NO gradient there, so without
+    this test nothing anywhere shows it is ever trained at all. A `Linear` that
+    silently received no gradient would produce an identical-looking loss curve
+    and an identical peak-memory number -- "it did not crash" is not "it trains".
+    """
+    policy = _depth_policy()  # depth_dropout = 0.0
+    policy.train()
+    batch = _depth_batch(seed=8)
+    assert bool(batch["depth_valid"].all()), "test needs depth present"
+
+    loss = policy._compute_metrics(batch)["policy", "loss"].sum(reduce=True)  # noqa: SLF001
+    loss.backward()
+
+    assert policy.depth_patch_embedding.weight.grad is not None
+    assert torch.any(policy.depth_patch_embedding.weight.grad != 0)
+    # ...and `no_depth` gets only ZERO gradient here, since no token was
+    # substituted. Not `is None`: it is the unselected branch of a `torch.where`,
+    # so autograd still routes a (zero) gradient to it.
+    assert policy.no_depth.grad is not None
+    assert not torch.any(policy.no_depth.grad != 0)


### PR DESCRIPTION
Adds the overhead depth stream to the nero-arms policy, as a **fourth camera**. Opt-in and **off by default** (`use_depth`), so it can be A/B'd rather than assumed to help.

> **Stacked on #267**, which is itself stacked on #269. Review those first — this adds only the depth arm. Design is `nero-arms/DATA_CONTRACT.md` §22; the recorder is [nutron-cli#4](https://github.com/yaak-ai/nutron-cli/pull/4) and the ingestion [rbyte#110](https://github.com/yaak-ai/rbyte/pull/110).

## Depth is not a fourth channel on the RGB

The obvious move — stack disparity as an extra channel on the overhead image — is wrong here, and would fail silently.

The stream declares `reference_frame: rectified_CAM_B`, `aligned_to: none`. Disparity lives in the rectified **left mono** camera's frame: a different sensor, at a different position, with a **much wider lens** — 96.0° HFOV against `CAM_A`'s 73.7°, both measured off the device. `setDepthAlign` would warp it into the RGB frame, but the recorder deliberately doesn't apply it, because warping invalidates the `fx_mono · baseline / disparity` conversion. So the two are genuinely different views, and stacking them misregisters every pixel with nothing to indicate it.

Instead depth gets its own patch tokens and its own 13-dim `camera_cond`, built from the **mono** intrinsics at the recorded depth resolution — reusing the machinery that already handles three heterogeneous cameras.

## A trainable patch embedding, not the frozen DINOv2

`Linear(525 → 512)`, ~269k trainable parameters. The 525 is a 16×16 patch over **2 channels** — standardised disparity plus the validity mask — plus the 13 conditioning dims.

Routing disparity through the frozen DINOv2 (which an earlier revision did) is wrong on three counts. DINOv2 is trained on natural RGB — photometric statistics, texture, semantics — while disparity is a smooth, single-channel, purely geometric signal, so most of the encoder's capacity is wasted or misleading. It is **frozen**, so nothing can adapt it. And the cost runs backwards: a fourth encoder pass is **+33% frozen-ViT compute per frame** to buy ~8% sequence, i.e. paying the larger cost for the worse representation.

Using the validity mask as an **input channel** also beats filling invalid pixels with the train-split mean: invalidity becomes a first-class input rather than a sentinel the network must learn to detect.

## Absence is the normal case

**None of the 104 existing episodes have depth**, and the recorder's `--depth` is off by default. So a depth-enabled model trains on a mixture where depth is usually missing. That is handled by a learned **`no_depth`** token — never zeros — covering all three routes: the key absent, `depth_valid` false, and dropout (0.25). Zeros would assert "a surface at zero disparity"; absence asserts nothing.

Depth tokens sit **between** the state and RGB tokens, so each frame block still ends on an RGB patch and the readout position is unchanged.

## Measured — this supersedes the contract's own estimate

RTX 5090, batch 8, 60 steps:

| | depth off | depth on | Δ |
|---|---|---|---|
| tokens / frame | 481 | 521 | +8.3% |
| sequence (T = 6) | 2886 | 3126 | +8.3% |
| peak memory | 1.743 GiB | 1.859 GiB | **+6.7%** |
| median step | 0.218 s | 0.229 s | +5.1% |
| parameters | 62,929,320 | 63,219,624 | **+290,304** |

§22.2 originally estimated "+33% sequence, ~1.8× attention" — wrong, because it assumed a fourth stream at the RGB patch grid. At patch 16 over 80×128, depth contributes **40** tokens/frame, not 160.

Every added parameter is **trainable**; zero frozen. The breakdown: 269,312 the patch projection, 20,480 the trunk's intra-frame positional embedding growing 481 → 521 slots (a knock-on from the longer sequence, not the encoder), 512 the `no_depth` token. That is **0.46%** of the model, against ~22M frozen for the ViT alternative.

## Depth-off is byte-identical to the parent

The guarantee that matters, since this is an opt-in arm. Verified by fingerprint — resolved config, per-tensor `state_dict` hashes, and the forward output:

```
config 17c14c6f2b3dc410 · weights 9ce51d24c4a33d2c · prediction 1dd5548f38d17ebc
```

identical on the parent branch and here with depth off. Re-verified after the rebase onto #269, and again after squashing this branch's history. Every depth module is constructed only under `use_depth` and **last**, so the init RNG stream for pre-existing modules is untouched — which is why the *weights* hash matches, not merely the output.

## Tests

**78 passed / 8 skipped**, same 3 pre-existing `test_models.py` fixture errors as the base. 13 depth tests, covering the depth-**absent** backward (`no_depth` receives gradient), the depth-**present** backward (the embedding actually trains — without this the suite would only prove "didn't crash"), validity masking, the fourth-stream `camera_cond`, and mixed batches.

**A real bug found and fixed on the way:** depth dropout used `present &= ...`, but `present` **aliases** `batch["depth_valid"]` — `.to()` returns *self* when dtype and device already match — so it permanently zeroed the loader's flag, and with a cached TensorDict the corruption outlives the step, invisibly. It was **introduced by a ruff `PLR6104` autofix**. Regression test added, and the same hazard is pinned in the `goal_valid` path on #267.

## What this does NOT claim

**No real depth recording exists yet.** Nothing here is validated against a real disparity stream — the recorder (nutron-cli#4) is itself unrun against hardware. The shapes and costs above are real; the behaviour on real data is not evidence.

**The smoke curves are not a learning claim.** They ran without a tokenizer checkpoint, so the inline RVQ is uninitialised and collapses every chunk onto code 0 — all four code losses are exactly `0.000`. They measure memory, throughput and stability only. No end-to-end accuracy comparison between the arms has been run.

## Judgement calls worth a second opinion

The depth token grid (patch 16 over 80×128 → 5×8), placing depth tokens between state and RGB, and `depth_dropout = 0.25`. Also: `letterbox_camera_cond` is **never called in the live path** (pre-existing, not from this work) — harmless only while extrinsics are identity placeholders, but it must be wired before real calibration lands, and doing so **will** change the depth-off model and invalidate the fingerprint above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
